### PR TITLE
fix: correct search routing and allow manual episode auto-grab override.

### DIFF
--- a/src/lib/server/indexers/runtime/RequestBuilder.test.ts
+++ b/src/lib/server/indexers/runtime/RequestBuilder.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { createFilterEngine } from '../engine/FilterEngine';
+import { createTemplateEngine } from '../engine/TemplateEngine';
+import { RequestBuilder } from './RequestBuilder';
+import type { SearchCriteria } from '../types';
+
+function createTestRequestBuilder(): RequestBuilder {
+	const definition = {
+		id: 'test-indexer',
+		name: 'Test Indexer',
+		type: 'private',
+		protocol: 'usenet',
+		links: ['https://example.test'],
+		caps: {
+			categories: {
+				'2000': 'Movies',
+				'5000': 'TV'
+			},
+			categorymappings: [
+				{ id: '2000', cat: 'Movies' },
+				{ id: '5000', cat: 'TV', default: true }
+			]
+		},
+		search: {
+			paths: [
+				{
+					path: '/api',
+					method: 'get',
+					categories: ['Movies'],
+					inputs: {
+						t: 'movie',
+						cat: '{{ join .Categories "," }}',
+						q: '{{ .Keywords }}'
+					}
+				},
+				{
+					path: '/api',
+					method: 'get',
+					categories: ['TV'],
+					inputs: {
+						t: 'tvsearch',
+						cat: '{{ join .Categories "," }}',
+						q: '{{ .Keywords }}'
+					}
+				},
+				{
+					path: '/api',
+					method: 'get',
+					inputs: {
+						t: 'search',
+						cat: '{{ join .Categories "," }}',
+						q: '{{ .Keywords }}'
+					}
+				}
+			],
+			response: { type: 'xml' },
+			rows: { selector: 'rss channel item' },
+			fields: {
+				title: { selector: 'title' }
+			}
+		}
+	} as any;
+
+	return new RequestBuilder(definition, createTemplateEngine(), createFilterEngine());
+}
+
+function getParam(url: string, key: string): string | null {
+	return new URL(url).searchParams.get(key);
+}
+
+describe('RequestBuilder category defaults', () => {
+	it('uses movie categories for movie search when categories are omitted', () => {
+		const builder = createTestRequestBuilder();
+		const criteria: SearchCriteria = {
+			searchType: 'movie',
+			query: 'The Wrecking Crew',
+			year: 2026
+		};
+
+		const requests = builder.buildSearchRequests(criteria);
+
+		expect(requests).toHaveLength(1);
+		expect(getParam(requests[0].url, 't')).toBe('movie');
+		expect(getParam(requests[0].url, 'cat')).toBe('2000');
+	});
+
+	it('uses TV categories for tv search when categories are omitted', () => {
+		const builder = createTestRequestBuilder();
+		const criteria: SearchCriteria = {
+			searchType: 'tv',
+			query: 'The Wrecking Crew',
+			season: 1,
+			episode: 1
+		};
+
+		const requests = builder.buildSearchRequests(criteria);
+
+		expect(requests).toHaveLength(1);
+		expect(getParam(requests[0].url, 't')).toBe('tvsearch');
+		expect(getParam(requests[0].url, 'cat')).toBe('5000');
+	});
+
+	it('keeps generic path for basic search', () => {
+		const builder = createTestRequestBuilder();
+		const criteria: SearchCriteria = {
+			searchType: 'basic',
+			query: 'Trap House 2025'
+		};
+
+		const requests = builder.buildSearchRequests(criteria);
+		const modes = requests
+			.map((request) => getParam(request.url, 't'))
+			.filter((mode): mode is string => Boolean(mode));
+
+		expect(requests).toHaveLength(1);
+		expect(modes).toContain('search');
+	});
+});

