### PR TITLE
feat: enhance profile size limits with validation and improve mobile responsiveness

### DIFF
--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -91,6 +91,10 @@ Not recommended. SQLite doesn't handle multiple writers well.
 | Logs            | `logs/` (Docker: `/config/logs/`)                                           |
 | Custom indexers | `data/indexers/definitions/` (Docker: `/config/data/indexers/definitions/`) |
 
+### Why can't I configure size limits for the Streamer profile?
+
+The Streamer profile plays media from external streaming sources rather than local files. Stream quality and file size can vary by provider, region, or time of request, so hard size limits don't make sense and can cause false rejections. For that reason, Streamer size limits are locked and shown as `Auto`.
+
 ---
 
 ## Library

--- a/src/lib/components/formats/FormatList.svelte
+++ b/src/lib/components/formats/FormatList.svelte
@@ -37,7 +37,7 @@
 	let searchQuery = $state('');
 	let filterType = $state<'all' | 'builtin' | 'custom'>('all');
 	let filterCategory = $state<FormatCategory | 'all'>('all');
-	const expandedCategories = new SvelteSet<FormatCategory>(FORMAT_CATEGORY_ORDER);
+	const expandedCategories = new SvelteSet<FormatCategory>();
 
 	// Filtered formats
 	const filteredFormats = $derived(() => {
@@ -102,6 +102,7 @@
 		if (expandedCategories.has(category)) {
 			expandedCategories.delete(category);
 		} else {
+			expandedCategories.clear();
 			expandedCategories.add(category);
 		}
 	}

--- a/src/lib/components/library/SeasonAccordion.svelte
+++ b/src/lib/components/library/SeasonAccordion.svelte
@@ -86,6 +86,7 @@
 		autoSearchingEpisodes?: Set<string>;
 		autoSearchEpisodeResults?: Map<string, AutoSearchResult>;
 		subtitleAutoSearchingEpisodes?: Set<string>;
+		onToggleOpen?: (seasonId: string) => void;
 		onSeasonMonitorToggle?: (seasonId: string, newValue: boolean) => void;
 		onEpisodeMonitorToggle?: (episodeId: string, newValue: boolean) => void;
 		onSeasonSearch?: (season: Season) => void;
@@ -114,6 +115,7 @@
 		autoSearchingEpisodes = new Set(),
 		autoSearchEpisodeResults = new Map(),
 		subtitleAutoSearchingEpisodes = new Set(),
+		onToggleOpen,
 		onSeasonMonitorToggle,
 		onEpisodeMonitorToggle,
 		onSeasonSearch,
@@ -215,7 +217,13 @@
 		<div class="flex w-full flex-wrap items-start gap-3 sm:flex-nowrap sm:items-center">
 			<button
 				class="flex min-w-0 flex-1 items-center gap-3 text-left"
-				onclick={() => (isOpen = !isOpen)}
+				onclick={() => {
+					if (onToggleOpen) {
+						onToggleOpen(season.id);
+					} else {
+						isOpen = !isOpen;
+					}
+				}}
 			>
 				{#if isOpen}
 					<ChevronDown size={20} class="text-base-content/50" />

--- a/src/lib/components/profiles/ProfileList.svelte
+++ b/src/lib/components/profiles/ProfileList.svelte
@@ -35,7 +35,7 @@
 		{/if}
 	</div>
 
-	<div class="card bg-base-100 shadow-xl">
+	<div class="card bg-transparent shadow-none sm:bg-base-100 sm:shadow-xl">
 		<div class="card-body p-0">
 			<ProfileTable
 				profiles={sortedProfiles()}

--- a/src/lib/components/profiles/ProfileModal.svelte
+++ b/src/lib/components/profiles/ProfileModal.svelte
@@ -43,14 +43,33 @@
 	let description = $state('');
 	let copyFromId = $state<string>('');
 	let upgradesAllowed = $state(true);
-	// Media-specific size limits (null = no limit)
-	let movieMinSizeGb = $state<number | null>(null);
-	let movieMaxSizeGb = $state<number | null>(null);
-	let episodeMinSizeMb = $state<number | null>(null);
-	let episodeMaxSizeMb = $state<number | null>(null);
+	// Media-specific size limits (string inputs to preserve cursor/editing)
+	let movieMinSizeGbInput = $state('');
+	let movieMaxSizeGbInput = $state('');
+	let episodeMinSizeMbInput = $state('');
+	let episodeMaxSizeMbInput = $state('');
 	let isDefault = $state(false);
 	// Format scores state
 	let formatScores = $state<Record<string, number>>({});
+
+	function coerceLimit(value: number | string | null | undefined): number | null {
+		if (value === null || value === undefined) return null;
+		if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		const parsed = Number(trimmed);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+
+	const movieMinSizeGbValue = $derived(parseNumberInput(movieMinSizeGbInput));
+	const movieMaxSizeGbValue = $derived(parseNumberInput(movieMaxSizeGbInput));
+	const episodeMinSizeMbValue = $derived(parseNumberInput(episodeMinSizeMbInput));
+	const episodeMaxSizeMbValue = $derived(parseNumberInput(episodeMaxSizeMbInput));
+
+	function stringifyLimit(value: number | null | undefined): string {
+		if (value === null || value === undefined) return '';
+		return Number.isFinite(value) ? String(value) : '';
+	}
 
 	// Initialize form when profile changes
 	$effect(() => {
@@ -60,10 +79,10 @@
 				description = profile.description || '';
 				copyFromId = ''; // No copy when editing existing profile
 				upgradesAllowed = profile.upgradesAllowed;
-				movieMinSizeGb = profile.movieMinSizeGb ?? null;
-				movieMaxSizeGb = profile.movieMaxSizeGb ?? null;
-				episodeMinSizeMb = profile.episodeMinSizeMb ?? null;
-				episodeMaxSizeMb = profile.episodeMaxSizeMb ?? null;
+				movieMinSizeGbInput = stringifyLimit(coerceLimit(profile.movieMinSizeGb));
+				movieMaxSizeGbInput = stringifyLimit(coerceLimit(profile.movieMaxSizeGb));
+				episodeMinSizeMbInput = stringifyLimit(coerceLimit(profile.episodeMinSizeMb));
+				episodeMaxSizeMbInput = stringifyLimit(coerceLimit(profile.episodeMaxSizeMb));
 				isDefault = profile.isDefault;
 				// Initialize format scores from profile
 				formatScores = { ...(profile.formatScores ?? {}) };
@@ -73,10 +92,10 @@
 				description = '';
 				copyFromId = defaultCopyFromId;
 				upgradesAllowed = true;
-				movieMinSizeGb = null;
-				movieMaxSizeGb = null;
-				episodeMinSizeMb = null;
-				episodeMaxSizeMb = null;
+				movieMinSizeGbInput = '';
+				movieMaxSizeGbInput = '';
+				episodeMinSizeMbInput = '';
+				episodeMaxSizeMbInput = '';
 				isDefault = false;
 				// For new profiles, start with empty scores (copyFrom is handled server-side)
 				formatScores = {};
@@ -85,6 +104,9 @@
 			activeTab = 'general';
 		}
 	});
+
+	const maxDescriptionLength = 70;
+	const descriptionTooLong = $derived(description.length > maxDescriptionLength);
 
 	// Convert Record<string, number> to Map<FormatCategory, FormatScoreEntry[]> for accordion
 	const groupedFormatScores = $derived(() => {
@@ -106,16 +128,118 @@
 		formatScores = { ...formatScores, [formatId]: score };
 	}
 
+	function normalizeLimit(value: number | string | null | undefined) {
+		const coerced = coerceLimit(value);
+		if (coerced === null) return null;
+		if (coerced === 0 || Number.isNaN(coerced)) return null;
+		return coerced;
+	}
+
+	function normalizeGbLimit(value: number | string | null | undefined) {
+		const coerced = normalizeLimit(value);
+		if (coerced === null) return null;
+		return Number(coerced.toFixed(2));
+	}
+
+	function normalizeMbLimit(value: number | string | null | undefined) {
+		const coerced = normalizeLimit(value);
+		if (coerced === null) return null;
+		return Math.round(coerced);
+	}
+
+	function parseNumberInput(value: string): number | null {
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		if (!/^\d*(\.\d*)?$/.test(trimmed)) return null;
+		const parsed = Number(trimmed);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+
+	function sanitizeDecimalInput(value: string, maxDecimals: number): string {
+		// Keep only digits and a single dot; enforce max decimals.
+		let cleaned = '';
+		let dotSeen = false;
+		let decimals = 0;
+		for (const ch of value) {
+			if (ch >= '0' && ch <= '9') {
+				if (dotSeen) {
+					if (decimals >= maxDecimals) continue;
+					decimals += 1;
+				}
+				cleaned += ch;
+				continue;
+			}
+			if (ch === '.' && !dotSeen && maxDecimals > 0) {
+				cleaned += ch;
+				dotSeen = true;
+			}
+		}
+		return cleaned;
+	}
+
+	function allowDecimalKey(event: KeyboardEvent, currentValue: string, maxDecimals: number) {
+		const key = event.key;
+		if (event.ctrlKey || event.metaKey || event.altKey) return;
+		if (
+			key === 'Backspace' ||
+			key === 'Delete' ||
+			key === 'ArrowLeft' ||
+			key === 'ArrowRight' ||
+			key === 'ArrowUp' ||
+			key === 'ArrowDown' ||
+			key === 'Home' ||
+			key === 'End' ||
+			key === 'Tab'
+		) {
+			return;
+		}
+		if (key === '.') {
+			if (maxDecimals === 0 || currentValue.includes('.')) {
+				event.preventDefault();
+			}
+			return;
+		}
+		if (key >= '0' && key <= '9') {
+			if (maxDecimals === 0 && currentValue.includes('.')) {
+				event.preventDefault();
+				return;
+			}
+			const dotIndex = currentValue.indexOf('.');
+			if (dotIndex !== -1 && currentValue.length - dotIndex - 1 >= maxDecimals) {
+				event.preventDefault();
+				return;
+			}
+			return;
+		}
+		event.preventDefault();
+	}
+
+	function sanitizePaste(
+		event: ClipboardEvent,
+		setter: (value: string) => void,
+		maxDecimals: number
+	) {
+		const text = event.clipboardData?.getData('text') ?? '';
+		const cleaned = sanitizeDecimalInput(text, maxDecimals);
+		if (cleaned !== text) {
+			event.preventDefault();
+			setter(cleaned);
+		}
+	}
+
 	function handleSave() {
+		if (descriptionTooLong) {
+			return;
+		}
 		onSave({
 			name,
 			description: description || undefined,
 			copyFromId: copyFromId || undefined, // Only include if creating new profile
 			upgradesAllowed,
-			movieMinSizeGb: movieMinSizeGb || null,
-			movieMaxSizeGb: movieMaxSizeGb || null,
-			episodeMinSizeMb: episodeMinSizeMb || null,
-			episodeMaxSizeMb: episodeMaxSizeMb || null,
+			movieMinSizeGb: normalizeGbLimit(movieMinSizeGbValue),
+			movieMaxSizeGb: normalizeGbLimit(movieMaxSizeGbValue),
+			episodeMinSizeMb: normalizeMbLimit(episodeMinSizeMbValue),
+			episodeMaxSizeMb: normalizeMbLimit(episodeMaxSizeMbValue),
 			isDefault,
 			// Include format scores (filter out zeros to keep payload lean)
 			formatScores: Object.fromEntries(
@@ -127,6 +251,7 @@
 	const isCoreReadonly = $derived(mode === 'view' || (profile?.isBuiltIn ?? false));
 	const isFullyReadonly = $derived(mode === 'view');
 	const isNewProfile = $derived(mode === 'add');
+	const isStreamerProfile = $derived(profile?.id === 'streamer');
 	const modalTitle = $derived(
 		mode === 'add' ? 'Create Profile' : profile?.isBuiltIn ? 'Edit Size Limits' : 'Edit Profile'
 	);
@@ -206,11 +331,24 @@
 					</label>
 					<textarea
 						id="profile-description"
-						class="textarea-bordered textarea h-20 textarea-sm"
+						class="textarea-bordered textarea h-20 resize-none textarea-sm"
 						bind:value={description}
 						disabled={isCoreReadonly}
+						maxlength={maxDescriptionLength}
 						placeholder="Describe what this profile is for..."
 					></textarea>
+					{#if !isCoreReadonly}
+						<div class="label py-1">
+							<span class="label-text-alt text-xs {descriptionTooLong ? 'text-error' : ''}">
+								{description.length}/{maxDescriptionLength}
+							</span>
+							{#if descriptionTooLong}
+								<span class="label-text-alt text-xs text-error">
+									Max {maxDescriptionLength} characters.
+								</span>
+							{/if}
+						</div>
+					{/if}
 				</div>
 
 				<!-- Copy From (only shown when creating new profile) -->
@@ -276,87 +414,142 @@
 			<div class="space-y-4">
 				<SectionHeader title="Size Limits" />
 
-				<div class="grid grid-cols-2 gap-2 sm:gap-3">
-					<div class="form-control">
-						<label class="label py-1" for="movie-min-size">
-							<span class="label-text">Movie Min (GB)</span>
-						</label>
-						<input
-							id="movie-min-size"
-							type="number"
-							step="0.1"
-							min="0"
-							class="input-bordered input input-sm"
-							bind:value={movieMinSizeGb}
-							disabled={isFullyReadonly}
-							placeholder="No min"
-						/>
+				{#if isStreamerProfile}
+					<div class="rounded-lg bg-base-200 p-3 text-xs text-base-content/70">
+						<Info class="mr-1 inline h-3 w-3" />
+						Streaming profiles use external sources, so size limits are not configurable.
+					</div>
+				{:else}
+					<div class="grid grid-cols-2 gap-2 sm:gap-3">
+						<div class="form-control">
+							<label class="label py-1" for="movie-min-size">
+								<span class="label-text">Movie Min (GB)</span>
+							</label>
+							<input
+								id="movie-min-size"
+								type="text"
+								inputmode="decimal"
+								class="input-bordered input input-sm"
+								value={movieMinSizeGbInput}
+								oninput={(event) => {
+									const target = event.currentTarget as HTMLInputElement;
+									movieMinSizeGbInput = sanitizeDecimalInput(target.value, 2);
+								}}
+								onkeydown={(event) => allowDecimalKey(event, movieMinSizeGbInput, 2)}
+								onpaste={(event) =>
+									sanitizePaste(
+										event,
+										(value) => {
+											movieMinSizeGbInput = value;
+										},
+										2
+									)}
+								disabled={isFullyReadonly}
+								placeholder="No min"
+							/>
+						</div>
+
+						<div class="form-control">
+							<label class="label py-1" for="movie-max-size">
+								<span class="label-text">Movie Max (GB)</span>
+							</label>
+							<input
+								id="movie-max-size"
+								type="text"
+								inputmode="decimal"
+								class="input-bordered input input-sm"
+								value={movieMaxSizeGbInput}
+								oninput={(event) => {
+									const target = event.currentTarget as HTMLInputElement;
+									movieMaxSizeGbInput = sanitizeDecimalInput(target.value, 2);
+								}}
+								onkeydown={(event) => allowDecimalKey(event, movieMaxSizeGbInput, 2)}
+								onpaste={(event) =>
+									sanitizePaste(
+										event,
+										(value) => {
+											movieMaxSizeGbInput = value;
+										},
+										2
+									)}
+								disabled={isFullyReadonly}
+								placeholder="No max"
+							/>
+						</div>
 					</div>
 
-					<div class="form-control">
-						<label class="label py-1" for="movie-max-size">
-							<span class="label-text">Movie Max (GB)</span>
-						</label>
-						<input
-							id="movie-max-size"
-							type="number"
-							step="0.1"
-							min="0"
-							class="input-bordered input input-sm"
-							bind:value={movieMaxSizeGb}
-							disabled={isFullyReadonly}
-							placeholder="No max"
-						/>
-					</div>
-				</div>
+					<div class="grid grid-cols-2 gap-2 sm:gap-3">
+						<div class="form-control">
+							<label class="label py-1" for="episode-min-size">
+								<span class="label-text">Episode Min (MB)</span>
+							</label>
+							<input
+								id="episode-min-size"
+								type="text"
+								inputmode="decimal"
+								class="input-bordered input input-sm"
+								value={episodeMinSizeMbInput}
+								oninput={(event) => {
+									const target = event.currentTarget as HTMLInputElement;
+									episodeMinSizeMbInput = sanitizeDecimalInput(target.value, 0);
+								}}
+								onkeydown={(event) => allowDecimalKey(event, episodeMinSizeMbInput, 0)}
+								onpaste={(event) =>
+									sanitizePaste(
+										event,
+										(value) => {
+											episodeMinSizeMbInput = value;
+										},
+										0
+									)}
+								disabled={isFullyReadonly}
+								placeholder="No min"
+							/>
+							{#if episodeMinSizeMbValue}
+								<div class="label py-0">
+									<span class="label-text-alt text-xs">
+										= {(episodeMinSizeMbValue / 1024).toFixed(2)} GB
+									</span>
+								</div>
+							{/if}
+						</div>
 
-				<div class="grid grid-cols-2 gap-2 sm:gap-3">
-					<div class="form-control">
-						<label class="label py-1" for="episode-min-size">
-							<span class="label-text">Episode Min (MB)</span>
-						</label>
-						<input
-							id="episode-min-size"
-							type="number"
-							step="10"
-							min="0"
-							class="input-bordered input input-sm"
-							bind:value={episodeMinSizeMb}
-							disabled={isFullyReadonly}
-							placeholder="No min"
-						/>
-						{#if episodeMinSizeMb}
-							<div class="label py-0">
-								<span class="label-text-alt text-xs">
-									= {(episodeMinSizeMb / 1024).toFixed(2)} GB
-								</span>
-							</div>
-						{/if}
+						<div class="form-control">
+							<label class="label py-1" for="episode-max-size">
+								<span class="label-text">Episode Max (MB)</span>
+							</label>
+							<input
+								id="episode-max-size"
+								type="text"
+								inputmode="decimal"
+								class="input-bordered input input-sm"
+								value={episodeMaxSizeMbInput}
+								oninput={(event) => {
+									const target = event.currentTarget as HTMLInputElement;
+									episodeMaxSizeMbInput = sanitizeDecimalInput(target.value, 0);
+								}}
+								onkeydown={(event) => allowDecimalKey(event, episodeMaxSizeMbInput, 0)}
+								onpaste={(event) =>
+									sanitizePaste(
+										event,
+										(value) => {
+											episodeMaxSizeMbInput = value;
+										},
+										0
+									)}
+								disabled={isFullyReadonly}
+								placeholder="No max"
+							/>
+							{#if episodeMaxSizeMbValue}
+								<div class="label py-0">
+									<span class="label-text-alt text-xs">
+										= {(episodeMaxSizeMbValue / 1024).toFixed(2)} GB
+									</span>
+								</div>
+							{/if}
+						</div>
 					</div>
-
-					<div class="form-control">
-						<label class="label py-1" for="episode-max-size">
-							<span class="label-text">Episode Max (MB)</span>
-						</label>
-						<input
-							id="episode-max-size"
-							type="number"
-							step="10"
-							min="0"
-							class="input-bordered input input-sm"
-							bind:value={episodeMaxSizeMb}
-							disabled={isFullyReadonly}
-							placeholder="No max"
-						/>
-						{#if episodeMaxSizeMb}
-							<div class="label py-0">
-								<span class="label-text-alt text-xs">
-									= {(episodeMaxSizeMb / 1024).toFixed(2)} GB
-								</span>
-							</div>
-						{/if}
-					</div>
-				</div>
+				{/if}
 
 				<div class="rounded-lg bg-base-200 p-3 text-xs text-base-content/70">
 					<Info class="mr-1 inline h-3 w-3" />
@@ -389,7 +582,11 @@
 			{isFullyReadonly ? 'Close' : 'Cancel'}
 		</button>
 		{#if !isFullyReadonly}
-			<button class="btn gap-2 btn-primary" onclick={handleSave} disabled={saving || !name}>
+			<button
+				class="btn gap-2 btn-primary"
+				onclick={handleSave}
+				disabled={saving || !name || descriptionTooLong}
+			>
 				{#if saving}
 					<Loader2 class="h-4 w-4 animate-spin" />
 				{:else}

--- a/src/lib/components/profiles/ProfileTable.svelte
+++ b/src/lib/components/profiles/ProfileTable.svelte
@@ -13,20 +13,79 @@
 
 	// Format size limit display
 	function formatMovieSize(profile: ScoringProfile): string {
+		if (profile.id === 'streamer') return 'Auto';
 		const min = profile.movieMinSizeGb;
 		const max = profile.movieMaxSizeGb;
-		if (min && max) return `${min} - ${max} GB`;
-		if (min) return `${min}+ GB`;
-		if (max) return `< ${max} GB`;
+		const formatValue = (value: number) => {
+			if (value < 1) {
+				const mb = value * 1024;
+				const label = Number.isInteger(mb) ? mb.toString() : mb.toFixed(0);
+				return `${label} MB`;
+			}
+			const label = Number.isInteger(value) ? value.toString() : value.toFixed(1);
+			return `${label} GB`;
+		};
+
+		if (min && max) {
+			const minLabel = formatValue(min);
+			const maxLabel = formatValue(max);
+			const sameUnit = (min < 1 && max < 1) || (min >= 1 && max >= 1);
+
+			if (sameUnit) {
+				const unit = min < 1 ? 'MB' : 'GB';
+				const minValue = min < 1 ? min * 1024 : min;
+				const maxValue = max < 1 ? max * 1024 : max;
+				const minText = Number.isInteger(minValue)
+					? minValue.toString()
+					: unit === 'MB'
+						? minValue.toFixed(0)
+						: minValue.toFixed(1);
+				const maxText = Number.isInteger(maxValue)
+					? maxValue.toString()
+					: unit === 'MB'
+						? maxValue.toFixed(0)
+						: maxValue.toFixed(1);
+				return `${minText} ${unit} - ${maxText} ${unit}`;
+			}
+
+			return `${minLabel} - ${maxLabel}`;
+		}
+		if (min) return `${formatValue(min)}+`;
+		if (max) return `< ${formatValue(max)}`;
 		return '-';
 	}
 
 	function formatEpisodeSize(profile: ScoringProfile): string {
+		if (profile.id === 'streamer') return 'Auto';
 		const min = profile.episodeMinSizeMb;
 		const max = profile.episodeMaxSizeMb;
-		if (min && max) return `${min} - ${max} MB`;
-		if (min) return `${min}+ MB`;
-		if (max) return `< ${max} MB`;
+		const formatValue = (value: number) => {
+			if (value >= 1024) {
+				const gb = value / 1024;
+				const label = Number.isInteger(gb) ? gb.toString() : gb.toFixed(1);
+				return `${label} GB`;
+			}
+			return `${value} MB`;
+		};
+
+		if (min && max) {
+			const minLabel = formatValue(min);
+			const maxLabel = formatValue(max);
+			const sameUnit = (min < 1024 && max < 1024) || (min >= 1024 && max >= 1024);
+
+			if (sameUnit) {
+				const unit = min < 1024 ? 'MB' : 'GB';
+				const minValue = min < 1024 ? min : min / 1024;
+				const maxValue = max < 1024 ? max : max / 1024;
+				const minText = Number.isInteger(minValue) ? minValue.toString() : minValue.toFixed(1);
+				const maxText = Number.isInteger(maxValue) ? maxValue.toString() : maxValue.toFixed(1);
+				return `${minText} ${unit} - ${maxText} ${unit}`;
+			}
+
+			return `${minLabel} - ${maxLabel}`;
+		}
+		if (min) return `${formatValue(min)}+`;
+		if (max) return `< ${formatValue(max)}`;
 		return '-';
 	}
 </script>
@@ -38,11 +97,93 @@
 		<p class="mt-1 text-sm">Add a profile to manage quality preferences</p>
 	</div>
 {:else}
-	<div class="overflow-x-auto">
+	<div class="space-y-3 sm:hidden">
+		{#each profiles as profile (profile.id)}
+			<div class="card border border-base-300/60 bg-base-200/40">
+				<div class="card-body gap-3 p-4">
+					<div class="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+						<div class="flex min-w-0 items-start gap-3">
+							<div class="mt-0.5 h-4 w-4 flex-none">
+								{#if profile.isBuiltIn}
+									<Lock class="h-4 w-4 text-base-content/40" />
+								{:else}
+									<Settings class="h-4 w-4 text-base-content/40" />
+								{/if}
+							</div>
+							<div class="min-w-0">
+								<div class="font-bold">{profile.name}</div>
+								{#if profile.description}
+									<div class="mt-0.5 text-sm wrap-break-word whitespace-normal opacity-50">
+										{profile.description}
+									</div>
+								{/if}
+							</div>
+						</div>
+						<div class="flex min-w-18 shrink-0 items-start justify-end gap-1">
+							{#if profile.id !== 'streamer'}
+								<button
+									class="btn h-8 w-8 min-w-8 p-0 btn-ghost btn-xs"
+									onclick={() => onEdit(profile)}
+									title="Edit"
+								>
+									<Settings class="h-4 w-4 flex-none" />
+								</button>
+							{/if}
+							{#if !profile.isBuiltIn}
+								<button
+									class="btn h-8 w-8 min-w-8 p-0 text-error btn-ghost btn-xs"
+									onclick={() => onDelete(profile)}
+									title="Delete"
+								>
+									<Trash2 class="h-4 w-4 flex-none" />
+								</button>
+							{/if}
+						</div>
+					</div>
+
+					<div class="flex flex-wrap items-center gap-2">
+						<span class="badge {profile.isBuiltIn ? 'badge-ghost' : 'badge-outline badge-primary'}">
+							{profile.isBuiltIn ? 'Built-in' : 'Custom'}
+						</span>
+						{#if profile.isDefault}
+							<span class="badge gap-1 badge-success">
+								<Check class="h-3 w-3" />
+								Default
+							</span>
+						{/if}
+					</div>
+
+					<div class="grid grid-cols-2 gap-3 text-sm">
+						<div>
+							<div class="text-xs tracking-wide text-base-content/50 uppercase">Movie Size</div>
+							<div class="font-mono">{formatMovieSize(profile)}</div>
+						</div>
+						<div>
+							<div class="text-xs tracking-wide text-base-content/50 uppercase">Episode Size</div>
+							<div class="font-mono">{formatEpisodeSize(profile)}</div>
+						</div>
+					</div>
+
+					{#if !profile.isDefault}
+						<button
+							class="btn w-fit btn-ghost btn-xs"
+							onclick={() => onSetDefault(profile)}
+							title="Set as default"
+						>
+							<Star class="h-3.5 w-3.5" />
+							Set as default
+						</button>
+					{/if}
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<div class="hidden overflow-x-auto sm:block">
 		<table class="table">
 			<thead>
 				<tr>
-					<th>Name</th>
+					<th class="w-[40%]">Name</th>
 					<th>Type</th>
 					<th>
 						<div class="flex items-center gap-1">
@@ -63,7 +204,7 @@
 			<tbody>
 				{#each profiles as profile (profile.id)}
 					<tr class="hover">
-						<td>
+						<td class="w-[40%]">
 							<div class="flex items-center gap-3">
 								{#if profile.isBuiltIn}
 									<Lock class="h-4 w-4 text-base-content/40" />
@@ -73,7 +214,7 @@
 								<div>
 									<div class="font-bold">{profile.name}</div>
 									{#if profile.description}
-										<div class="max-w-xs truncate text-sm opacity-50">
+										<div class="max-w-[70ch] text-sm wrap-break-word whitespace-normal opacity-50">
 											{profile.description}
 										</div>
 									{/if}
@@ -111,9 +252,11 @@
 						</td>
 						<td>
 							<div class="flex justify-end gap-1">
-								<button class="btn btn-ghost btn-sm" onclick={() => onEdit(profile)} title="Edit">
-									<Settings class="h-4 w-4" />
-								</button>
+								{#if profile.id !== 'streamer'}
+									<button class="btn btn-ghost btn-sm" onclick={() => onEdit(profile)} title="Edit">
+										<Settings class="h-4 w-4" />
+									</button>
+								{/if}
 								{#if !profile.isBuiltIn}
 									<button
 										class="btn text-error btn-ghost btn-sm"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -361,10 +361,10 @@
 										</div>
 									{/if}
 									<div class="min-w-0 flex-1">
-										<p class="truncate font-medium">
+										<p class="font-medium break-words whitespace-normal">
 											{episode.series?.title || 'Unknown Series'}
 										</p>
-										<p class="text-sm text-base-content/70">
+										<p class="text-sm break-words whitespace-normal text-base-content/70">
 											S{String(episode.seasonNumber).padStart(2, '0')}E{String(
 												episode.episodeNumber
 											).padStart(2, '0')}

--- a/src/routes/api/scoring-profiles/+server.ts
+++ b/src/routes/api/scoring-profiles/+server.ts
@@ -258,10 +258,22 @@ export const PUT: RequestHandler = async ({ request }) => {
 				await db
 					.update(profileSizeLimits)
 					.set({
-						movieMinSizeGb: updateData.movieMinSizeGb ?? existing[0].movieMinSizeGb,
-						movieMaxSizeGb: updateData.movieMaxSizeGb ?? existing[0].movieMaxSizeGb,
-						episodeMinSizeMb: updateData.episodeMinSizeMb ?? existing[0].episodeMinSizeMb,
-						episodeMaxSizeMb: updateData.episodeMaxSizeMb ?? existing[0].episodeMaxSizeMb,
+						movieMinSizeGb:
+							updateData.movieMinSizeGb !== undefined
+								? updateData.movieMinSizeGb
+								: existing[0].movieMinSizeGb,
+						movieMaxSizeGb:
+							updateData.movieMaxSizeGb !== undefined
+								? updateData.movieMaxSizeGb
+								: existing[0].movieMaxSizeGb,
+						episodeMinSizeMb:
+							updateData.episodeMinSizeMb !== undefined
+								? updateData.episodeMinSizeMb
+								: existing[0].episodeMinSizeMb,
+						episodeMaxSizeMb:
+							updateData.episodeMaxSizeMb !== undefined
+								? updateData.episodeMaxSizeMb
+								: existing[0].episodeMaxSizeMb,
 						isDefault: updateData.isDefault ?? existing[0].isDefault,
 						updatedAt: new Date().toISOString()
 					})

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -50,6 +50,7 @@
 	// Selection state
 	let selectedEpisodes = new SvelteSet<string>();
 	let showCheckboxes = $state(false);
+	let openSeasonId = $state<string | null>(null);
 
 	// Auto-search state
 	let autoSearchingEpisodes = new SvelteSet<string>();
@@ -799,6 +800,10 @@
 		selectedEpisodes.clear();
 	}
 
+	function handleSeasonToggle(seasonId: string) {
+		openSeasonId = openSeasonId === seasonId ? null : seasonId;
+	}
+
 	interface Release {
 		guid: string;
 		title: string;
@@ -992,7 +997,7 @@
 						{season}
 						seriesMonitored={data.series.monitored ?? false}
 						isStreamerProfile={data.series.scoringProfileId === 'streamer'}
-						defaultOpen={false}
+						defaultOpen={openSeasonId === season.id}
 						{selectedEpisodes}
 						{showCheckboxes}
 						{downloadingEpisodeIds}
@@ -1002,6 +1007,7 @@
 						{autoSearchingEpisodes}
 						{autoSearchEpisodeResults}
 						{subtitleAutoSearchingEpisodes}
+						onToggleOpen={handleSeasonToggle}
 						onSeasonMonitorToggle={handleSeasonMonitorToggle}
 						onEpisodeMonitorToggle={handleEpisodeMonitorToggle}
 						onSeasonSearch={handleSeasonSearch}


### PR DESCRIPTION
## Summary

This pull request introduces several improvements to the profile management UI, particularly around size limit handling and input validation, as well as minor usability enhancements elsewhere. The most significant changes are the overhaul of size limit inputs in the profile modal, improved display logic for size limits, and special handling for the Streamer profile. Additionally, there are small UI tweaks and a new callback for the season accordion.

**Profile size limit handling and Streamer profile support:**

* Refactored size limit fields in `ProfileModal.svelte` to use string inputs with custom validation and sanitization, allowing for more robust user input handling and preserving cursor position. Added helper functions for parsing, normalizing, and displaying size limits, and switched input types from `number` to `text` for better UX. [[1]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL46-R73) [[2]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL63-R85) [[3]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL76-R98) [[4]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eR131-R242) [[5]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eR417-R446) [[6]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL302-R474) [[7]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL320-R511) [[8]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL343-R552)
* Added special handling for the Streamer profile: size limits are now locked and displayed as `Auto` in both the modal and the profile table, and a user-facing explanation is shown when editing the Streamer profile (fallback for, if a user manages to access the modal). [[1]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eR254) [[2]](diffhunk://#diff-b3c49bc0891c0b808fb172d69e9bebeb9de47a83e9acb1841ddcca9256820c1eR16-R88) [[3]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eR417-R446)
* Improved display logic for size limits in `ProfileTable.svelte` to show values in GB or MB as appropriate, including handling edge cases where values cross units.

**Input validation and user feedback:**

* Added a description character limit in `ProfileModal.svelte`, with live feedback and error handling to prevent saving if the limit is exceeded. [[1]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eR108-R110) [[2]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL209-R351) [[3]](diffhunk://#diff-5c709796791cfc653df03e0d9e3c0108b19ee3469d5f38c33f99388848df283eL392-R589)

**UI/UX improvements:**

* Made profile cards transparent and shadowless on small screens for improved mobile appearance in `ProfileList.svelte`.
* Updated the format list category expansion logic to only allow one expanded category at a time for better usability. [[1]](diffhunk://#diff-5ba4091c2ad6d705d296f30c0def4e641d1991905fe375d03cab273a25f2b272L40-R40) [[2]](diffhunk://#diff-5ba4091c2ad6d705d296f30c0def4e641d1991905fe375d03cab273a25f2b272R105)

**Library/season accordion enhancements:**

* Added an optional `onToggleOpen` callback to `SeasonAccordion.svelte` so parent components can respond to accordion open/close events. [[1]](diffhunk://#diff-5b3b187816d3c29c875f1d8dbdf38370ab5325299aab0ccacc0cf11d2d91e953R89) [[2]](diffhunk://#diff-5b3b187816d3c29c875f1d8dbdf38370ab5325299aab0ccacc0cf11d2d91e953R118) [[3]](diffhunk://#diff-5b3b187816d3c29c875f1d8dbdf38370ab5325299aab0ccacc0cf11d2d91e953L218-R226)

**Documentation update:**

* Added a FAQ entry explaining why Streamer profile size limits cannot be configured.

## Related Issues

#109 #62 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Fix size limit editing to allow clearing built-in values and prevent invalid payloads.
- Add strict decimal validation (GB=2 decimals, MB=0) with paste/key filtering and rounding on save.
- Improve size display formatting (dynamic MB/GB units; units shown on both sides).
- Lock Streamer size controls and show Auto sizes; hide Streamer edit action.
- Update profile UI for mobile cards, stable icon sizing.
- Make Custom Format categories and Season accordion exclusive-open by default.
- Improve Missing Episodes card wrapping on mobile.
- Update FAQ.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [x] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [x] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
