### PR TITLE
fix: resolve worker slot leaks and, enhance "Update .strm URLs" & "Reprobe .strm Media Info" tasks

### DIFF
--- a/src/lib/components/tasks/TaskHistoryList.svelte
+++ b/src/lib/components/tasks/TaskHistoryList.svelte
@@ -145,10 +145,15 @@
 		if (typeof summarySource.updatedFiles === 'number') {
 			parts.push(`${summarySource.updatedFiles}/${summarySource.totalFiles ?? 0} files updated`);
 		}
-
 		// STRM reprobe results
 		if (typeof summarySource.updated === 'number') {
 			parts.push(`${summarySource.updated}/${summarySource.total ?? 0} files updated`);
+		}
+		if (
+			typeof summarySource.probeFallbackUsed === 'number' &&
+			summarySource.probeFallbackUsed > 0
+		) {
+			parts.push(`${summarySource.probeFallbackUsed} fallback`);
 		}
 		if (typeof summarySource.failed === 'number' && summarySource.failed > 0) {
 			parts.push(`${summarySource.failed} failed`);
@@ -177,6 +182,9 @@
 		// Errors count
 		if (typeof summarySource.errors === 'number' && summarySource.errors > 0) {
 			parts.push(`${summarySource.errors} errors`);
+		}
+		if (Array.isArray(summarySource.errors) && summarySource.errors.length > 0) {
+			parts.push(`${summarySource.errors.length} errors`);
 		}
 
 		return parts.join(', ');

--- a/src/lib/server/streaming/prefetch/StreamPrefetchService.ts
+++ b/src/lib/server/streaming/prefetch/StreamPrefetchService.ts
@@ -167,9 +167,9 @@ export class StreamPrefetchService {
 			// Build the resolve URL
 			let resolveUrl: string;
 			if (mediaType === 'movie') {
-				resolveUrl = `/api/streaming/resolve/movie/${tmdbId}`;
+				resolveUrl = `/api/streaming/resolve/movie/${tmdbId}?prefetch=1`;
 			} else {
-				resolveUrl = `/api/streaming/resolve/tv/${tmdbId}/${season}/${episode}`;
+				resolveUrl = `/api/streaming/resolve/tv/${tmdbId}/${season}/${episode}?prefetch=1`;
 			}
 
 			// Make the prefetch request

--- a/src/routes/api/streaming/resolve/movie/[tmdbId]/+server.ts
+++ b/src/routes/api/streaming/resolve/movie/[tmdbId]/+server.ts
@@ -19,6 +19,9 @@ function errorResponse(message: string, code: string, status: number): Response 
 
 export const GET: RequestHandler = async ({ params, request }) => {
 	const tmdbId = params.tmdbId;
+	const url = new URL(request.url);
+	const isPrefetch =
+		url.searchParams.get('prefetch') === '1' || request.headers.get('x-prefetch') === 'true';
 
 	if (!tmdbId) {
 		return errorResponse('Missing TMDB ID', 'MISSING_PARAM', 400);
@@ -31,29 +34,33 @@ export const GET: RequestHandler = async ({ params, request }) => {
 
 	const tmdbIdNum = parseInt(tmdbId, 10);
 
-	// Create or find existing stream worker for this media
-	let worker = streamWorkerRegistry.findByMedia(tmdbIdNum, 'movie');
+	// Prefetch requests should not consume worker slots
+	let worker: StreamWorker | undefined;
+	if (!isPrefetch) {
+		worker = streamWorkerRegistry.findByMedia(tmdbIdNum, 'movie');
 
-	if (!worker) {
-		worker = new StreamWorker({
-			mediaType: 'movie',
-			tmdbId: tmdbIdNum
-		});
+		if (!worker) {
+			const newWorker = new StreamWorker({
+				mediaType: 'movie',
+				tmdbId: tmdbIdNum
+			});
 
-		try {
-			workerManager.spawn(worker);
-			streamWorkerRegistry.register(worker);
-			workerManager.spawnInBackground(worker);
-		} catch (e) {
-			worker.log(
-				'warn',
-				`Could not create worker: ${e instanceof Error ? e.message : 'Unknown error'}`
-			);
-			worker = undefined as unknown as StreamWorker;
+			try {
+				workerManager.spawn(newWorker);
+				streamWorkerRegistry.register(newWorker);
+				workerManager.spawnInBackground(newWorker);
+				worker = newWorker;
+			} catch (e) {
+				newWorker.log(
+					'warn',
+					`Could not create worker: ${e instanceof Error ? e.message : 'Unknown error'}`
+				);
+				worker = undefined;
+			}
 		}
-	}
 
-	worker?.extractionStarted();
+		worker?.extractionStarted();
+	}
 
 	try {
 		const { resolveStream, getBaseUrlAsync } = await import('$lib/server/streaming');
@@ -68,18 +75,28 @@ export const GET: RequestHandler = async ({ params, request }) => {
 		// Track success/failure in worker
 		if (response.ok) {
 			worker?.extractionSucceeded('streaming', 'auto');
+			worker?.complete();
+			if (worker) {
+				streamWorkerRegistry.unregister(worker);
+			}
 		} else {
 			const body = await response
 				.clone()
 				.json()
 				.catch(() => ({ error: 'Unknown error' }));
 			worker?.fail(body.error || 'Stream resolution failed');
+			if (worker) {
+				streamWorkerRegistry.unregister(worker);
+			}
 		}
 
 		return response;
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 		worker?.fail(errorMessage);
+		if (worker) {
+			streamWorkerRegistry.unregister(worker);
+		}
 		return errorResponse(`Stream extraction error: ${errorMessage}`, 'INTERNAL_ERROR', 500);
 	}
 };

--- a/src/routes/api/streaming/resolve/tv/[tmdbId]/[season]/[episode]/+server.ts
+++ b/src/routes/api/streaming/resolve/tv/[tmdbId]/[season]/[episode]/+server.ts
@@ -19,6 +19,9 @@ function errorResponse(message: string, code: string, status: number): Response 
 
 export const GET: RequestHandler = async ({ params, request }) => {
 	const { tmdbId, season, episode } = params;
+	const url = new URL(request.url);
+	const isPrefetch =
+		url.searchParams.get('prefetch') === '1' || request.headers.get('x-prefetch') === 'true';
 
 	if (!tmdbId || !season || !episode) {
 		return errorResponse('Missing parameters', 'MISSING_PARAM', 400);
@@ -33,31 +36,35 @@ export const GET: RequestHandler = async ({ params, request }) => {
 	const seasonNum = parseInt(season, 10);
 	const episodeNum = parseInt(episode, 10);
 
-	// Create or find existing stream worker for this media
-	let worker = streamWorkerRegistry.findByMedia(tmdbIdNum, 'tv', seasonNum, episodeNum);
+	// Prefetch requests should not consume worker slots
+	let worker: StreamWorker | undefined;
+	if (!isPrefetch) {
+		worker = streamWorkerRegistry.findByMedia(tmdbIdNum, 'tv', seasonNum, episodeNum);
 
-	if (!worker) {
-		worker = new StreamWorker({
-			mediaType: 'tv',
-			tmdbId: tmdbIdNum,
-			season: seasonNum,
-			episode: episodeNum
-		});
+		if (!worker) {
+			const newWorker = new StreamWorker({
+				mediaType: 'tv',
+				tmdbId: tmdbIdNum,
+				season: seasonNum,
+				episode: episodeNum
+			});
 
-		try {
-			workerManager.spawn(worker);
-			streamWorkerRegistry.register(worker);
-			workerManager.spawnInBackground(worker);
-		} catch (e) {
-			worker.log(
-				'warn',
-				`Could not create worker: ${e instanceof Error ? e.message : 'Unknown error'}`
-			);
-			worker = undefined as unknown as StreamWorker;
+			try {
+				workerManager.spawn(newWorker);
+				streamWorkerRegistry.register(newWorker);
+				workerManager.spawnInBackground(newWorker);
+				worker = newWorker;
+			} catch (e) {
+				newWorker.log(
+					'warn',
+					`Could not create worker: ${e instanceof Error ? e.message : 'Unknown error'}`
+				);
+				worker = undefined;
+			}
 		}
-	}
 
-	worker?.extractionStarted();
+		worker?.extractionStarted();
+	}
 
 	try {
 		const { resolveStream, getBaseUrlAsync } = await import('$lib/server/streaming');
@@ -74,18 +81,28 @@ export const GET: RequestHandler = async ({ params, request }) => {
 		// Track success/failure in worker
 		if (response.ok) {
 			worker?.extractionSucceeded('streaming', 'auto');
+			worker?.complete();
+			if (worker) {
+				streamWorkerRegistry.unregister(worker);
+			}
 		} else {
 			const body = await response
 				.clone()
 				.json()
 				.catch(() => ({ error: 'Unknown error' }));
 			worker?.fail(body.error || 'Stream resolution failed');
+			if (worker) {
+				streamWorkerRegistry.unregister(worker);
+			}
 		}
 
 		return response;
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 		worker?.fail(errorMessage);
+		if (worker) {
+			streamWorkerRegistry.unregister(worker);
+		}
 		return errorResponse(`Stream extraction error: ${errorMessage}`, 'INTERNAL_ERROR', 500);
 	}
 };

--- a/src/routes/discover/movie/[id]/+page.svelte
+++ b/src/routes/discover/movie/[id]/+page.svelte
@@ -9,8 +9,9 @@
 	// Prefetch stream when page loads (warms cache for faster playback)
 	$effect(() => {
 		if (data.movie?.id) {
-			fetch(`/api/streaming/resolve/movie/${data.movie.id}`, {
-				signal: AbortSignal.timeout(5000)
+			fetch(`/api/streaming/resolve/movie/${data.movie.id}?prefetch=1`, {
+				signal: AbortSignal.timeout(5000),
+				headers: { 'X-Prefetch': 'true' }
 			}).catch(() => {});
 		}
 	});

--- a/src/routes/discover/tv/[id]/+page.svelte
+++ b/src/routes/discover/tv/[id]/+page.svelte
@@ -13,8 +13,9 @@
 			// Find first season with episodes (skip specials/season 0)
 			const firstSeason = data.tv.seasons.find((s) => s.season_number > 0 && s.episode_count > 0);
 			if (firstSeason) {
-				fetch(`/api/streaming/resolve/tv/${data.tv.id}/${firstSeason.season_number}/1`, {
-					signal: AbortSignal.timeout(5000)
+				fetch(`/api/streaming/resolve/tv/${data.tv.id}/${firstSeason.season_number}/1?prefetch=1`, {
+					signal: AbortSignal.timeout(5000),
+					headers: { 'X-Prefetch': 'true' }
 				}).catch(() => {});
 			}
 		}


### PR DESCRIPTION
## Summary

This pull request introduces several improvements to task history presentation, streaming file handling, and server robustness. The changes enhance error reporting and visibility in the UI, improve the accuracy and scope of streamer-profile `.strm` file updates, and add reliability to streaming and SSE APIs.

**Task History and Error Reporting Improvements:**

* Enhanced the `TaskHistoryModal.svelte` UI to show detailed error counts and allow users to expand and view individual failed items, including error messages and affected paths. This includes new helper functions for error extraction and toggling, improving clarity and troubleshooting. [[1]](diffhunk://#diff-76f045fe4096f18b69d8f7da1434cddedba41481fc995856907b801a3a60393eR14) [[2]](diffhunk://#diff-76f045fe4096f18b69d8f7da1434cddedba41481fc995856907b801a3a60393eR49-R100) [[3]](diffhunk://#diff-76f045fe4096f18b69d8f7da1434cddedba41481fc995856907b801a3a60393eR145-R157) [[4]](diffhunk://#diff-76f045fe4096f18b69d8f7da1434cddedba41481fc995856907b801a3a60393eL104-R239)
* Updated `TaskHistoryList.svelte` to better summarize fallback usage and error counts, including handling both numeric and array-based error representations. [[1]](diffhunk://#diff-9e5ece095ab3e8a01c741371f6c291a5bd0bd87972a26c039b2292c7e167e4c2L148-R157) [[2]](diffhunk://#diff-9e5ece095ab3e8a01c741371f6c291a5bd0bd87972a26c039b2292c7e167e4c2R186-R188)

**Streaming and STRM File Handling Enhancements:**

* Refactored `StrmService.ts` to target only streamer-profile `.strm` files for bulk URL updates, improving accuracy and avoiding unintended modifications. Added a method to resolve media paths from database metadata and removed unnecessary directory scanning. [[1]](diffhunk://#diff-fcb50c65d43c31177db19df5a64138fda98ace46da96f8d3cdff0e61822e7834L9-R21) [[2]](diffhunk://#diff-fcb50c65d43c31177db19df5a64138fda98ace46da96f8d3cdff0e61822e7834R354-R374) [[3]](diffhunk://#diff-fcb50c65d43c31177db19df5a64138fda98ace46da96f8d3cdff0e61822e7834L385-R413) [[4]](diffhunk://#diff-fcb50c65d43c31177db19df5a64138fda98ace46da96f8d3cdff0e61822e7834L431-R492)
* Improved `MediaInfoService` to provide granular fallback reasons when probing `.strm` files fails, and allow callers to treat malformed STRM URLs as hard failures if desired. [[1]](diffhunk://#diff-549ae1955cd48bebee7d78fc248b3a20ce91b43112dbd19f2e4ac32fd5f52083L297-R341) [[2]](diffhunk://#diff-549ae1955cd48bebee7d78fc248b3a20ce91b43112dbd19f2e4ac32fd5f52083R350) [[3]](diffhunk://#diff-549ae1955cd48bebee7d78fc248b3a20ce91b43112dbd19f2e4ac32fd5f52083R360-R362) [[4]](diffhunk://#diff-549ae1955cd48bebee7d78fc248b3a20ce91b43112dbd19f2e4ac32fd5f52083R391-R394)

**Server Robustness and Streaming API:**

* Enhanced the `createSSEStream` function to ensure proper cleanup of event listeners and timers when the connection closes, improving reliability and preventing resource leaks. [[1]](diffhunk://#diff-e955a33d461e359b34ef51466b4e317aeb1341bcd866334e2dd1768484ab46beR35-R42) [[2]](diffhunk://#diff-e955a33d461e359b34ef51466b4e317aeb1341bcd866334e2dd1768484ab46beL48-R87)
* Updated streaming prefetch requests to include a query parameter, allowing the server to distinguish prefetch operations and optimize accordingly. ([src/lib/server/streaming/prefetch/StreamPrefetchService.tsL170-R172](diffhunk://#diff-1f46f334c4cc8bedd5067a4f61b79580edb23d46a06830209ed163c4c48f525bL170-R172), [src/routes/api/streaming/resolve/movie/[tmdbId]/+server.tsR22-R24](diffhunk://#diff-f6143a3a71c9d7a006fe56f5a648ba1b37594c8f818842f2601dd21234ce9442R22-R24))

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Marked stream warmup calls as prefetch (?prefetch=1 / X-Prefetch) from discover and library detail pages.
- Updated resolve APIs to skip worker allocation for prefetch requests so passive page visits do not consume stream worker slots.
- Fixed worker lifecycle for real resolve requests: workers are now completed/unregistered on success, failure responses, and thrown errors, preventing stale workers and Concurrency limit reached for stream workers: 10/10 warnings.
- Hardened SSE stream cleanup so disconnects reliably release heartbeat timers/listeners.
- Restricted bulk .strm URL updates to Streamer-profile library entries only (DB-driven path resolution), avoiding unrelated .strm files under non-streamer profiles.
- Enhanced reprobe behavior and reporting: invalid .strm URLs can fail explicitly, probe fallbacks are tracked (probeFallbackUsed), and task history now shows clean error counts/details with expandable failed-item lists instead of [object Object].
- Improved task run summary logging to emit compact numeric summaries instead of dumping large raw result payloads.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