--- a/src/lib/server/library/searchOnAdd.test.ts
+++ b/src/lib/server/library/searchOnAdd.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	episodesFindFirst: vi.fn(),
+	seriesFindFirst: vi.fn(),
+	episodeFilesFindMany: vi.fn(),
+	searchEnhanced: vi.fn(),
+	evaluateForEpisode: vi.fn(),
+	grabRelease: vi.fn(),
+	getIndexerManager: vi.fn()
+}));
+
+vi.mock('$lib/server/db/index.js', () => ({
+	db: {
+		query: {
+			episodes: { findFirst: mocks.episodesFindFirst },
+			series: { findFirst: mocks.seriesFindFirst },
+			episodeFiles: { findMany: mocks.episodeFilesFindMany }
+		}
+	}
+}));
+
+vi.mock('$lib/server/indexers/IndexerManager.js', () => ({
+	getIndexerManager: mocks.getIndexerManager
+}));
+
+vi.mock('$lib/server/downloads/index.js', () => ({
+	releaseDecisionService: {
+		evaluateForEpisode: mocks.evaluateForEpisode
+	},
+	getReleaseGrabService: () => ({
+		grabRelease: mocks.grabRelease
+	}),
+	getCascadingSearchStrategy: vi.fn()
+}));
+
+vi.mock('$lib/logging/index.js', () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	}
+}));
+
+import { searchOnAdd } from './searchOnAdd';
+
+describe('SearchOnAddService.searchForEpisode monitoring behavior', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getIndexerManager.mockResolvedValue({
+			searchEnhanced: mocks.searchEnhanced
+		});
+	});
+
+	it('skips when series is unmonitored by default', async () => {
+		mocks.episodesFindFirst.mockResolvedValue({
+			id: 'ep-1',
+			seriesId: 'series-1',
+			seasonNumber: 2,
+			episodeNumber: 1
+		});
+		mocks.seriesFindFirst.mockResolvedValue({
+			id: 'series-1',
+			title: 'The Pitt',
+			tmdbId: 250307,
+			tvdbId: 448176,
+			imdbId: 'tt3193862',
+			monitored: false,
+			scoringProfileId: null
+		});
+
+		const result = await searchOnAdd.searchForEpisode({ episodeId: 'ep-1' });
+
+		expect(result).toEqual({ success: true });
+		expect(mocks.searchEnhanced).not.toHaveBeenCalled();
+		expect(mocks.grabRelease).not.toHaveBeenCalled();
+	});
+
+	it('searches and grabs when bypassMonitoring is true', async () => {
+		mocks.episodesFindFirst.mockResolvedValue({
+			id: 'ep-1',
+			seriesId: 'series-1',
+			seasonNumber: 2,
+			episodeNumber: 1
+		});
+		mocks.seriesFindFirst.mockResolvedValue({
+			id: 'series-1',
+			title: 'The Pitt',
+			tmdbId: 250307,
+			tvdbId: 448176,
+			imdbId: 'tt3193862',
+			monitored: false,
+			scoringProfileId: null
+		});
+		mocks.episodeFilesFindMany.mockResolvedValue([]);
+		mocks.searchEnhanced.mockResolvedValue({
+			releases: [
+				{
+					title: 'The.Pitt.S02E01.1080p.WEB.H264-GROUP',
+					size: 2_000_000_000,
+					parsed: {
+						resolution: '1080p',
+						source: 'webdl',
+						codec: 'h264',
+						hdr: null
+					},
+					indexerId: 'indexer-1',
+					infoHash: 'abc123',
+					downloadUrl: 'https://example.test/download/1',
+					magnetUrl: null
+				}
+			],
+			rejectedCount: 0
+		});
+		mocks.evaluateForEpisode.mockResolvedValue({
+			accepted: true,
+			isUpgrade: false
+		});
+		mocks.grabRelease.mockResolvedValue({
+			success: true,
+			releaseName: 'The.Pitt.S02E01.1080p.WEB.H264-GROUP',
+			queueItemId: 'queue-1'
+		});
+
+		const result = await searchOnAdd.searchForEpisode({
+			episodeId: 'ep-1',
+			bypassMonitoring: true
+		});
+
+		expect(mocks.searchEnhanced).toHaveBeenCalledOnce();
+		expect(mocks.grabRelease).toHaveBeenCalledOnce();
+		expect(result).toMatchObject({
+			success: true,
+			releaseName: 'The.Pitt.S02E01.1080p.WEB.H264-GROUP'
+		});
+	});
+});

