### PR TITLE
feat: Initialize subtitle provider registry during service startup

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -256,7 +256,6 @@ async function initializeEpgScheduler() {
 	}
 }
 
-
 // Start initialization in next tick - ensures module loading completes immediately
 // so the HTTP server can start responding to requests while services initialize in background.
 // Using setImmediate pushes the async work to the next event loop iteration.


### PR DESCRIPTION
This pull request makes a small but important change to the server initialization process by ensuring that the subtitle provider registry is properly initialized during startup. This helps prepare the system for subtitle-related requests and improves error handling for provider initialization failures.

* Initialization improvements:
  * Added a call to `initializeProviderFactory()` in `src/hooks.server.ts` to initialize the subtitle provider registry during server startup, with error logging if initialization fails. [[1]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR27) [[2]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR275-R279)## Summary

<!-- Brief description of what this PR does -->

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Initialize subtitle provider registry during service startup

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [x] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
