### PR TITLE
feat: enhance movie availability tracking and UI updates

### DIFF
--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -6,12 +6,14 @@
 	import StatusIndicator from './StatusIndicator.svelte';
 	import QualityBadge from './QualityBadge.svelte';
 	import ScoreBadge from './ScoreBadge.svelte';
+	import { getMovieAvailabilityLevel } from '$lib/utils/movieAvailability';
 	import {
 		Search,
 		Settings,
 		Trash2,
 		ExternalLink,
 		Download,
+		Clock,
 		Loader2,
 		Check,
 		X
@@ -70,6 +72,10 @@
 		return 'missing';
 	});
 	const totalSize = $derived(movie.files.reduce((sum, f) => sum + (f.size || 0), 0));
+	const movieAvailability = $derived(getMovieAvailabilityLevel(movie));
+	const showUnreleasedBadge = $derived(
+		!movie.hasFile && Boolean(movie.monitored) && movieAvailability !== 'released'
+	);
 	const statusQualityText = $derived.by(() => {
 		if (isStreamerProfile && movie.hasFile) return 'Auto';
 		if (!bestQuality.quality) return null;
@@ -225,6 +231,14 @@
 			<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<div class="flex flex-wrap items-center gap-2 sm:gap-4">
 					<StatusIndicator status={fileStatus} qualityText={statusQualityText} />
+					{#if showUnreleasedBadge}
+						<div
+							class="inline-flex items-center gap-2 rounded-lg bg-error/5 px-3 py-1.5 text-sm text-error/80 ring-1 ring-error/25"
+						>
+							<Clock size={16} />
+							<span class="font-medium">Unreleased</span>
+						</div>
+					{/if}
 					{#if movie.hasFile && totalSize > 0}
 						<span class="text-sm text-base-content/70">
 							{formatBytes(totalSize)}

--- a/src/lib/components/library/SeasonAccordion.svelte
+++ b/src/lib/components/library/SeasonAccordion.svelte
@@ -315,7 +315,7 @@
 				<div class="p-8 text-center text-base-content/60">No episodes in this season</div>
 			{:else}
 				<div class="w-full max-w-full overflow-x-hidden sm:overflow-x-auto">
-					<table class="table w-full table-sm sm:min-w-[640px] sm:table-auto">
+					<table class="table w-full table-sm sm:min-w-160 sm:table-auto">
 						<thead>
 							<tr class="text-xs text-base-content/60">
 								{#if showCheckboxes}

--- a/src/lib/components/tasks/TaskCard.svelte
+++ b/src/lib/components/tasks/TaskCard.svelte
@@ -5,6 +5,7 @@
 
 	interface Props {
 		task: UnifiedTask;
+		now: number;
 		history: TaskHistoryEntry[];
 		onRunTask: (taskId: string) => Promise<void>;
 		onCancelTask?: (taskId: string) => Promise<void>;
@@ -12,17 +13,10 @@
 		onShowHistory: () => void;
 	}
 
-	let { task, history, onRunTask, onCancelTask, onToggleEnabled, onShowHistory }: Props = $props();
+	let { task, now, history, onRunTask, onCancelTask, onToggleEnabled, onShowHistory }: Props =
+		$props();
 
 	let isCancelling = $state(false);
-	let now = $state(Date.now());
-
-	$effect(() => {
-		const interval = setInterval(() => {
-			now = Date.now();
-		}, 1000);
-		return () => clearInterval(interval);
-	});
 
 	$effect(() => {
 		if (!task.isRunning) {

--- a/src/lib/components/tasks/TaskTableRow.svelte
+++ b/src/lib/components/tasks/TaskTableRow.svelte
@@ -6,6 +6,7 @@
 
 	interface Props {
 		task: UnifiedTask;
+		now: number;
 		history: TaskHistoryEntry[];
 		onRunTask: (taskId: string) => Promise<void>;
 		onCancelTask?: (taskId: string) => Promise<void>;
@@ -13,20 +14,10 @@
 		onShowHistory: () => void;
 	}
 
-	let { task, history, onRunTask, onCancelTask, onToggleEnabled, onShowHistory }: Props = $props();
+	let { task, now, history, onRunTask, onCancelTask, onToggleEnabled, onShowHistory }: Props =
+		$props();
 
 	let isCancelling = $state(false);
-
-	// Live countdown state - updated every second
-	let now = $state(Date.now());
-
-	// Tick the clock every second for live countdowns
-	$effect(() => {
-		const interval = setInterval(() => {
-			now = Date.now();
-		}, 1000);
-		return () => clearInterval(interval);
-	});
 
 	// Reset cancelling state when task stops running
 	$effect(() => {

--- a/src/lib/components/tasks/TasksTable.svelte
+++ b/src/lib/components/tasks/TasksTable.svelte
@@ -26,6 +26,14 @@
 	// History modal state
 	let selectedTask: UnifiedTask | null = $state(null);
 	let showHistoryModal = $state(false);
+	let now = $state(Date.now());
+
+	$effect(() => {
+		const interval = setInterval(() => {
+			now = Date.now();
+		}, 1000);
+		return () => clearInterval(interval);
+	});
 
 	function openHistory(task: UnifiedTask) {
 		selectedTask = task;
@@ -86,6 +94,7 @@
 					{#each scheduledTasks as task (task.id)}
 						<TaskCard
 							{task}
+							{now}
 							history={taskHistory[task.id] ?? []}
 							{onRunTask}
 							{onCancelTask}
@@ -110,6 +119,7 @@
 							{#each scheduledTasks as task (task.id)}
 								<TaskTableRow
 									{task}
+									{now}
 									history={taskHistory[task.id] ?? []}
 									{onRunTask}
 									{onCancelTask}
@@ -172,6 +182,7 @@
 					{#each maintenanceTasks as task (task.id)}
 						<TaskCard
 							{task}
+							{now}
 							history={taskHistory[task.id] ?? []}
 							{onRunTask}
 							{onCancelTask}
@@ -195,6 +206,7 @@
 							{#each maintenanceTasks as task (task.id)}
 								<TaskTableRow
 									{task}
+									{now}
 									history={taskHistory[task.id] ?? []}
 									{onRunTask}
 									{onCancelTask}

--- a/src/lib/server/streaming/validation/StreamValidator.ts
+++ b/src/lib/server/streaming/validation/StreamValidator.ts
@@ -518,12 +518,12 @@ export async function quickValidateStream(
 	referer?: string,
 	timeout = 3000
 ): Promise<boolean> {
-	const headers: HeadersInit = {
+	const headers: Record<string, string> = {
 		'User-Agent': DEFAULT_USER_AGENT,
 		Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
 	};
 	if (referer) {
-		headers['Referer'] = referer;
+		headers.Referer = referer;
 	}
 
 	const controller = new AbortController();

--- a/src/lib/utils/movieAvailability.ts
+++ b/src/lib/utils/movieAvailability.ts
@@ -1,0 +1,33 @@
+export type MovieAvailabilityLevel = 'announced' | 'inCinemas' | 'released';
+
+interface MovieAvailabilityInput {
+	year: number | null | undefined;
+	added: string | null | undefined;
+}
+
+/**
+ * Match server-side availability heuristics used for movie searching.
+ */
+export function getMovieAvailabilityLevel(
+	movie: MovieAvailabilityInput,
+	now: Date = new Date()
+): MovieAvailabilityLevel {
+	const currentYear = now.getFullYear();
+	const movieYear = movie.year;
+
+	if (!movieYear) return 'announced';
+	if (movieYear > currentYear) return 'announced';
+	if (movieYear < currentYear) return 'released';
+
+	const addedDate = movie.added ? new Date(movie.added) : now;
+	const daysSinceAdded = (now.getTime() - addedDate.getTime()) / (1000 * 60 * 60 * 24);
+
+	if (daysSinceAdded > 120) return 'released';
+	if (daysSinceAdded > 30) return 'inCinemas';
+
+	return 'inCinemas';
+}
+
+export function isMovieReleased(movie: MovieAvailabilityInput, now: Date = new Date()): boolean {
+	return getMovieAvailabilityLevel(movie, now) === 'released';
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -210,6 +210,14 @@
 					{#if stats.movies.missing > 0}
 						<span class="badge badge-sm badge-warning">{stats.movies.missing} missing</span>
 					{/if}
+					{#if (stats.movies.unreleased || 0) > 0}
+						<span class="badge badge-sm badge-secondary">{stats.movies.unreleased} unreleased</span>
+					{/if}
+					{#if (stats.movies.unmonitoredMissing || 0) > 0}
+						<span class="badge badge-sm badge-accent"
+							>{stats.movies.unmonitoredMissing} ignored</span
+						>
+					{/if}
 				</div>
 			</div>
 		</a>
@@ -227,12 +235,17 @@
 					</div>
 				</div>
 				<div class="mt-2 flex flex-wrap gap-2 text-xs">
-					<span class="badge badge-sm badge-info">{stats.episodes.withFile} files</span>
+					<span class="badge badge-sm badge-success">{stats.episodes.withFile} files</span>
 					{#if stats.episodes.missing > 0}
 						<span class="badge badge-sm badge-warning">{stats.episodes.missing} missing</span>
 					{/if}
 					{#if (stats.episodes.unaired || 0) > 0}
 						<span class="badge badge-sm badge-secondary">{stats.episodes.unaired} unaired</span>
+					{/if}
+					{#if (stats.episodes.unmonitoredMissing || 0) > 0}
+						<span class="badge badge-sm badge-accent">
+							{stats.episodes.unmonitoredMissing} ignored
+						</span>
 					{/if}
 				</div>
 			</div>
@@ -384,9 +397,15 @@
 											<p class="text-xs text-white/70">{movie.year}</p>
 										</div>
 									</div>
-									{#if !movie.hasFile}
+									{#if !movie.hasFile && movie.monitored}
 										<div class="absolute top-1 right-1">
-											<span class="badge badge-xs badge-warning">Missing</span>
+											<span
+												class="badge badge-xs {movie.isReleased
+													? 'badge-warning'
+													: 'badge-secondary'}"
+											>
+												{movie.isReleased ? 'Missing' : 'Unreleased'}
+											</span>
 										</div>
 									{/if}
 								</a>

--- a/src/routes/api/streaming/resolve/movie/[tmdbId]/+server.ts
+++ b/src/routes/api/streaming/resolve/movie/[tmdbId]/+server.ts
@@ -46,9 +46,8 @@ export const GET: RequestHandler = async ({ params, request }) => {
 			});
 
 			try {
-				workerManager.spawn(newWorker);
-				streamWorkerRegistry.register(newWorker);
 				workerManager.spawnInBackground(newWorker);
+				streamWorkerRegistry.register(newWorker);
 				worker = newWorker;
 			} catch (e) {
 				newWorker.log(

--- a/src/routes/api/streaming/resolve/tv/[tmdbId]/[season]/[episode]/+server.ts
+++ b/src/routes/api/streaming/resolve/tv/[tmdbId]/[season]/[episode]/+server.ts
@@ -50,9 +50,8 @@ export const GET: RequestHandler = async ({ params, request }) => {
 			});
 
 			try {
-				workerManager.spawn(newWorker);
-				streamWorkerRegistry.register(newWorker);
 				workerManager.spawnInBackground(newWorker);
+				streamWorkerRegistry.register(newWorker);
 				worker = newWorker;
 			} catch (e) {
 				newWorker.log(

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -26,15 +26,16 @@
 	// Reactive data that will be updated via SSE
 	let movieState = $state<LibraryMovie | null>(null);
 	let queueItemState = $state<PageData['queueItem'] | undefined>(undefined);
+	let lastMovieId = $state<string | null>(null);
 	const movie = $derived(movieState ?? data.movie);
 	const queueItem = $derived(queueItemState === undefined ? data.queueItem : queueItemState);
 
 	$effect(() => {
-		if (movieState === null) {
+		const incomingMovieId = data.movie.id;
+		if (lastMovieId !== incomingMovieId) {
 			movieState = $state.snapshot(data.movie);
-		}
-		if (queueItemState === undefined) {
 			queueItemState = $state.snapshot(data.queueItem);
+			lastMovieId = incomingMovieId;
 		}
 	});
 

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -27,19 +27,18 @@
 	let seriesState = $state<PageData['series'] | null>(null);
 	let seasonsState = $state<PageData['seasons'] | null>(null);
 	let queueItemsState = $state<PageData['queueItems'] | null>(null);
+	let lastSeriesId = $state<string | null>(null);
 	const series = $derived(seriesState ?? data.series);
 	const seasons = $derived(seasonsState ?? data.seasons);
 	const queueItems = $derived(queueItemsState ?? data.queueItems);
 
 	$effect(() => {
-		if (seriesState === null) {
+		const incomingSeriesId = data.series.id;
+		if (lastSeriesId !== incomingSeriesId) {
 			seriesState = $state.snapshot(data.series);
-		}
-		if (seasonsState === null) {
 			seasonsState = $state.snapshot(data.seasons);
-		}
-		if (queueItemsState === null) {
 			queueItemsState = $state.snapshot(data.queueItems);
+			lastSeriesId = incomingSeriesId;
 		}
 	});
 

--- a/src/routes/settings/tasks/+page.svelte
+++ b/src/routes/settings/tasks/+page.svelte
@@ -56,9 +56,6 @@
 
 	$effect(() => {
 		mobileSSEStatus.publish(MOBILE_SSE_SOURCE, sseStatus);
-		return () => {
-			mobileSSEStatus.clear(MOBILE_SSE_SOURCE);
-		};
 	});
 
 	onMount(() => {
@@ -68,6 +65,7 @@
 
 	onDestroy(() => {
 		disconnectSSE();
+		mobileSSEStatus.clear(MOBILE_SSE_SOURCE);
 	});
 
 	function connectSSE() {


### PR DESCRIPTION
## Summary

This pull request introduces improvements to movie availability tracking, refines library issue handling, and optimizes task timer state management. The most notable changes are the addition of movie availability heuristics for more accurate UI badges and counters, enhanced handling and labeling of library issues, and centralization of live timer state for tasks. Below are the top changes grouped by theme:

**Movie Availability Tracking**

* Added `getMovieAvailabilityLevel` utility and integrated it into `LibraryMovieHeader.svelte` and server logic to distinguish between "announced", "in cinemas", and "released" movies, enabling new "Unreleased" badge and improved missing movie counters. (`src/lib/utils/movieAvailability.ts`, `src/lib/components/library/LibraryMovieHeader.svelte`, `src/routes/+page.server.ts`) [[1]](diffhunk://#diff-fde012988b885f6fa6e2a3944653508c9bc01d8cfb2c1d8f3b8f6ab47b459943R1-R33) [[2]](diffhunk://#diff-13d88eed5696fb7f74660a4ff17dd84d6c9f39417f6647f4e9ab3223e3ef404eR9-R16) [[3]](diffhunk://#diff-13d88eed5696fb7f74660a4ff17dd84d6c9f39417f6647f4e9ab3223e3ef404eR75-R78) [[4]](diffhunk://#diff-13d88eed5696fb7f74660a4ff17dd84d6c9f39417f6647f4e9ab3223e3ef404eR234-R241) [[5]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fR14) [[6]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fL48-R61) [[7]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fR73-R116) [[8]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fR204-R217)

**Library Issue Handling Improvements**

* Refined issue summary and detail labels to distinguish between missing and invalid root folder assignments, and updated UI logic and button disabling to use type-specific counts for bulk actions. (`src/lib/components/unmatched/UnmatchedLibraryIssues.svelte`) [[1]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL38-R73) [[2]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeR195-R204) [[3]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL246-R286) [[4]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL259-R299) [[5]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL282-R320) [[6]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL310-R348) [[7]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL340-R378) [[8]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL383-R429)

**Task Timer State Optimization**

* Centralized live timer state in `TasksTable.svelte` and passed `now` prop to `TaskCard` and `TaskTableRow` components, removing redundant per-component timer intervals for improved performance. (`src/lib/components/tasks/TasksTable.svelte`, `src/lib/components/tasks/TaskCard.svelte`, `src/lib/components/tasks/TaskTableRow.svelte`) [[1]](diffhunk://#diff-bc36cb67d29b8a6c9505de5a072f8eff6da1704575d26c093be5d46856ca4022R29-R36) [[2]](diffhunk://#diff-bc36cb67d29b8a6c9505de5a072f8eff6da1704575d26c093be5d46856ca4022R97) [[3]](diffhunk://#diff-bc36cb67d29b8a6c9505de5a072f8eff6da1704575d26c093be5d46856ca4022R122) [[4]](diffhunk://#diff-bc36cb67d29b8a6c9505de5a072f8eff6da1704575d26c093be5d46856ca4022R185) [[5]](diffhunk://#diff-bc36cb67d29b8a6c9505de5a072f8eff6da1704575d26c093be5d46856ca4022R209) [[6]](diffhunk://#diff-8b6ef57f7d0ad3f012e8a4e14314f19537300896636e021e2d363225f1aaa889R8-L25) [[7]](diffhunk://#diff-d225ff457ae571df4184f87606e8a9fa0fe42358d3644431c2b0ac747fdf5c2aR9-L30)

**Other UI Tweaks**

* Adjusted minimum table width in `SeasonAccordion.svelte` for improved responsiveness. (`src/lib/components/library/SeasonAccordion.svelte`)

**Miscellaneous**

* Improved type safety in streaming validation by switching to a stricter header type. (`src/lib/server/streaming/validation/StreamValidator.ts`)
* Fixed SSE connection cleanup by making the `close` method externally callable. (`src/lib/sse/sse.svelte.ts`) [[1]](diffhunk://#diff-4de26c7c672d2657a10168afcf254e87e0e052faa100dfaf703dd353e551c4d8R52) [[2]](diffhunk://#diff-4de26c7c672d2657a10168afcf254e87e0e052faa100dfaf703dd353e551c4d8R167-R175) [[3]](diffhunk://#diff-4de26c7c672d2657a10168afcf254e87e0e052faa100dfaf703dd353e551c4d8L186-R190)

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Added `getMovieAvailabilityLevel` utility to determine movie release status based on year and added date.
- Integrated movie availability checks in the `LibraryMovieHeader` component to display unreleased badges.
- Updated `TasksTable` and `TaskCard` components to pass current time for countdowns.
- Modified `UnmatchedLibraryIssues` to provide detailed issue summaries for missing and invalid root folders.
- Improved API endpoints to include movie availability in responses and adjusted logic for counting missing/unreleased movies.
- Refactored various components to ensure consistent handling of movie and series states.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

<img width="1083" height="553" alt="image" src="https://github.com/user-attachments/assets/001116af-8a96-4e7d-b370-c77d7d930078" /><br>

<img width="935" height="334" alt="image" src="https://github.com/user-attachments/assets/e7447c2e-6dc7-4f39-86da-d51dbbc750b5" />

