### PR TITLE
feat(unmatched): restore root-folder assignment UI for library items

### DIFF
--- a/src/lib/components/tasks/TaskTableRow.svelte
+++ b/src/lib/components/tasks/TaskTableRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { History } from 'lucide-svelte';
 	import type { UnifiedTask } from '$lib/server/tasks/UnifiedTaskRegistry';
 	import type { TaskHistoryEntry } from '$lib/types/task';
 	import TaskIntervalCell from './TaskIntervalCell.svelte';
@@ -138,9 +139,9 @@
 					Running
 				</span>
 			{:else if lastRunStatus === 'completed'}
-				<span class="badge badge-sm badge-success"></span>
+				<span class="badge badge-sm badge-success">OK</span>
 			{:else if lastRunStatus === 'failed'}
-				<span class="badge badge-sm badge-error"></span>
+				<span class="badge badge-sm badge-error">Failed</span>
 			{/if}
 		</div>
 	</td>
@@ -254,20 +255,7 @@
 			{/if}
 
 			<button class="btn btn-square btn-ghost btn-xs" onclick={onShowHistory} title="View History">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="16"
-					height="16"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<polyline points="9 11 12 14 22 4" />
-					<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-				</svg>
+				<History class="h-4 w-4" />
 			</button>
 		</div>
 	</td>

