### PR TITLE
fix: deduplicate episode files and optimize STRM reprobe

### DIFF
--- a/src/lib/components/library/BulkQualityProfileModal.svelte
+++ b/src/lib/components/library/BulkQualityProfileModal.svelte
@@ -32,7 +32,11 @@
 		}
 	});
 
-	const currentProfile = $derived(qualityProfiles.find((p) => p.id === qualityProfileId));
+	const defaultProfile = $derived(qualityProfiles.find((p) => p.isDefault));
+	const nonDefaultProfiles = $derived(qualityProfiles.filter((p) => p.id !== defaultProfile?.id));
+	const currentProfile = $derived(
+		qualityProfiles.find((p) => p.id === qualityProfileId) ?? defaultProfile
+	);
 
 	const itemLabel = $derived(
 		mediaType === 'movie'
@@ -81,14 +85,9 @@
 			bind:value={qualityProfileId}
 			class="select-bordered select w-full"
 		>
-			<option value=""
-				>Default ({qualityProfiles.find((p) => p.isDefault)?.name ?? 'System Default'})</option
-			>
-			{#each qualityProfiles as profile (profile.id)}
-				<option value={profile.id}>
-					{profile.name}
-					{profile.isBuiltIn ? '' : '(Custom)'}
-				</option>
+			<option value="">{defaultProfile?.name ?? 'System Default'} (Default)</option>
+			{#each nonDefaultProfiles as profile (profile.id)}
+				<option value={profile.id}>{profile.name}</option>
 			{/each}
 		</select>
 		<div class="label">

--- a/src/lib/components/library/MatchFolderModal.svelte
+++ b/src/lib/components/library/MatchFolderModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Search, X, Clapperboard, Tv, Check, Loader2, Folder, FileVideo } from 'lucide-svelte';
+	import { Search, X, Clapperboard, Tv, Check, Loader2, Folder } from 'lucide-svelte';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
 	import TmdbImage from '$lib/components/tmdb/TmdbImage.svelte';
@@ -213,7 +213,7 @@
 			<div>
 				<p class="mb-2 text-sm font-medium">Files will be matched:</p>
 				<div class="max-h-48 space-y-1 overflow-y-auto rounded-lg bg-base-200 p-2">
-					{#each matchPreview.slice(0, 10) as item}
+					{#each matchPreview.slice(0, 10) as item, index (`${item.file}-${index}`)}
 						<div class="flex items-center justify-between rounded bg-base-300/50 px-2 py-1 text-sm">
 							<span class="flex-1 truncate" title={item.file}>{item.file}</span>
 							{#if item.season !== undefined && item.episode !== undefined}
@@ -293,7 +293,7 @@
 				<p class="mb-2 text-sm text-base-content/70">
 					Click a result to select it and preview the match
 				</p>
-				{#each searchResults as result}
+				{#each searchResults as result (result.id)}
 					<button
 						class="flex w-full items-center gap-3 rounded-lg bg-base-200 p-3 text-left transition-colors hover:bg-base-300"
 						onclick={() => selectMedia(result)}

--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -51,7 +51,11 @@
 	$effect(() => {
 		if (open) {
 			monitored = movie.monitored ?? true;
-			qualityProfileId = movie.scoringProfileId ?? '';
+			const defaultProfileId = qualityProfiles.find((p) => p.isDefault)?.id;
+			qualityProfileId =
+				movie.scoringProfileId && movie.scoringProfileId !== defaultProfileId
+					? movie.scoringProfileId
+					: '';
 			rootFolderId = movie.rootFolderId ?? '';
 			minimumAvailability = movie.minimumAvailability ?? 'released';
 			wantsSubtitles = movie.wantsSubtitles ?? true;
@@ -69,8 +73,12 @@
 		{ value: 'preDb', label: 'PreDB', description: 'Search when movie appears on PreDB' }
 	];
 
-	// Get the current quality profile for description display
-	let currentProfile = $derived(qualityProfiles.find((p) => p.id === qualityProfileId));
+	// Get profile data for labels/description
+	let defaultProfile = $derived(qualityProfiles.find((p) => p.isDefault));
+	let nonDefaultProfiles = $derived(qualityProfiles.filter((p) => p.id !== defaultProfile?.id));
+	let currentProfile = $derived(
+		qualityProfiles.find((p) => p.id === qualityProfileId) ?? defaultProfile
+	);
 
 	function formatBytes(bytes: number | null): string {
 		if (!bytes) return 'Unknown';
@@ -136,14 +144,9 @@
 				bind:value={qualityProfileId}
 				class="select-bordered select w-full"
 			>
-				<option value=""
-					>Default ({qualityProfiles.find((p) => p.isDefault)?.name ?? 'System Default'})</option
-				>
-				{#each qualityProfiles as profile (profile.id)}
-					<option value={profile.id}>
-						{profile.name}
-						{profile.isBuiltIn ? '' : '(Custom)'}
-					</option>
+				<option value="">{defaultProfile?.name ?? 'System Default'} (Default)</option>
+				{#each nonDefaultProfiles as profile (profile.id)}
+					<option value={profile.id}>{profile.name}</option>
 				{/each}
 			</select>
 			<div class="label">

--- a/src/lib/components/library/SeriesEditModal.svelte
+++ b/src/lib/components/library/SeriesEditModal.svelte
@@ -60,15 +60,23 @@
 	$effect(() => {
 		if (open) {
 			monitored = series.monitored ?? true;
-			qualityProfileId = series.scoringProfileId ?? '';
+			const defaultProfileId = qualityProfiles.find((p) => p.isDefault)?.id;
+			qualityProfileId =
+				series.scoringProfileId && series.scoringProfileId !== defaultProfileId
+					? series.scoringProfileId
+					: '';
 			rootFolderId = series.rootFolderId ?? '';
 			seasonFolder = series.seasonFolder ?? true;
 			wantsSubtitles = series.wantsSubtitles ?? true;
 		}
 	});
 
-	// Get the current quality profile for description display
-	let currentProfile = $derived(qualityProfiles.find((p) => p.id === qualityProfileId));
+	// Get profile data for labels/description
+	let defaultProfile = $derived(qualityProfiles.find((p) => p.isDefault));
+	let nonDefaultProfiles = $derived(qualityProfiles.filter((p) => p.id !== defaultProfile?.id));
+	let currentProfile = $derived(
+		qualityProfiles.find((p) => p.id === qualityProfileId) ?? defaultProfile
+	);
 
 	function formatBytes(bytes: number | null): string {
 		if (!bytes) return 'Unknown';
@@ -143,14 +151,9 @@
 				bind:value={qualityProfileId}
 				class="select-bordered select w-full"
 			>
-				<option value=""
-					>Default ({qualityProfiles.find((p) => p.isDefault)?.name ?? 'System Default'})</option
-				>
-				{#each qualityProfiles as profile (profile.id)}
-					<option value={profile.id}>
-						{profile.name}
-						{profile.isBuiltIn ? '' : '(Custom)'}
-					</option>
+				<option value="">{defaultProfile?.name ?? 'System Default'} (Default)</option>
+				{#each nonDefaultProfiles as profile (profile.id)}
+					<option value={profile.id}>{profile.name}</option>
 				{/each}
 			</select>
 			<div class="label">

--- a/src/lib/server/db/schema-sync.ts
+++ b/src/lib/server/db/schema-sync.ts
@@ -72,8 +72,9 @@ interface MigrationDefinition {
  * Version 45: Add smart_lists table for dynamic content lists
  * Version 46: Add activities and activity_details tables for unified activity tracking
  * Version 47: Add task_settings table for per-task configuration with migration from monitoring_settings
+ * Version 48: Dedupe episode_files and enforce unique series/path constraint
  */
-export const CURRENT_SCHEMA_VERSION = 47;
+export const CURRENT_SCHEMA_VERSION = 48;
 
 /**
  * All table definitions with CREATE TABLE IF NOT EXISTS
@@ -1091,6 +1092,7 @@ const INDEX_DEFINITIONS: string[] = [
 	`CREATE INDEX IF NOT EXISTS "idx_indexer_status_health" ON "indexer_status" ("health", "is_disabled")`,
 	`CREATE INDEX IF NOT EXISTS "idx_movies_monitored_hasfile" ON "movies" ("monitored", "has_file")`,
 	`CREATE UNIQUE INDEX IF NOT EXISTS "idx_movie_files_unique_path" ON "movie_files" ("movie_id", "relative_path")`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS "idx_episode_files_unique_path" ON "episode_files" ("series_id", "relative_path")`,
 	`CREATE INDEX IF NOT EXISTS "idx_series_monitored" ON "series" ("monitored")`,
 	`CREATE INDEX IF NOT EXISTS "idx_episodes_series_season" ON "episodes" ("series_id", "season_number")`,
 	`CREATE INDEX IF NOT EXISTS "idx_episodes_monitored_hasfile" ON "episodes" ("monitored", "has_file")`,
@@ -3264,17 +3266,17 @@ const MIGRATIONS: MigrationDefinition[] = [
 			sqlite
 				.prepare(
 					`
-				CREATE TABLE IF NOT EXISTS "task_settings" (
-					"id" text PRIMARY KEY NOT NULL,
-					"enabled" integer DEFAULT 1 NOT NULL,
-					"interval_hours" real,
-					"min_interval_hours" real DEFAULT 0.25 NOT NULL,
-					"last_run_at" text,
-					"next_run_at" text,
-					"created_at" text,
-					"updated_at" text
-				)
-			`
+					CREATE TABLE IF NOT EXISTS "task_settings" (
+						"id" text PRIMARY KEY NOT NULL,
+						"enabled" integer DEFAULT 1 NOT NULL,
+						"interval_hours" real,
+						"min_interval_hours" real DEFAULT 0.25 NOT NULL,
+						"last_run_at" text,
+						"next_run_at" text,
+						"created_at" text,
+						"updated_at" text
+					)
+				`
 				)
 				.run();
 
@@ -3340,14 +3342,225 @@ const MIGRATIONS: MigrationDefinition[] = [
 				sqlite
 					.prepare(
 						`
-					INSERT OR REPLACE INTO task_settings (id, enabled, interval_hours, min_interval_hours, last_run_at, next_run_at, created_at, updated_at)
-					VALUES (?, 1, ?, ?, ?, ?, ?, ?)
-					`
+						INSERT OR REPLACE INTO task_settings (id, enabled, interval_hours, min_interval_hours, last_run_at, next_run_at, created_at, updated_at)
+						VALUES (?, 1, ?, ?, ?, ?, ?, ?)
+						`
 					)
 					.run(taskId, intervalHours, config.minInterval, lastRunAt, nextRunAt, now, now);
 			}
 
 			logger.info('[SchemaSync] Created task_settings table with default settings');
+		}
+	},
+
+	// Migration 48: Dedupe episode_files rows and enforce unique path per series
+	{
+		version: 48,
+		name: 'dedupe_episode_files_and_add_unique_path_index',
+		apply: (sqlite) => {
+			type DuplicateGroupRow = {
+				seriesId: string;
+				relativePath: string;
+			};
+			type EpisodeFileRow = {
+				id: string;
+				episodeIds: string | null;
+			};
+			type JsonIdRow = {
+				id: string;
+				value: string | null;
+			};
+
+			const duplicateGroups = sqlite
+				.prepare(
+					`
+						SELECT
+							series_id AS seriesId,
+							relative_path AS relativePath
+						FROM episode_files
+						GROUP BY series_id, relative_path
+						HAVING COUNT(*) > 1
+					`
+				)
+				.all() as DuplicateGroupRow[];
+
+			if (duplicateGroups.length === 0) {
+				sqlite
+					.prepare(
+						`CREATE UNIQUE INDEX IF NOT EXISTS "idx_episode_files_unique_path" ON "episode_files" ("series_id", "relative_path")`
+					)
+					.run();
+				logger.info('[SchemaSync] episode_files already deduped, ensured unique path index');
+				return;
+			}
+
+			const selectGroupRows = sqlite.prepare(
+				`
+					SELECT
+						id,
+						episode_ids AS episodeIds
+					FROM episode_files
+					WHERE series_id = ? AND relative_path = ?
+					ORDER BY date_added ASC, id ASC
+				`
+			);
+			const updateEpisodeIds = sqlite.prepare(
+				`UPDATE episode_files SET episode_ids = ? WHERE id = ?`
+			);
+			const updateDownloadHistoryIds = sqlite.prepare(
+				`UPDATE download_history SET episode_file_ids = ? WHERE id = ?`
+			);
+			const updateActivityDetailsIds = sqlite.prepare(
+				`UPDATE activity_details SET replaced_episode_file_ids = ? WHERE id = ?`
+			);
+			const deleteEpisodeFile = sqlite.prepare(`DELETE FROM episode_files WHERE id = ?`);
+
+			const idRemap = new Map<string, string>();
+			let duplicateRowsDeleted = 0;
+			let canonicalRowsUpdated = 0;
+
+			for (const group of duplicateGroups) {
+				const rows = selectGroupRows.all(group.seriesId, group.relativePath) as EpisodeFileRow[];
+				if (rows.length < 2) continue;
+
+				const canonical = rows[0];
+				const canonicalEpisodeIds: string[] = [];
+				const seenCanonical = new Set<string>();
+
+				for (const row of rows) {
+					let parsedIds: unknown = [];
+					try {
+						parsedIds = row.episodeIds ? JSON.parse(row.episodeIds) : [];
+					} catch {
+						parsedIds = [];
+					}
+
+					if (Array.isArray(parsedIds)) {
+						for (const value of parsedIds) {
+							if (typeof value !== 'string') continue;
+							if (seenCanonical.has(value)) continue;
+							seenCanonical.add(value);
+							canonicalEpisodeIds.push(value);
+						}
+					}
+				}
+
+				let canonicalChanged = false;
+				try {
+					const existingParsed = canonical.episodeIds ? JSON.parse(canonical.episodeIds) : [];
+					if (!Array.isArray(existingParsed)) {
+						canonicalChanged = true;
+					} else if (existingParsed.length !== canonicalEpisodeIds.length) {
+						canonicalChanged = true;
+					} else {
+						for (let i = 0; i < existingParsed.length; i++) {
+							if (existingParsed[i] !== canonicalEpisodeIds[i]) {
+								canonicalChanged = true;
+								break;
+							}
+						}
+					}
+				} catch {
+					canonicalChanged = true;
+				}
+
+				if (canonicalChanged) {
+					updateEpisodeIds.run(JSON.stringify(canonicalEpisodeIds), canonical.id);
+					canonicalRowsUpdated++;
+				}
+
+				for (const duplicate of rows.slice(1)) {
+					idRemap.set(duplicate.id, canonical.id);
+					deleteEpisodeFile.run(duplicate.id);
+					duplicateRowsDeleted++;
+				}
+			}
+
+			let downloadHistoryRowsUpdated = 0;
+			let activityDetailsRowsUpdated = 0;
+
+			const remapIdArrayJson = (
+				value: string | null
+			): { changed: boolean; json: string | null } => {
+				if (!value) return { changed: false, json: value };
+
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(value);
+				} catch {
+					return { changed: false, json: value };
+				}
+
+				if (!Array.isArray(parsed)) return { changed: false, json: value };
+
+				const remapped: string[] = [];
+				const seen = new Set<string>();
+				let changed = false;
+
+				for (const item of parsed) {
+					if (typeof item !== 'string') continue;
+					const mapped = idRemap.get(item) ?? item;
+					if (mapped !== item) changed = true;
+					if (seen.has(mapped)) {
+						changed = true;
+						continue;
+					}
+					seen.add(mapped);
+					remapped.push(mapped);
+				}
+
+				if (!changed && remapped.length === parsed.length) {
+					for (let i = 0; i < parsed.length; i++) {
+						if (parsed[i] !== remapped[i]) {
+							changed = true;
+							break;
+						}
+					}
+				}
+
+				if (!changed) return { changed: false, json: value };
+				return { changed: true, json: JSON.stringify(remapped) };
+			};
+
+			if (idRemap.size > 0) {
+				const historyRows = sqlite
+					.prepare(
+						`SELECT id, episode_file_ids AS value FROM download_history WHERE episode_file_ids IS NOT NULL`
+					)
+					.all() as JsonIdRow[];
+				for (const row of historyRows) {
+					const remapped = remapIdArrayJson(row.value);
+					if (!remapped.changed || remapped.json === null) continue;
+					updateDownloadHistoryIds.run(remapped.json, row.id);
+					downloadHistoryRowsUpdated++;
+				}
+
+				const activityRows = sqlite
+					.prepare(
+						`SELECT id, replaced_episode_file_ids AS value FROM activity_details WHERE replaced_episode_file_ids IS NOT NULL`
+					)
+					.all() as JsonIdRow[];
+				for (const row of activityRows) {
+					const remapped = remapIdArrayJson(row.value);
+					if (!remapped.changed || remapped.json === null) continue;
+					updateActivityDetailsIds.run(remapped.json, row.id);
+					activityDetailsRowsUpdated++;
+				}
+			}
+
+			sqlite
+				.prepare(
+					`CREATE UNIQUE INDEX IF NOT EXISTS "idx_episode_files_unique_path" ON "episode_files" ("series_id", "relative_path")`
+				)
+				.run();
+
+			logger.info('[SchemaSync] Deduped episode_files and enforced unique path index', {
+				groupsDeduped: duplicateGroups.length,
+				duplicateRowsDeleted,
+				canonicalRowsUpdated,
+				downloadHistoryRowsUpdated,
+				activityDetailsRowsUpdated
+			});
 		}
 	}
 ];

--- a/src/lib/server/library/disk-scan.ts
+++ b/src/lib/server/library/disk-scan.ts
@@ -337,7 +337,12 @@ export class DiskScanService extends EventEmitter {
 					progress.filesAdded++;
 				} else if (existingFile.size !== file.size) {
 					// File changed - update media info
-					await this.updateFileMediaInfo(existingFile.id, file, rootFolder.mediaType);
+					await this.updateFileMediaInfo(
+						existingFile.id,
+						file,
+						rootFolder.mediaType,
+						existingFile.allowStrmProbe
+					);
 					progress.filesUpdated++;
 				}
 
@@ -445,13 +450,18 @@ export class DiskScanService extends EventEmitter {
 	private async getExistingFiles(
 		rootFolderId: string,
 		mediaType: string
-	): Promise<Map<string, { id: string; path: string; size: number | null }>> {
-		const existingMap = new Map<string, { id: string; path: string; size: number | null }>();
+	): Promise<
+		Map<string, { id: string; path: string; size: number | null; allowStrmProbe: boolean }>
+	> {
+		const existingMap = new Map<
+			string,
+			{ id: string; path: string; size: number | null; allowStrmProbe: boolean }
+		>();
 
 		if (mediaType === 'movie') {
 			// Get movie files via movies table
 			const moviesInFolder = await db
-				.select({ id: movies.id, path: movies.path })
+				.select({ id: movies.id, path: movies.path, scoringProfileId: movies.scoringProfileId })
 				.from(movies)
 				.where(eq(movies.rootFolderId, rootFolderId));
 
@@ -478,7 +488,12 @@ export class DiskScanService extends EventEmitter {
 						const movie = moviesInFolder.find((m) => m.id === file.movieId);
 						if (movie) {
 							const fullPath = join(folder.path, movie.path, file.relativePath);
-							existingMap.set(fullPath, { id: file.id, path: fullPath, size: file.size });
+							existingMap.set(fullPath, {
+								id: file.id,
+								path: fullPath,
+								size: file.size,
+								allowStrmProbe: movie.scoringProfileId !== 'streamer'
+							});
 						}
 					}
 				}
@@ -486,7 +501,7 @@ export class DiskScanService extends EventEmitter {
 		} else {
 			// Get episode files via series table
 			const seriesInFolder = await db
-				.select({ id: series.id, path: series.path })
+				.select({ id: series.id, path: series.path, scoringProfileId: series.scoringProfileId })
 				.from(series)
 				.where(eq(series.rootFolderId, rootFolderId));
 
@@ -512,7 +527,12 @@ export class DiskScanService extends EventEmitter {
 						const seriesItem = seriesInFolder.find((s) => s.id === file.seriesId);
 						if (seriesItem) {
 							const fullPath = join(folder.path, seriesItem.path, file.relativePath);
-							existingMap.set(fullPath, { id: file.id, path: fullPath, size: file.size });
+							existingMap.set(fullPath, {
+								id: file.id,
+								path: fullPath,
+								size: file.size,
+								allowStrmProbe: seriesItem.scoringProfileId !== 'streamer'
+							});
 						}
 					}
 				}
@@ -526,7 +546,12 @@ export class DiskScanService extends EventEmitter {
 			.where(eq(unmatchedFiles.rootFolderId, rootFolderId));
 
 		for (const file of unmatched) {
-			existingMap.set(file.path, { id: file.id, path: file.path, size: file.size });
+			existingMap.set(file.path, {
+				id: file.id,
+				path: file.path,
+				size: file.size,
+				allowStrmProbe: true
+			});
 		}
 
 		return existingMap;
@@ -720,10 +745,11 @@ export class DiskScanService extends EventEmitter {
 	private async updateFileMediaInfo(
 		fileId: string,
 		file: DiscoveredFile,
-		mediaType: string
+		mediaType: string,
+		allowStrmProbe = true
 	): Promise<void> {
 		// Extract fresh media info
-		const mediaInfo = await mediaInfoService.extractMediaInfo(file.path);
+		const mediaInfo = await mediaInfoService.extractMediaInfo(file.path, { allowStrmProbe });
 
 		if (mediaType === 'movie') {
 			await db

--- a/src/lib/server/library/ffprobe.ts
+++ b/src/lib/server/library/ffprobe.ts
@@ -327,7 +327,15 @@ export async function runFFprobe(
 			if (code !== 0) {
 				const isRemote = /^https?:\/\//i.test(filePath);
 				if (isRemote) {
-					logger.debug('[FFprobe] Exited with non-zero code', { code, stderr });
+					const stderrText = stderr.trim();
+					// STRM URL probes often fail and fall back to placeholder media info.
+					// Silence expected remote failures unless ffprobe emitted useful diagnostics.
+					if (stderrText) {
+						logger.debug('[FFprobe] Remote probe exited with non-zero code', {
+							code,
+							stderr: stderrText
+						});
+					}
 				} else {
 					logger.error('[FFprobe] Exited with non-zero code', undefined, { code, stderr });
 				}

--- a/src/lib/server/monitoring/search/MonitoringSearchService.ts
+++ b/src/lib/server/monitoring/search/MonitoringSearchService.ts
@@ -65,6 +65,39 @@ import {
 
 const parser = new ReleaseParser();
 
+type EpisodeFileUpsertInput = Omit<typeof episodeFiles.$inferInsert, 'id'> & { id?: string };
+type EpisodeFileWriteExecutor = Pick<typeof db, 'select' | 'update' | 'insert'>;
+
+/**
+ * Upsert episode file by (seriesId, relativePath) and return canonical row id.
+ */
+async function upsertEpisodeFileByPath(
+	executor: EpisodeFileWriteExecutor,
+	record: EpisodeFileUpsertInput
+): Promise<string> {
+	const { id: requestedId, ...values } = record;
+
+	const existing = await executor
+		.select({ id: episodeFiles.id })
+		.from(episodeFiles)
+		.where(
+			and(
+				eq(episodeFiles.seriesId, record.seriesId),
+				eq(episodeFiles.relativePath, record.relativePath)
+			)
+		)
+		.limit(1);
+
+	if (existing.length > 0) {
+		await executor.update(episodeFiles).set(values).where(eq(episodeFiles.id, existing[0].id));
+		return existing[0].id;
+	}
+
+	const id = requestedId ?? randomUUID();
+	await executor.insert(episodeFiles).values({ id, ...values });
+	return id;
+}
+
 /**
  * Search result for individual item
  */
@@ -2825,10 +2858,8 @@ export class MonitoringSearchService {
 					}
 				}
 
-				// Create episode file record
-				const fileId = randomUUID();
-				await db.insert(episodeFiles).values({
-					id: fileId,
+				// Create/update episode file record
+				const fileId = await upsertEpisodeFileByPath(db, {
 					seriesId,
 					seasonNumber: parsed.season,
 					episodeIds: [episodeRow.id],
@@ -3052,10 +3083,8 @@ export class MonitoringSearchService {
 						}
 					}
 
-					// Create episode file record
-					const fileId = randomUUID();
-					await tx.insert(episodeFiles).values({
-						id: fileId,
+					// Create/update episode file record
+					const fileId = await upsertEpisodeFileByPath(tx, {
 						seriesId,
 						seasonNumber,
 						episodeIds: [epData.episodeId],

--- a/src/routes/library/movies/+page.server.ts
+++ b/src/routes/library/movies/+page.server.ts
@@ -1,5 +1,11 @@
 import { db } from '$lib/server/db/index.js';
-import { movies, movieFiles, rootFolders, scoringProfiles } from '$lib/server/db/schema.js';
+import {
+	movies,
+	movieFiles,
+	rootFolders,
+	scoringProfiles,
+	profileSizeLimits
+} from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 import type { LibraryMovie, MovieFile } from '$lib/types/library';
@@ -173,9 +179,19 @@ export const load: PageServerLoad = async ({ url }) => {
 			})
 			.from(scoringProfiles);
 
+		const defaultBuiltInOverride = await db
+			.select({ profileId: profileSizeLimits.profileId })
+			.from(profileSizeLimits)
+			.where(eq(profileSizeLimits.isDefault, true))
+			.limit(1);
+
 		const BUILT_IN_IDS = DEFAULT_PROFILES.map((p) => p.id);
 		const dbIds = new Set(dbProfiles.map((p) => p.id));
-		const hasDbDefault = dbProfiles.some((p) => Boolean(p.isDefault));
+		const customDefaultId = dbProfiles.find(
+			(p) => !BUILT_IN_IDS.includes(p.id) && Boolean(p.isDefault)
+		)?.id;
+		const builtInDefaultId = defaultBuiltInOverride[0]?.profileId;
+		const resolvedDefaultId = customDefaultId ?? builtInDefaultId ?? 'balanced';
 
 		const qualityProfiles: QualityProfileSummary[] = [
 			...DEFAULT_PROFILES.filter((p) => !dbIds.has(p.id)).map((p) => ({
@@ -183,14 +199,14 @@ export const load: PageServerLoad = async ({ url }) => {
 				name: p.name,
 				description: p.description,
 				isBuiltIn: true,
-				isDefault: !hasDbDefault && p.id === 'efficient'
+				isDefault: p.id === resolvedDefaultId
 			})),
 			...dbProfiles.map((p) => ({
 				id: p.id,
 				name: p.name,
 				description: p.description ?? '',
 				isBuiltIn: BUILT_IN_IDS.includes(p.id),
-				isDefault: Boolean(p.isDefault)
+				isDefault: p.id === resolvedDefaultId
 			}))
 		];
 

--- a/src/routes/library/tv/[id]/+page.server.ts
+++ b/src/routes/library/tv/[id]/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	episodeFiles,
 	rootFolders,
 	scoringProfiles,
+	profileSizeLimits,
 	downloadQueue,
 	subtitles
 } from '$lib/server/db/schema.js';
@@ -302,10 +303,20 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 		})
 		.from(scoringProfiles);
 
+	const defaultBuiltInOverride = await db
+		.select({ profileId: profileSizeLimits.profileId })
+		.from(profileSizeLimits)
+		.where(eq(profileSizeLimits.isDefault, true))
+		.limit(1);
+
 	// Built-in profile IDs - derived from DEFAULT_PROFILES
 	const BUILT_IN_IDS = DEFAULT_PROFILES.map((p) => p.id);
 	const dbIds = new Set(dbProfiles.map((p) => p.id));
-	const hasDbDefault = dbProfiles.some((p) => Boolean(p.isDefault));
+	const customDefaultId = dbProfiles.find(
+		(p) => !BUILT_IN_IDS.includes(p.id) && Boolean(p.isDefault)
+	)?.id;
+	const builtInDefaultId = defaultBuiltInOverride[0]?.profileId;
+	const resolvedDefaultId = customDefaultId ?? builtInDefaultId ?? 'balanced';
 
 	// Merge built-in profiles with database profiles (avoiding duplicates)
 	const allQualityProfiles: QualityProfileSummary[] = [
@@ -315,8 +326,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 			name: p.name,
 			description: p.description,
 			isBuiltIn: true,
-			// Efficient is default only if no DB default is set
-			isDefault: !hasDbDefault && p.id === 'efficient'
+			isDefault: p.id === resolvedDefaultId
 		})),
 		// Database profiles (correctly mark built-ins stored in DB)
 		...dbProfiles.map((p) => ({
@@ -324,7 +334,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 			name: p.name,
 			description: p.description ?? '',
 			isBuiltIn: BUILT_IN_IDS.includes(p.id),
-			isDefault: Boolean(p.isDefault)
+			isDefault: p.id === resolvedDefaultId
 		}))
 	];
 

--- a/src/routes/library/unmatched/+page.svelte
+++ b/src/routes/library/unmatched/+page.svelte
@@ -615,7 +615,7 @@
 											<span class="badge badge-outline badge-sm">
 												{folder.mediaType === 'movie' ? 'Movie' : 'TV'}
 											</span>
-											{#each folder.reasons as reason}
+											{#each folder.reasons as reason, index (`${reason}-${index}`)}
 												<span class="badge badge-sm badge-warning">{reason}</span>
 											{/each}
 										</div>
@@ -649,7 +649,7 @@
 								<div class="mt-4 border-t border-base-300 pt-4">
 									<p class="mb-2 text-xs font-medium text-base-content/60">Files in this folder:</p>
 									<div class="space-y-1">
-										{#each folder.files as file}
+										{#each folder.files as file (file.path)}
 											<div
 												class="flex items-center justify-between rounded bg-base-300/50 px-3 py-2 text-sm"
 											>


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

This pull request introduces improvements to quality profile selection and database integrity, along with enhancements to file handling logic. The changes streamline how default and custom quality profiles are displayed and selected, enforce uniqueness for episode files in the database, and update file scanning logic to better handle streamer-specific files.

**Quality profile selection improvements:**

* Quality profile dropdowns in `BulkQualityProfileModal.svelte`, `MovieEditModal.svelte`, and `SeriesEditModal.svelte` now separate default and custom profiles, display the default profile more clearly, and ensure the default is used when no custom profile is selected. [[1]](diffhunk://#diff-b15cc12a800b53bd70f447ec713bf06abf414da3062225f208053b919a88bbf4L35-R39) [[2]](diffhunk://#diff-b15cc12a800b53bd70f447ec713bf06abf414da3062225f208053b919a88bbf4L84-R90) [[3]](diffhunk://#diff-85cc64d603f2752d526d4d902788d607a717c7431dbfed9ffe941570718d62c0L54-R58) [[4]](diffhunk://#diff-85cc64d603f2752d526d4d902788d607a717c7431dbfed9ffe941570718d62c0L72-R81) [[5]](diffhunk://#diff-85cc64d603f2752d526d4d902788d607a717c7431dbfed9ffe941570718d62c0L139-R149) [[6]](diffhunk://#diff-55c70a7f685939d1fe03e85f5375085db7364d75bf14c22fb119f2f618d645b7L63-R79) [[7]](diffhunk://#diff-55c70a7f685939d1fe03e85f5375085db7364d75bf14c22fb119f2f618d645b7L146-R156)

**Database integrity and migration:**

* Added schema migration (version 48) to deduplicate `episode_files` by enforcing a unique constraint on `(series_id, relative_path)`, updating related references in `download_history` and `activity_details`, and ensuring only canonical episode file records remain. [[1]](diffhunk://#diff-8fde3478fcd77fe167bebb6a3a59b1d318d7b00c9f0c29a5150c3bf470d603a2R75-R77) [[2]](diffhunk://#diff-8fde3478fcd77fe167bebb6a3a59b1d318d7b00c9f0c29a5150c3bf470d603a2R1095) [[3]](diffhunk://#diff-8fde3478fcd77fe167bebb6a3a59b1d318d7b00c9f0c29a5150c3bf470d603a2R3354-R3564)
* Introduced a new `upsertEpisodeFileByPath` function in `ReleaseGrabService.ts` to create or update episode file records by path, ensuring uniqueness and preventing duplicates. [[1]](diffhunk://#diff-a081ff19f07a2f547f2c705447f269074dd5ac921db018760413a0cc6212d037R52-R84) [[2]](diffhunk://#diff-a081ff19f07a2f547f2c705447f269074dd5ac921db018760413a0cc6212d037L1096-R1130) [[3]](diffhunk://#diff-a081ff19f07a2f547f2c705447f269074dd5ac921db018760413a0cc6212d037L1353-R1385)

**File scanning and handling enhancements:**

* Updated `DiskScanService` to track the `allowStrmProbe` property for files, using the scoring profile to determine if probing is allowed for streamer files, and passing this property when updating file media info. [[1]](diffhunk://#diff-49fffb179fe7a9871e898866b54c014b96f90ca289ff83d914e224fc6dc585d5L340-R345) [[2]](diffhunk://#diff-49fffb179fe7a9871e898866b54c014b96f90ca289ff83d914e224fc6dc585d5L448-R464) [[3]](diffhunk://#diff-49fffb179fe7a9871e898866b54c014b96f90ca289ff83d914e224fc6dc585d5L481-R504) [[4]](diffhunk://#diff-49fffb179fe7a9871e898866b54c014b96f90ca289ff83d914e224fc6dc585d5L515-R535) [[5]](diffhunk://#diff-49fffb179fe7a9871e898866b54c014b96f90ca289ff83d914e224fc6dc585d5L529-R554)

**UI list rendering optimizations:**

* Improved Svelte component list rendering by adding explicit keys to `each` blocks for better performance and stability. [[1]](diffhunk://#diff-4933fa633991752a9550d1ed21da76f660bc60deba921355b0f36f35125d3368L216-R216) [[2]](diffhunk://#diff-4933fa633991752a9550d1ed21da76f660bc60deba921355b0f36f35125d3368L296-R296)

**Minor UI cleanup:**

* Removed unused icon import (`FileVideo`) from `MatchFolderModal.svelte`.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

#112 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Added schema migration v48 to dedupe episode_files by (series_id, relative_path).
- Remapped duplicated IDs in download_history.episode_file_ids and activity_details.replaced_episode_file_ids.
- Added upsertEpisodeFileByPath function to handle creation and updating of episode files based on seriesId and relativePath.
- Refactored various services and API endpoints to utilize the new upsert functionality, ensuring that episode files are correctly created or updated without duplication.
- Enhanced media info extraction to respect scoring profiles, particularly for streamer profiles, preventing unnecessary probing of STRM files.
- Updated logging and error handling for media info extraction processes.
- Improved performance by batching updates for media info and handling duplicates in the STRM reprobe process.
- Updated STRM reprobe to skip streamer-profile items and collapse duplicate DB rows by distinct full path

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