--- a/src/lib/server/library/searchOnAdd.ts
+++ b/src/lib/server/library/searchOnAdd.ts
@@ -67,6 +67,8 @@ interface GrabResult {
 /** Parameters for searching a specific episode */
 interface SearchForEpisodeParams {
 	episodeId: string;
+	/** Bypass monitoring checks for manual user-triggered searches */
+	bypassMonitoring?: boolean;
 }
 
 /** Parameters for searching a season pack */
@@ -396,7 +398,7 @@ class SearchOnAddService {
 	 * - OR release is an upgrade over existing file
 	 */
 	async searchForEpisode(params: SearchForEpisodeParams): Promise<GrabResult> {
-		const { episodeId } = params;
+		const { episodeId, bypassMonitoring = false } = params;
 
 		logger.info('[SearchOnAdd] Starting episode search', { episodeId });
 
@@ -418,7 +420,7 @@ class SearchOnAddService {
 				return { success: false, error: 'Series not found' };
 			}
 
-			if (!seriesData.monitored) {
+			if (!bypassMonitoring && !seriesData.monitored) {
 				logger.info('[SearchOnAdd] Skipping episode search for unmonitored series', {
 					episodeId,
 					seriesId: seriesData.id

--- a/src/routes/api/library/series/[id]/auto-search/+server.ts
+++ b/src/routes/api/library/series/[id]/auto-search/+server.ts
@@ -45,7 +45,10 @@ export const POST: RequestHandler = async ({ params, request }) => {
 					);
 				}
 
-				const result = await searchOnAdd.searchForEpisode({ episodeId });
+				const result = await searchOnAdd.searchForEpisode({
+					episodeId,
+					bypassMonitoring: true
+				});
 
 				return json({
 					success: result.success,

--- a/src/routes/library/unmatched/+page.svelte
+++ b/src/routes/library/unmatched/+page.svelte
@@ -263,7 +263,6 @@
 		}
 		try {
 			for (const item of selectedItems) {
-				// eslint-disable-next-line no-await-in-loop
 				await updateRootFolder(item, rootFolderId, { silent: true });
 			}
 			toasts.success('Root folder updated for selected items');


### PR DESCRIPTION
## Summary

This pull request introduces improvements to search behavior and category handling in the indexer and library modules, as well as adds new tests for these features. The main focus is on ensuring correct category defaults for different search types, enabling bypass of monitoring checks for manual searches, and improving test coverage.

Indexer search category handling:

* Added logic in `RequestBuilder` (`RequestBuilder.ts`) to apply category defaults based on search type when categories are omitted, ensuring movie and TV searches use the correct categories instead of falling back to generic defaults. [[1]](diffhunk://#diff-82575f8cecb5febfce3194f6331d5b0ec51e7818d0e6fc9d979a51fa8c1357d0R237-R261) [[2]](diffhunk://#diff-82575f8cecb5febfce3194f6331d5b0ec51e7818d0e6fc9d979a51fa8c1357d0R272-R328)
* Introduced filtering of search paths to prefer category-scoped paths for typed searches (movie/tv/etc.), avoiding unnecessary generic fallback paths.
* Added tests in `RequestBuilder.test.ts` to verify correct category selection and path filtering for movie, TV, and basic searches.

Library search monitoring and bypass:

* Added a `bypassMonitoring` parameter to `searchForEpisode` in `searchOnAdd.ts`, allowing manual searches to skip monitoring checks for unmonitored series. [[1]](diffhunk://#diff-2207c2c3916da9a5c9c575530fc65f80f983935d45ab6f415368e935ef6d5492R70-R71) [[2]](diffhunk://#diff-2207c2c3916da9a5c9c575530fc65f80f983935d45ab6f415368e935ef6d5492L399-R401) [[3]](diffhunk://#diff-2207c2c3916da9a5c9c575530fc65f80f983935d45ab6f415368e935ef6d5492L421-R423)
* Updated the auto-search endpoint (`series/[id]/auto-search/+server.ts`) to use `bypassMonitoring: true` for user-triggered searches. ([src/routes/api/library/series/[id]/auto-search/+server.tsL48-R51](diffhunk://#diff-1f515336df7300e0caeb2c32a87972f3c7f834eea4c1eef31cb1e7aab8830863L48-R51))
* Added tests in `searchOnAdd.test.ts` to verify monitoring behavior and bypass functionality.

Miscellaneous:

* Removed unnecessary ESLint directive in `unmatched/+page.svelte` for improved code clarity.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

#108 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- RequestBuilder now applies searchType-based default categories when none are provided, preventing movie searches from falling back to TV category defaults on Newznab indexers.
- RequestBuilder path selection now prefers category-scoped paths for typed searches (movie/tv/music/book) and avoids also sending generic fallback requests, reducing duplicate API calls and rate-limit risk.
- Basic text searches continue to prefer generic search paths.
- Added RequestBuilder regression tests for:
  - movie default category fallback (2000)
  - tv default category fallback (5000)
  - basic search using generic path
- SearchOnAdd episode search now supports an explicit `bypassMonitoring` flag.
- Manual episode auto-search (`/api/library/series/[id]/auto-search`, type=episode) now sets `bypassMonitoring: true`, so user-triggered "Auto-grab best" is not blocked when series/season monitoring is disabled.
- Added SearchOnAdd regression tests to verify:
  - default skip behavior for unmonitored series
  - manual bypass path executes search/grab flow

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

<img width="1367" height="192" alt="image" src="https://github.com/user-attachments/assets/6fb8864f-f223-4056-a5a3-b78551882576" />