--- a/src/lib/components/unmatched/UnmatchedLibraryIssues.svelte
+++ b/src/lib/components/unmatched/UnmatchedLibraryIssues.svelte
@@ -1,0 +1,432 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
+	import {
+		AlertCircle,
+		AlertTriangle,
+		ChevronDown,
+		ChevronRight,
+		Link,
+		Loader2
+	} from 'lucide-svelte';
+	import { toasts } from '$lib/stores/toast.svelte';
+	import type { LibraryIssue, RootFolderOption } from '$lib/types/unmatched.js';
+
+	interface Props {
+		unmatchedFileCount?: number;
+	}
+
+	let { unmatchedFileCount = 0 }: Props = $props();
+
+	let libraryItems = $state<LibraryIssue[]>([]);
+	let rootFolders = $state<RootFolderOption[]>([]);
+	let loading = $state(false);
+	let libraryIssuesOpen = $state(false);
+	let libraryIssuesFilter = $state<'movie' | 'tv'>('movie');
+	let selectedIssues = $state<string[]>([]);
+	let selectedRootFolders = $state<Record<string, string>>({});
+	let bulkMovieRootFolder = $state('');
+	let bulkTvRootFolder = $state('');
+	let bulkSavingMovie = $state(false);
+	let bulkSavingTv = $state(false);
+	const savingIssues = new SvelteMap<string, boolean>();
+
+	const movieIssueCount = $derived(
+		libraryItems.filter((item) => item.mediaType === 'movie').length
+	);
+	const tvIssueCount = $derived(libraryItems.filter((item) => item.mediaType === 'tv').length);
+	const selectedCount = $derived(selectedIssues.length);
+	const movieFolders = $derived(rootFolders.filter((folder) => folder.mediaType === 'movie'));
+	const tvFolders = $derived(rootFolders.filter((folder) => folder.mediaType === 'tv'));
+	const filteredLibraryItems = $derived(
+		libraryItems.filter((item) => item.mediaType === libraryIssuesFilter)
+	);
+
+	onMount(() => {
+		void loadIssues();
+	});
+
+	$effect(() => {
+		if (movieIssueCount > 0 && tvIssueCount === 0 && libraryIssuesFilter !== 'movie') {
+			libraryIssuesFilter = 'movie';
+		} else if (tvIssueCount > 0 && movieIssueCount === 0 && libraryIssuesFilter !== 'tv') {
+			libraryIssuesFilter = 'tv';
+		}
+	});
+
+	$effect(() => {
+		// Keep the issues panel collapsed whenever unmatched files exist.
+		if (unmatchedFileCount > 0) {
+			libraryIssuesOpen = false;
+		}
+	});
+
+	function getSelectedRootFolder(itemId: string): string {
+		return selectedRootFolders[itemId] ?? '';
+	}
+
+	function setSelectedRootFolder(itemId: string, rootFolderId: string): void {
+		selectedRootFolders = { ...selectedRootFolders, [itemId]: rootFolderId };
+	}
+
+	function clearSelectedRootFolder(itemId: string): void {
+		if (!(itemId in selectedRootFolders)) return;
+		const { [itemId]: _removed, ...rest } = selectedRootFolders;
+		selectedRootFolders = rest;
+	}
+
+	function clearSelectionsForIds(ids: string[]): void {
+		selectedIssues = selectedIssues.filter((id) => !ids.includes(id));
+		for (const id of ids) {
+			clearSelectedRootFolder(id);
+		}
+	}
+
+	async function loadIssues(): Promise<void> {
+		loading = true;
+		try {
+			const response = await fetch('/api/library/unmatched/issues');
+			const result = await response.json();
+
+			if (response.ok && result.success) {
+				libraryItems = result.data.libraryItems ?? [];
+				rootFolders = result.data.rootFolders ?? [];
+				if ((result.data.total ?? 0) > 0) {
+					libraryIssuesOpen = unmatchedFileCount === 0;
+				}
+			} else {
+				toasts.error('Failed to load library issues', {
+					description: result.error || 'Please try again'
+				});
+			}
+		} catch {
+			toasts.error('Failed to load library issues');
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function assignRootFolder(item: LibraryIssue, rootFolderId: string): Promise<boolean> {
+		const endpoint =
+			item.mediaType === 'movie'
+				? `/api/library/movies/${item.id}`
+				: `/api/library/series/${item.id}`;
+		const response = await fetch(endpoint, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ rootFolderId })
+		});
+		const result = await response.json();
+		return response.ok && result.success !== false;
+	}
+
+	async function updateRootFolder(item: LibraryIssue): Promise<void> {
+		const rootFolderId = getSelectedRootFolder(item.id);
+		if (!rootFolderId) {
+			toasts.info('Select a root folder first');
+			return;
+		}
+
+		savingIssues.set(item.id, true);
+		try {
+			const success = await assignRootFolder(item, rootFolderId);
+			if (success) {
+				libraryItems = libraryItems.filter((libraryItem) => libraryItem.id !== item.id);
+				clearSelectionsForIds([item.id]);
+				toasts.success('Root folder updated');
+			} else {
+				toasts.error('Failed to update root folder');
+			}
+		} catch {
+			toasts.error('Failed to update root folder');
+		} finally {
+			savingIssues.delete(item.id);
+		}
+	}
+
+	function toggleIssueSelection(itemId: string): void {
+		if (selectedIssues.includes(itemId)) {
+			selectedIssues = selectedIssues.filter((id) => id !== itemId);
+			return;
+		}
+		selectedIssues = [...selectedIssues, itemId];
+	}
+
+	function selectAllIssues(mediaType: 'movie' | 'tv'): void {
+		selectedIssues = libraryItems
+			.filter((item) => item.mediaType === mediaType)
+			.map((item) => item.id);
+	}
+
+	function clearIssueSelection(): void {
+		selectedIssues = [];
+	}
+
+	async function bulkAssignRootFolder(mediaType: 'movie' | 'tv'): Promise<void> {
+		const rootFolderId = mediaType === 'movie' ? bulkMovieRootFolder : bulkTvRootFolder;
+		if (!rootFolderId) {
+			toasts.info('Select a root folder first');
+			return;
+		}
+
+		const selectedItems = libraryItems.filter(
+			(item) => item.mediaType === mediaType && selectedIssues.includes(item.id)
+		);
+		if (selectedItems.length === 0) {
+			toasts.info('Select items to apply the bulk action');
+			return;
+		}
+
+		if (mediaType === 'movie') {
+			bulkSavingMovie = true;
+		} else {
+			bulkSavingTv = true;
+		}
+		for (const item of selectedItems) {
+			savingIssues.set(item.id, true);
+		}
+
+		try {
+			const results = await Promise.all(
+				selectedItems.map(async (item) => {
+					try {
+						return await assignRootFolder(item, rootFolderId);
+					} catch {
+						return false;
+					}
+				})
+			);
+
+			const successIds = selectedItems.filter((_, index) => results[index]).map((item) => item.id);
+			const failedCount = selectedItems.length - successIds.length;
+
+			if (successIds.length > 0) {
+				libraryItems = libraryItems.filter((item) => !successIds.includes(item.id));
+				clearSelectionsForIds(successIds);
+			}
+
+			if (failedCount === 0) {
+				toasts.success('Root folder updated for selected items');
+			} else if (successIds.length > 0) {
+				toasts.warning('Some root folder updates failed');
+			} else {
+				toasts.error('Failed to update root folder for selected items');
+			}
+		} finally {
+			for (const item of selectedItems) {
+				savingIssues.delete(item.id);
+			}
+			if (mediaType === 'movie') {
+				bulkSavingMovie = false;
+			} else {
+				bulkSavingTv = false;
+			}
+		}
+	}
+</script>
+
+{#if loading}
+	<div class="card bg-base-200">
+		<div class="card-body items-center py-6">
+			<span class="loading loading-md loading-spinner"></span>
+			<p class="text-sm text-base-content/70">Loading library issues...</p>
+		</div>
+	</div>
+{:else if libraryItems.length > 0}
+	<div class="card bg-base-200">
+		<button
+			class="card-body flex-row items-center justify-between gap-3 p-4 text-left"
+			onclick={() => (libraryIssuesOpen = !libraryIssuesOpen)}
+		>
+			<div class="flex items-center gap-2">
+				<AlertCircle class="h-5 w-5 text-warning" />
+				<div>
+					<div class="font-semibold">Library Issues</div>
+					<div class="text-xs text-base-content/60">
+						Missing root folder on {libraryItems.length} item{libraryItems.length !== 1 ? 's' : ''}
+					</div>
+				</div>
+			</div>
+			{#if libraryIssuesOpen}
+				<ChevronDown class="h-4 w-4 text-base-content/60" />
+			{:else}
+				<ChevronRight class="h-4 w-4 text-base-content/60" />
+			{/if}
+		</button>
+
+		{#if libraryIssuesOpen}
+			<div class="border-t border-base-300 px-4 pb-4">
+				<p class="pt-3 text-xs text-base-content/60">
+					These library items have no root folder set. Select a root folder to fix them.
+				</p>
+
+				<div class="mt-3 flex flex-wrap gap-2">
+					<button
+						class="btn btn-xs {libraryIssuesFilter === 'movie' ? 'btn-primary' : 'btn-ghost'}"
+						onclick={() => (libraryIssuesFilter = 'movie')}
+						disabled={movieIssueCount === 0}
+					>
+						Movies ({movieIssueCount})
+					</button>
+					<button
+						class="btn btn-xs {libraryIssuesFilter === 'tv' ? 'btn-primary' : 'btn-ghost'}"
+						onclick={() => (libraryIssuesFilter = 'tv')}
+						disabled={tvIssueCount === 0}
+					>
+						TV Shows ({tvIssueCount})
+					</button>
+				</div>
+
+				<div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center">
+					<div class="flex flex-wrap items-center gap-2 text-xs text-base-content/60">
+						<span>{selectedCount} selected</span>
+						{#if libraryIssuesFilter === 'movie'}
+							<button class="btn btn-ghost btn-xs" onclick={() => selectAllIssues('movie')}>
+								Select all Movies
+							</button>
+						{:else}
+							<button class="btn btn-ghost btn-xs" onclick={() => selectAllIssues('tv')}>
+								Select all TV shows
+							</button>
+						{/if}
+						<button class="btn btn-ghost btn-xs" onclick={clearIssueSelection}>Clear</button>
+					</div>
+
+					{#if libraryIssuesFilter === 'movie'}
+						<div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+							{#if movieFolders.length > 0}
+								<select
+									class="select-bordered select w-full select-sm sm:w-72"
+									bind:value={bulkMovieRootFolder}
+									disabled={bulkSavingMovie}
+								>
+									<option value="">Select root folder</option>
+									{#each movieFolders as folder (folder.id)}
+										<option value={folder.id}>{folder.name} - {folder.path}</option>
+									{/each}
+								</select>
+								<button
+									class="btn btn-outline btn-xs"
+									disabled={!bulkMovieRootFolder || bulkSavingMovie || selectedCount === 0}
+									onclick={() => bulkAssignRootFolder('movie')}
+								>
+									{#if bulkSavingMovie}
+										<Loader2 class="h-3.5 w-3.5 animate-spin" />
+									{/if}
+									Apply to selected
+								</button>
+							{:else}
+								<span class="text-xs text-warning">
+									No Movie root folders configured.
+									<a class="ml-1 link" href="/settings/general">Add a root folder</a>
+								</span>
+							{/if}
+						</div>
+					{:else}
+						<div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+							{#if tvFolders.length > 0}
+								<select
+									class="select-bordered select w-full select-sm sm:w-72"
+									bind:value={bulkTvRootFolder}
+									disabled={bulkSavingTv}
+								>
+									<option value="">Select root folder</option>
+									{#each tvFolders as folder (folder.id)}
+										<option value={folder.id}>{folder.name} - {folder.path}</option>
+									{/each}
+								</select>
+								<button
+									class="btn btn-outline btn-xs"
+									disabled={!bulkTvRootFolder || bulkSavingTv || selectedCount === 0}
+									onclick={() => bulkAssignRootFolder('tv')}
+								>
+									{#if bulkSavingTv}
+										<Loader2 class="h-3.5 w-3.5 animate-spin" />
+									{/if}
+									Apply to selected
+								</button>
+							{:else}
+								<span class="text-xs text-warning">
+									No TV root folders configured.
+									<a class="ml-1 link" href="/settings/general">Add a root folder</a>
+								</span>
+							{/if}
+						</div>
+					{/if}
+				</div>
+
+				<div class="mt-4 space-y-2">
+					{#each filteredLibraryItems as item (item.id)}
+						<div class="rounded-lg bg-base-100 p-3">
+							<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+								<div class="flex min-w-0 items-center gap-3">
+									<input
+										type="checkbox"
+										class="checkbox checkbox-sm"
+										checked={selectedIssues.includes(item.id)}
+										onchange={() => toggleIssueSelection(item.id)}
+									/>
+									<div
+										class="badge badge-sm {item.mediaType === 'movie'
+											? 'badge-primary'
+											: 'badge-secondary'}"
+									>
+										{item.mediaType === 'movie' ? 'M' : 'TV'}
+									</div>
+									<div class="min-w-0">
+										<div class="truncate font-medium">
+											{item.title}
+											{#if item.year}
+												<span class="text-base-content/70">({item.year})</span>
+											{/if}
+										</div>
+										<div class="mt-0.5 flex items-center gap-1 text-xs text-warning">
+											<AlertTriangle class="h-3.5 w-3.5" />
+											Root folder not set
+										</div>
+									</div>
+								</div>
+
+								<div class="flex w-full items-center gap-2 sm:w-auto">
+									<select
+										class="select-bordered select w-full select-sm sm:w-72"
+										value={getSelectedRootFolder(item.id)}
+										disabled={savingIssues.get(item.id)}
+										onchange={(event) =>
+											setSelectedRootFolder(
+												item.id,
+												(event.currentTarget as HTMLSelectElement).value
+											)}
+									>
+										<option value="">Select root folder</option>
+										{#if item.mediaType === 'movie'}
+											{#each movieFolders as folder (folder.id)}
+												<option value={folder.id}>{folder.name} - {folder.path}</option>
+											{/each}
+										{:else}
+											{#each tvFolders as folder (folder.id)}
+												<option value={folder.id}>{folder.name} - {folder.path}</option>
+											{/each}
+										{/if}
+									</select>
+									<button
+										class="btn btn-ghost btn-sm"
+										title="Apply root folder"
+										disabled={!getSelectedRootFolder(item.id) || savingIssues.get(item.id)}
+										onclick={() => updateRootFolder(item)}
+									>
+										{#if savingIssues.get(item.id)}
+											<Loader2 class="h-4 w-4 animate-spin" />
+										{:else}
+											<Link class="h-4 w-4" />
+										{/if}
+									</button>
+								</div>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/components/unmatched/index.ts
+++ b/src/lib/components/unmatched/index.ts
@@ -4,3 +4,4 @@ export { default as UnmatchedFilters } from './UnmatchedFilters.svelte';
 export { default as UnmatchedBulkActions } from './UnmatchedBulkActions.svelte';
 export { default as UnmatchedEmptyState } from './UnmatchedEmptyState.svelte';
 export { default as UnmatchedPagination } from './UnmatchedPagination.svelte';
+export { default as UnmatchedLibraryIssues } from './UnmatchedLibraryIssues.svelte';

--- a/src/lib/types/unmatched.ts
+++ b/src/lib/types/unmatched.ts
@@ -109,6 +109,13 @@ export interface LibraryIssue {
 	issue: 'missing_root_folder' | 'invalid_root_folder';
 }
 
+export interface RootFolderOption {
+	id: string;
+	name: string;
+	path: string;
+	mediaType: 'movie' | 'tv';
+}
+
 export interface UnmatchedState {
 	files: UnmatchedFile[];
 	folders: UnmatchedFolder[];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,6 @@
 		Tv,
 		Download,
 		AlertCircle,
-		AlertTriangle,
 		Clock,
 		CheckCircle,
 		XCircle,
@@ -170,7 +169,7 @@
 			<p class="text-base-content/70">Welcome to Cinephage</p>
 		</div>
 		<div class="flex items-center gap-2">
-			<div class="hidden items-center gap-2 sm:flex">
+			<div class="hidden items-center gap-2 lg:flex">
 				{#if sse.isConnected}
 					<span class="badge gap-1 badge-success">
 						<Wifi class="h-3 w-3" />
@@ -290,22 +289,17 @@
 		{#if stats.unmatchedFiles > 0}
 			<a
 				href={resolve('/library/unmatched')}
-				class="card bg-base-200 transition-colors hover:bg-base-300"
+				class="card overflow-hidden bg-base-200 transition-colors hover:bg-base-300"
 			>
 				<div class="card-body p-4">
-					<div class="flex items-center gap-3">
-						<div class="rounded-lg bg-error/10 p-2">
+					<div class="flex min-w-0 items-center gap-3">
+						<div class="shrink-0 rounded-lg bg-error/10 p-2">
 							<FileQuestion class="h-6 w-6 text-error" />
 						</div>
-						<div>
+						<div class="min-w-0">
 							<div class="text-2xl font-bold">{stats.unmatchedFiles}</div>
 							<div class="text-sm text-base-content/70">Unmatched</div>
 						</div>
-						{#if stats.missingRootFolders > 0}
-							<div class="ml-auto rounded-full bg-warning/10 p-1">
-								<AlertTriangle class="h-4 w-4 text-warning" />
-							</div>
-						{/if}
 					</div>
 					<div class="mt-2 text-xs text-base-content/50">Files need attention</div>
 					{#if stats.missingRootFolders > 0}
@@ -318,19 +312,16 @@
 		{:else if stats.missingRootFolders > 0}
 			<a
 				href={resolve('/library/unmatched')}
-				class="card bg-base-200 transition-colors hover:bg-base-300"
+				class="card overflow-hidden bg-base-200 transition-colors hover:bg-base-300"
 			>
 				<div class="card-body p-4">
-					<div class="flex items-center gap-3">
-						<div class="rounded-lg bg-warning/10 p-2">
+					<div class="flex min-w-0 items-center gap-3">
+						<div class="shrink-0 rounded-lg bg-warning/10 p-2">
 							<AlertCircle class="h-6 w-6 text-warning" />
 						</div>
-						<div>
+						<div class="min-w-0">
 							<div class="text-2xl font-bold">0</div>
 							<div class="text-sm text-base-content/70">Unmatched</div>
-						</div>
-						<div class="ml-auto rounded-full bg-warning/10 p-1">
-							<AlertTriangle class="h-4 w-4 text-warning" />
 						</div>
 					</div>
 					<div class="mt-2 text-xs">

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -445,7 +445,7 @@
 			<p class="text-base-content/70">Download and search history</p>
 		</div>
 		<!-- Connection Status -->
-		<div class="hidden sm:block">
+		<div class="hidden lg:block">
 			{#if sse.isConnected}
 				<span class="badge gap-1 badge-success">
 					<Wifi class="h-3 w-3" />

--- a/src/routes/api/library/movies/[id]/stream/+server.ts
+++ b/src/routes/api/library/movies/[id]/stream/+server.ts
@@ -3,7 +3,7 @@ import { downloadMonitor } from '$lib/server/downloadClients/monitoring';
 import { importService } from '$lib/server/downloadClients/import';
 import { db } from '$lib/server/db';
 import { movies, movieFiles, rootFolders, downloadQueue, subtitles } from '$lib/server/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { LibraryMovie, MovieFile } from '$lib/types/library';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
@@ -120,7 +120,7 @@ async function getQueueItem(movieId: string): Promise<QueueItem | null> {
 			progress: downloadQueue.progress
 		})
 		.from(downloadQueue)
-		.where(eq(downloadQueue.movieId, movieId));
+		.where(and(eq(downloadQueue.movieId, movieId), eq(downloadQueue.status, 'downloading')));
 
 	if (!queueItem) return null;
 

--- a/src/routes/api/library/series/[id]/stream/+server.ts
+++ b/src/routes/api/library/series/[id]/stream/+server.ts
@@ -11,7 +11,7 @@ import {
 	downloadQueue,
 	subtitles
 } from '$lib/server/db/schema';
-import { eq, asc, inArray } from 'drizzle-orm';
+import { eq, asc, inArray, and } from 'drizzle-orm';
 import type { RequestHandler } from '@sveltejs/kit';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
 
@@ -292,7 +292,7 @@ async function getQueueItems(seriesId: string): Promise<QueueItem[]> {
 			seasonNumber: downloadQueue.seasonNumber
 		})
 		.from(downloadQueue)
-		.where(eq(downloadQueue.seriesId, seriesId));
+		.where(and(eq(downloadQueue.seriesId, seriesId), eq(downloadQueue.status, 'downloading')));
 
 	return results.map((q) => ({
 		id: q.id,

--- a/src/routes/api/library/unmatched/issues/+server.ts
+++ b/src/routes/api/library/unmatched/issues/+server.ts
@@ -1,0 +1,102 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import { db } from '$lib/server/db/index.js';
+import { movies, rootFolders, series } from '$lib/server/db/schema.js';
+import { sql } from 'drizzle-orm';
+import { logger } from '$lib/logging';
+import type { LibraryIssue, RootFolderOption } from '$lib/types/unmatched.js';
+
+/**
+ * GET /api/library/unmatched/issues
+ * Return library items with missing/invalid root folder assignments.
+ */
+export const GET: RequestHandler = async () => {
+	try {
+		const [movieItems, seriesItems, rootFolderOptions] = await Promise.all([
+			db
+				.select({
+					id: movies.id,
+					title: movies.title,
+					year: movies.year,
+					posterPath: movies.posterPath
+				})
+				.from(movies).where(sql`
+					${movies.rootFolderId} IS NULL
+					OR ${movies.rootFolderId} = ''
+					OR ${movies.rootFolderId} = 'null'
+					OR NOT EXISTS (
+						SELECT 1 FROM ${rootFolders} rf WHERE rf.id = ${movies.rootFolderId}
+					)
+					OR EXISTS (
+						SELECT 1 FROM ${rootFolders} rf
+						WHERE rf.id = ${movies.rootFolderId} AND rf.media_type != 'movie'
+					)
+				`),
+			db
+				.select({
+					id: series.id,
+					title: series.title,
+					year: series.year,
+					posterPath: series.posterPath
+				})
+				.from(series).where(sql`
+					${series.rootFolderId} IS NULL
+					OR ${series.rootFolderId} = ''
+					OR ${series.rootFolderId} = 'null'
+					OR NOT EXISTS (
+						SELECT 1 FROM ${rootFolders} rf WHERE rf.id = ${series.rootFolderId}
+					)
+					OR EXISTS (
+						SELECT 1 FROM ${rootFolders} rf
+						WHERE rf.id = ${series.rootFolderId} AND rf.media_type != 'tv'
+					)
+				`),
+			db
+				.select({
+					id: rootFolders.id,
+					name: rootFolders.name,
+					path: rootFolders.path,
+					mediaType: rootFolders.mediaType
+				})
+				.from(rootFolders)
+		]);
+
+		const libraryItems: LibraryIssue[] = [
+			...movieItems.map((item) => ({
+				...item,
+				mediaType: 'movie' as const,
+				issue: 'missing_root_folder' as const
+			})),
+			...seriesItems.map((item) => ({
+				...item,
+				mediaType: 'tv' as const,
+				issue: 'missing_root_folder' as const
+			}))
+		];
+
+		return json({
+			success: true,
+			data: {
+				libraryItems,
+				rootFolders: rootFolderOptions as RootFolderOption[],
+				total: libraryItems.length
+			},
+			meta: {
+				timestamp: new Date().toISOString()
+			}
+		});
+	} catch (error) {
+		logger.error(
+			'[API] Error fetching unmatched library issues',
+			error instanceof Error ? error : undefined
+		);
+		return json(
+			{
+				success: false,
+				error: error instanceof Error ? error.message : 'Failed to fetch library issues',
+				data: null
+			},
+			{ status: 500 }
+		);
+	}
+};

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -8,7 +8,7 @@ import {
 	downloadQueue,
 	subtitles
 } from '$lib/server/db/schema.js';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import type { LibraryMovie, MovieFile } from '$lib/types/library';
@@ -183,7 +183,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 			progress: downloadQueue.progress
 		})
 		.from(downloadQueue)
-		.where(eq(downloadQueue.movieId, id));
+		.where(and(eq(downloadQueue.movieId, id), eq(downloadQueue.status, 'downloading')));
 
 	const queueItem: QueueItemInfo | null =
 		queueResults.length > 0

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -54,11 +54,7 @@
 			queueItemState = payload.queueItem;
 		},
 		'queue:updated': (payload) => {
-			if (
-				payload.status === 'imported' ||
-				payload.status === 'removed' ||
-				payload.status === 'failed'
-			) {
+			if (payload.status !== 'downloading') {
 				queueItemState = null;
 			} else {
 				queueItemState = {
@@ -532,7 +528,7 @@
 						</div>
 					{/if}
 				</div>
-				<div class="hidden shrink-0 items-center sm:flex">
+				<div class="hidden shrink-0 items-center lg:flex">
 					{#if sse.isConnected}
 						<span
 							class="inline-flex items-center gap-1 rounded-full border border-success/70 bg-success/90 px-2.5 py-1 text-xs font-medium text-success-content shadow-sm"

--- a/src/routes/library/tv/[id]/+page.server.ts
+++ b/src/routes/library/tv/[id]/+page.server.ts
@@ -10,7 +10,7 @@ import {
 	downloadQueue,
 	subtitles
 } from '$lib/server/db/schema.js';
-import { eq, asc, inArray } from 'drizzle-orm';
+import { eq, asc, inArray, and } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { DEFAULT_PROFILES } from '$lib/server/scoring/profiles.js';
@@ -361,7 +361,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 			seasonNumber: downloadQueue.seasonNumber
 		})
 		.from(downloadQueue)
-		.where(eq(downloadQueue.seriesId, id));
+		.where(and(eq(downloadQueue.seriesId, id), eq(downloadQueue.status, 'downloading')));
 
 	const queueItems: QueueItemInfo[] = queueResults.map((q) => ({
 		id: q.id,

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -73,12 +73,8 @@
 			queueItemsState = payload.queueItems;
 		},
 		'queue:updated': (payload) => {
-			if (
-				payload.status === 'imported' ||
-				payload.status === 'removed' ||
-				payload.status === 'failed'
-			) {
-				// Remove from queue if terminal state
+			if (payload.status !== 'downloading') {
+				// Keep local queue state aligned to actively downloading items only
 				queueItemsState = queueItems.filter((q) => q.id !== payload.id);
 			} else {
 				// Update or add queue item
@@ -1137,7 +1133,7 @@
 						</div>
 					{/if}
 				</div>
-				<div class="hidden shrink-0 items-center sm:flex">
+				<div class="hidden shrink-0 items-center lg:flex">
 					{#if sse.isConnected}
 						<span
 							class="inline-flex items-center gap-1 rounded-full border border-success/70 bg-success/90 px-2.5 py-1 text-xs font-medium text-success-content shadow-sm"

--- a/src/routes/library/unmatched/+page.svelte
+++ b/src/routes/library/unmatched/+page.svelte
@@ -8,7 +8,8 @@
 		UnmatchedFilters,
 		UnmatchedBulkActions,
 		UnmatchedEmptyState,
-		UnmatchedPagination
+		UnmatchedPagination,
+		UnmatchedLibraryIssues
 	} from '$lib/components/unmatched';
 	import MatchFileModal from '$lib/components/library/MatchFileModal.svelte';
 	import MatchFolderModal from '$lib/components/library/MatchFolderModal.svelte';
@@ -176,6 +177,9 @@
 			showCheckboxes = showing;
 		}}
 	/>
+
+	<!-- Library issues panel (missing/invalid root folders) -->
+	<UnmatchedLibraryIssues unmatchedFileCount={pagination.total} />
 
 	<!-- Loading State -->
 	{#if loading}

--- a/src/routes/settings/tasks/+page.svelte
+++ b/src/routes/settings/tasks/+page.svelte
@@ -7,6 +7,7 @@
 	import type { TaskHistoryEntry } from '$lib/types/task';
 	import TasksTable from '$lib/components/tasks/TasksTable.svelte';
 	import CreateTaskPlaceholder from '$lib/components/tasks/CreateTaskPlaceholder.svelte';
+	import { Wifi } from 'lucide-svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -369,12 +370,18 @@
 			</p>
 		</div>
 		<div class="flex items-center gap-2 sm:gap-3">
-			{#if sseConnected}
-				<span class="badge hidden gap-1 badge-ghost badge-sm sm:inline-flex">
-					<span class="inline-block h-1.5 w-1.5 rounded-full bg-success"></span>
-					Live
-				</span>
-			{/if}
+			<div class="hidden items-center gap-2 lg:flex">
+				{#if sseConnected}
+					<span class="badge gap-1 badge-success">
+						<Wifi class="h-3 w-3" />
+						Live
+					</span>
+				{:else if sseStatus === 'connecting' || sseStatus === 'error'}
+					<span class="badge gap-1 {sseStatus === 'error' ? 'badge-error' : 'badge-warning'}">
+						{sseStatus === 'error' ? 'Reconnecting...' : 'Connecting...'}
+					</span>
+				{/if}
+			</div>
 			<button
 				class="btn w-full gap-2 btn-sm btn-primary sm:w-auto"
 				onclick={() => (showCreateModal = true)}


### PR DESCRIPTION
## Summary

This pull request introduces several improvements and fixes across the application, focusing on better handling and display of unmatched library items with missing or invalid root folders, improved download queue filtering, and UI consistency updates. The most notable changes include the addition of a new API endpoint and UI component for reporting library issues, refinements to download queue logic to only show active downloads, and various user interface enhancements for clarity and responsiveness.

**Unmatched Library Issues Handling:**

* Added a new API endpoint at `src/routes/api/library/unmatched/issues/+server.ts` that returns library items (movies and series) with missing or invalid root folder assignments, including available root folder options for remediation.
* Introduced a new Svelte component `UnmatchedLibraryIssues` and integrated it into the unmatched library page to display detected issues to users. [[1]](diffhunk://#diff-dc077d73aae830786825be566a5591fa5b1d1c4df7849f677d6ce0cb42d004dfR7) [[2]](diffhunk://#diff-731e7ef4b939f2407ce0dbaec9554c1758887c08f47de80a3b1433a728fc9257L11-R12) [[3]](diffhunk://#diff-731e7ef4b939f2407ce0dbaec9554c1758887c08f47de80a3b1433a728fc9257R181-R183)
* Defined a new `RootFolderOption` interface in `src/lib/types/unmatched.ts` for use in reporting and resolving root folder issues.

**Download Queue Filtering and State Management:**

* Updated all download queue queries (movies and series) to only include items with a status of `'downloading'`, both in API and server-side page loads, ensuring only active downloads are shown. ([src/routes/api/library/movies/[id]/stream/+server.tsL123-R123](diffhunk://#diff-361e7f56063f6da4add0e10f7d0d341277112d58b826a45cbf51bec2c94be48cL123-R123), [src/routes/api/library/series/[id]/stream/+server.tsL295-R295](diffhunk://#diff-57636651afdb001bd21773f0d3dfa879d3ef992a521ff861e8476e8107f67453L295-R295), [src/routes/library/movie/[id]/+page.server.tsL186-R186](diffhunk://#diff-33fdb321d0b8328f800c6670b082fd5f6226298b57de3f65cfaccf6938ccecb2L186-R186), [src/routes/library/tv/[id]/+page.server.tsL364-R364](diffhunk://#diff-92650df16dc2073b0596703b0d09d7227d89da63a314bd5991b6d73c48f08822L364-R364))
* Simplified client-side queue state updates to remove items from the queue when their status is not `'downloading'`, keeping the UI in sync with backend logic. ([src/routes/library/movie/[id]/+page.svelteL57-R57](diffhunk://#diff-09e1e21e58b0ac8e58479f2c758611daf1f77612eb4da72aeac696003dd9639bL57-R57), [src/routes/library/tv/[id]/+page.svelteL76-R77](diffhunk://#diff-b72e3068a7c7e9132c5abe7f2e89d7f301e4e1b305c363bce3f115448392fe24L76-R77))

**User Interface and Responsiveness Improvements:**

* Enhanced the display of connection status badges and other UI elements to only show on larger screens (`lg` breakpoint), improving layout consistency across different pages. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL173-R172) [[2]](diffhunk://#diff-d1f2eaae26ea20535172f770d1268a5f526ec525c1048dd067751f159de006e0L448-R448) [src/routes/library/movie/[id]/+page.svelteL535-R531](diffhunk://#diff-09e1e21e58b0ac8e58479f2c758611daf1f77612eb4da72aeac696003dd9639bL535-R531), [src/routes/library/tv/[id]/+page.svelteL1140-R1136](diffhunk://#diff-b72e3068a7c7e9132c5abe7f2e89d7f301e4e1b305c363bce3f115448392fe24L1140-R1136), [[3]](diffhunk://#diff-90a122a0863d14d3a8c12b4e910a20801c03a1440ad717692043a16f6f6a0921R373-R384)
* Improved the layout and visual clarity of unmatched file and root folder issue cards, including better handling of overflow and alignment for counts and icons. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL293-L308) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL321-L334)
* Updated task status badges in `TaskTableRow.svelte` to display text ("OK", "Failed") for completed and failed statuses, and replaced a custom SVG with the `History` icon from `lucide-svelte` for consistency. [[1]](diffhunk://#diff-d225ff457ae571df4184f87606e8a9fa0fe42358d3644431c2b0ac747fdf5c2aR2) [[2]](diffhunk://#diff-d225ff457ae571df4184f87606e8a9fa0fe42358d3644431c2b0ac747fdf5c2aL141-R144) [[3]](diffhunk://#diff-d225ff457ae571df4184f87606e8a9fa0fe42358d3644431c2b0ac747fdf5c2aL257-R258)

**Minor Codebase Cleanups:**

* Removed unused icons and imports, and made minor code formatting improvements. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL7) [[2]](diffhunk://#diff-90a122a0863d14d3a8c12b4e910a20801c03a1440ad717692043a16f6f6a0921R10)

**Backend Query Consistency:**

* Standardized the use of `and` from `drizzle-orm` for compound query conditions across API and server-side logic. ([src/routes/api/library/movies/[id]/stream/+server.tsL6-R6](diffhunk://#diff-361e7f56063f6da4add0e10f7d0d341277112d58b826a45cbf51bec2c94be48cL6-R6), [src/routes/api/library/series/[id]/stream/+server.tsL14-R14](diffhunk://#diff-57636651afdb001bd21773f0d3dfa879d3ef992a521ff861e8476e8107f67453L14-R14), [src/routes/library/movie/[id]/+page.server.tsL11-R11](diffhunk://#diff-33fdb321d0b8328f800c6670b082fd5f6226298b57de3f65cfaccf6938ccecb2L11-R11), [src/routes/library/tv/[id]/+page.server.tsL13-R13](diffhunk://#diff-92650df16dc2073b0596703b0d09d7227d89da63a314bd5991b6d73c48f08822L13-R13))

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Reintroduced root-folder assignment for library items (movies/TV) without changing the new unmatched files/folders architecture.
- Added a new API endpoint: GET /api/library/unmatched/issues:
  - returns library items with missing/invalid root-folder assignments
  - returns available root-folder options (movie/tv)
- Added UnmatchedLibraryIssues panel on the unmatched page:
  - collapsible “Library Issues” section
  - movie/tv tabs
  - per-item root-folder select + apply
  - bulk select + bulk apply for selected items
  - loading/saving states and toast feedback
- Integrated panel into +page.svelte while keeping existing unmatched list/folder flows intact.
- Updated unmatched exports/types to support the new panel and API payloads (RootFolderOption, component export).
- UI Polish:
  - Desktop Tasks status indicators now use explicit labels (OK / Failed) instead of color-only dots.
  - Desktop Tasks history action icon now uses a clear history glyph.
  - Tasks desktop SSE badge matches the shared Live/Connecting/Reconnecting style used elsewhere.
- Fixed library queue state handling so only truly active downloads are treated as downloading.
- Updated detail-page SSE queue handlers to remove items when status is anything other than `downloading` (applied the same rule to both initial load and SSE stream paths for parity):
  - this prevents stale episode/series download counters and “Downloading” row states when Activity shows zero active downloads.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
<img width="1635" height="687" alt="image" src="https://github.com/user-attachments/assets/168c2abb-5047-4e9a-9831-72cd5df01239" /><br>

<img width="1637" height="731" alt="image" src="https://github.com/user-attachments/assets/02a63abd-e24f-423b-b4a9-676d7ba98d7b" />

