### PR TITLE
fix: enhance search input handling and NZB-Mount test connection behavior

### DIFF
--- a/src/lib/components/discover/SearchBar.svelte
+++ b/src/lib/components/discover/SearchBar.svelte
@@ -18,11 +18,11 @@
 
 	function handleInput(e: Event) {
 		const target = e.target as HTMLInputElement;
-		value = target.value;
+		value = target.value.replace(/^\s+/, '');
 
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(() => {
-			onSearch(value.trim());
+			onSearch(value);
 		}, 300);
 	}
 

--- a/src/lib/server/downloadClients/nzbmount/NZBMountClient.test.ts
+++ b/src/lib/server/downloadClients/nzbmount/NZBMountClient.test.ts
@@ -41,7 +41,7 @@ describe('NZBMountClient test routine', () => {
 		proxyClass.instances.length = 0;
 	});
 
-	it('skips fullstatus for altmount', async () => {
+	it('continues when fullstatus returns unknown mode for altmount', async () => {
 		const client = new NZBMountClient({
 			host: 'localhost',
 			port: 3000,
@@ -54,13 +54,13 @@ describe('NZBMountClient test routine', () => {
 		proxy.getConfig.mockResolvedValue({ categories: [], misc: { complete_dir: '/complete' } });
 		proxy.getWarnings.mockResolvedValue([]);
 		proxy.getFullStatus.mockImplementation(() => {
-			throw new Error('fullstatus should not be called');
+			throw new SabnzbdApiError('Unknown mode: fullstatus');
 		});
 
 		const result = await client.test();
 
 		expect(result.success).toBe(true);
-		expect(proxy.getFullStatus).not.toHaveBeenCalled();
+		expect(proxy.getFullStatus).toHaveBeenCalled();
 	});
 
 	it('continues when fullstatus returns unknown mode for nzbdav', async () => {

--- a/src/lib/server/downloadClients/nzbmount/NZBMountClient.ts
+++ b/src/lib/server/downloadClients/nzbmount/NZBMountClient.ts
@@ -70,19 +70,17 @@ export class NZBMountClient implements IDownloadClient {
 			const categories = sabConfig.categories.map((c) => c.name);
 
 			let diskInfo: SabnzbdFullStatus | null = null;
-			if (this.mountMode !== 'altmount') {
-				try {
-					diskInfo = await this.proxy.getFullStatus();
-				} catch (statusError) {
-					const statusMessage =
-						statusError instanceof SabnzbdApiError ? statusError.message : String(statusError);
-					if (!statusMessage.toLowerCase().includes('unknown mode')) {
-						throw statusError;
-					}
-					logger.warn('[NZB-Mount] fullstatus not supported, skipping disk info', {
-						error: statusMessage
-					});
+			try {
+				diskInfo = await this.proxy.getFullStatus();
+			} catch (statusError) {
+				const statusMessage =
+					statusError instanceof SabnzbdApiError ? statusError.message : String(statusError);
+				if (!statusMessage.toLowerCase().includes('unknown mode')) {
+					throw statusError;
 				}
+				logger.warn('[NZB-Mount] fullstatus not supported, skipping disk info', {
+					error: statusMessage
+				});
 			}
 
 			let warnings: SabnzbdWarning[] = [];

--- a/src/routes/discover/+page.svelte
+++ b/src/routes/discover/+page.svelte
@@ -74,13 +74,15 @@
 	} | null>(null);
 	let searchLoadMoreTrigger = $state<HTMLElement>();
 
+	const normalizedSearchQuery = $derived(searchQuery.trim());
 	// Computed: are we in search mode?
-	let isSearchMode = $derived(searchQuery.length > 0);
+	let isSearchMode = $derived(normalizedSearchQuery.length > 0);
 
 	async function handleSearch(query: string) {
 		searchQuery = query;
+		const normalizedQuery = query.trim();
 
-		if (!query.trim()) {
+		if (!normalizedQuery) {
 			searchResults = [];
 			searchPagination = null;
 			return;
@@ -89,7 +91,7 @@
 		isSearching = true;
 		try {
 			const res = await fetch(
-				`/api/discover/search?query=${encodeURIComponent(query)}&type=${type}`
+				`/api/discover/search?query=${encodeURIComponent(normalizedQuery)}&type=${type}`
 			);
 			if (!res.ok) throw new Error('Search failed');
 
@@ -112,7 +114,7 @@
 		try {
 			const nextPage = searchPagination.page + 1;
 			const res = await fetch(
-				`/api/discover/search?query=${encodeURIComponent(searchQuery)}&type=${type}&page=${nextPage}`
+				`/api/discover/search?query=${encodeURIComponent(normalizedSearchQuery)}&type=${type}&page=${nextPage}`
 			);
 			if (!res.ok) return;
 


### PR DESCRIPTION
## Summary

- Adjusted Discover search input handling to avoid trimming while typing and to improve whitespace behavior. 
- Adjusted connection test for API Variant "Altmount" to test for the `fullstatus` endpoint insteading of skipping it outrightly.

## Related Issues

Resolves issue: https://github.com/MoldyTaint/Cinephage/issues/61

Enhances test routine behavior for NZB-Mount client type in PR: https://github.com/MoldyTaint/Cinephage/pull/60

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

[Discover] - Search Bar
- Keep raw input during typing and trim only for the search request.
- Trim leading spaces as the user types.

[NZB-Mount Client]
- Update test routine for API Variant Altmount to test for the 'fullstatus` endpoint and skip if variant returns `unknownmode`, this ensures that should the endpoint become available in the API Variant, it will be checked as well.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
