### PR TITLE
feat: add paused status to activity and download queue

### DIFF
--- a/src/lib/components/activity/ActivityDetailModal.svelte
+++ b/src/lib/components/activity/ActivityDetailModal.svelte
@@ -6,6 +6,7 @@
 		CheckCircle2,
 		XCircle,
 		Loader2,
+		PauseCircle,
 		AlertCircle,
 		Minus,
 		Clapperboard,
@@ -51,6 +52,7 @@
 		imported: { label: 'Imported', variant: 'badge-success', icon: CheckCircle2 },
 		streaming: { label: 'Streaming', variant: 'badge-info', icon: CheckCircle2 },
 		downloading: { label: 'Downloading', variant: 'badge-info', icon: Loader2 },
+		paused: { label: 'Paused', variant: 'badge-warning', icon: PauseCircle },
 		failed: { label: 'Failed', variant: 'badge-error', icon: XCircle },
 		rejected: { label: 'Rejected', variant: 'badge-warning', icon: AlertCircle },
 		removed: { label: 'Removed', variant: 'badge-ghost', icon: XCircle },
@@ -301,7 +303,7 @@
 								<Pause class="h-4 w-4" />
 								Pause
 							</button>
-						{:else}
+						{:else if activity.status === 'paused'}
 							<button class="btn btn-ghost btn-sm" onclick={handleResume} disabled={actionLoading}>
 								<Play class="h-4 w-4" />
 								Resume

--- a/src/lib/components/activity/ActivityFilters.svelte
+++ b/src/lib/components/activity/ActivityFilters.svelte
@@ -81,6 +81,7 @@
 		{ value: 'all', label: 'All', color: '' },
 		{ value: 'success', label: 'Success', color: 'badge-success' },
 		{ value: 'downloading', label: 'Downloading', color: 'badge-info' },
+		{ value: 'paused', label: 'Paused', color: 'badge-warning' },
 		{ value: 'failed', label: 'Failed', color: 'badge-error' },
 		{ value: 'removed', label: 'Removed', color: 'badge-ghost' },
 		{ value: 'rejected', label: 'Rejected', color: 'badge-warning' },

--- a/src/lib/components/library/EpisodeRow.svelte
+++ b/src/lib/components/library/EpisodeRow.svelte
@@ -151,6 +151,7 @@
 				: 'Not monitored'
 			: 'Series is unmonitored. Enable series monitoring to monitor episodes.'
 	);
+	const hasEpisodeFile = $derived(episode.file !== null);
 
 	function formatAirDate(dateString: string | null): string {
 		if (!dateString) return 'TBA';
@@ -230,7 +231,7 @@
 	}
 </script>
 
-<tr class="hover" class:opacity-60={!isAired(episode.airDate) && !episode.hasFile}>
+<tr class="hover" class:opacity-60={!isAired(episode.airDate) && !hasEpisodeFile}>
 	<!-- Checkbox for selection -->
 	{#if showCheckbox}
 		<td class="w-10">
@@ -313,7 +314,7 @@
 									Interactive search
 								</button>
 							</li>
-							{#if episode.hasFile && (onSubtitleSearch || onSubtitleAutoSearch)}
+							{#if hasEpisodeFile && (onSubtitleSearch || onSubtitleAutoSearch)}
 								<li class="menu-title">
 									<span>Subtitles</span>
 								</li>
@@ -400,7 +401,7 @@
 			<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-base-content/60 sm:hidden">
 				<span>{formatAirDate(episode.airDate)}</span>
 				<span class="text-base-content/40">•</span>
-				{#if episode.hasFile && episode.file}
+				{#if hasEpisodeFile}
 					<span class="text-success">Downloaded</span>
 				{:else if isDownloading}
 					<span class="text-warning">Downloading</span>
@@ -418,12 +419,12 @@
 					{/if}
 				</span>
 			</div>
-			{#if episode.hasFile && episode.file}
+			{#if hasEpisodeFile}
 				<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-base-content/60 sm:hidden">
 					{#if isStreamerProfile}
 						<span class="badge badge-xs badge-secondary">Streaming</span>
 					{:else}
-						<QualityBadge quality={episode.file.quality} mediaInfo={null} size="sm" />
+						<QualityBadge quality={episode.file?.quality ?? null} mediaInfo={null} size="sm" />
 					{/if}
 					{#if allSubtitles.length > 0}
 						<div class="flex items-center gap-1">
@@ -443,14 +444,14 @@
 
 	<!-- Status -->
 	<td class="hidden sm:table-cell">
-		{#if episode.hasFile && episode.file}
+		{#if hasEpisodeFile}
 			<div class="flex flex-col gap-1">
 				<div class="flex items-center gap-2">
 					<CheckCircle size={16} class="text-success" />
 					{#if isStreamerProfile}
 						<span class="badge badge-xs badge-secondary">Streaming</span>
 					{:else}
-						<QualityBadge quality={episode.file.quality} mediaInfo={null} size="sm" />
+						<QualityBadge quality={episode.file?.quality ?? null} mediaInfo={null} size="sm" />
 					{/if}
 				</div>
 				{#if allSubtitles.length > 0}
@@ -546,7 +547,7 @@
 							Interactive search
 						</button>
 					</li>
-					{#if episode.hasFile && (onSubtitleSearch || onSubtitleAutoSearch)}
+					{#if hasEpisodeFile && (onSubtitleSearch || onSubtitleAutoSearch)}
 						<li class="menu-title">
 							<span>Subtitles</span>
 						</li>

--- a/src/lib/components/library/SeasonAccordion.svelte
+++ b/src/lib/components/library/SeasonAccordion.svelte
@@ -136,8 +136,11 @@
 		isOpen = defaultOpen;
 	});
 
-	const downloadedCount = $derived(season.episodeFileCount ?? 0);
-	const totalCount = $derived(season.episodeCount ?? season.episodes.length);
+	// Keep header counts aligned with visible rows (episodes array), not cached flags/aggregates.
+	const downloadedCount = $derived(
+		season.episodes.filter((episode) => episode.file !== null).length
+	);
+	const totalCount = $derived(season.episodes.length);
 	const percentComplete = $derived(
 		totalCount > 0 ? Math.round((downloadedCount / totalCount) * 100) : 0
 	);

--- a/src/lib/server/activity/ActivityService.ts
+++ b/src/lib/server/activity/ActivityService.ts
@@ -813,6 +813,8 @@ export class ActivityService {
 
 	private mapQueueStatus(status: string): ActivityStatus {
 		switch (status) {
+			case 'paused':
+				return 'paused';
 			case 'failed':
 				return 'failed';
 			case 'imported':

--- a/src/lib/types/activity.ts
+++ b/src/lib/types/activity.ts
@@ -12,6 +12,7 @@ export type ActivityStatus =
 	| 'imported' // Successfully imported to library
 	| 'streaming' // Streaming source (no download)
 	| 'downloading' // Currently downloading
+	| 'paused' // Download paused
 	| 'failed' // Download or import failed
 	| 'rejected' // Release rejected (quality, blocklist, etc.)
 	| 'removed' // Removed from queue

--- a/src/lib/utils/movieAvailability.ts
+++ b/src/lib/utils/movieAvailability.ts
@@ -19,12 +19,13 @@ export function getMovieAvailabilityLevel(
 	if (movieYear > currentYear) return 'announced';
 	if (movieYear < currentYear) return 'released';
 
-	const addedDate = movie.added ? new Date(movie.added) : now;
-	const daysSinceAdded = (now.getTime() - addedDate.getTime()) / (1000 * 60 * 60 * 24);
+	// Current-year movies are unreleased by default and only considered released
+	// after they have been in-library for a sustained period.
+	const addedTimestamp = movie.added ? new Date(movie.added).getTime() : Number.NaN;
+	if (Number.isNaN(addedTimestamp)) return 'inCinemas';
 
+	const daysSinceAdded = (now.getTime() - addedTimestamp) / (1000 * 60 * 60 * 24);
 	if (daysSinceAdded > 120) return 'released';
-	if (daysSinceAdded > 30) return 'inCinemas';
-
 	return 'inCinemas';
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 		Tv,
 		Download,
 		AlertCircle,
+		PauseCircle,
 		Clock,
 		CheckCircle,
 		XCircle,
@@ -139,6 +140,7 @@
 			imported: { label: 'Imported', variant: 'badge-success', icon: CheckCircle },
 			streaming: { label: 'Streaming', variant: 'badge-info', icon: CheckCircle },
 			downloading: { label: 'Downloading', variant: 'badge-info', icon: Loader2 },
+			paused: { label: 'Paused', variant: 'badge-warning', icon: PauseCircle },
 			failed: { label: 'Failed', variant: 'badge-error', icon: XCircle },
 			rejected: { label: 'Rejected', variant: 'badge-warning', icon: AlertCircle },
 			removed: { label: 'Removed', variant: 'badge-ghost', icon: XCircle },
@@ -259,21 +261,14 @@
 						<Download class="h-6 w-6 text-accent" />
 					</div>
 					<div>
-						<div class="text-2xl font-bold">
-							{stats.activeDownloads + (stats.failedDownloads || 0)}
-						</div>
+						<div class="text-2xl font-bold">{stats.activeDownloads}</div>
 						<div class="text-sm text-base-content/70">Downloads</div>
 					</div>
 				</div>
 				<div class="mt-2 text-xs">
-					{#if stats.activeDownloads > 0 || (stats.failedDownloads || 0) > 0}
+					{#if stats.activeDownloads > 0}
 						<div class="flex flex-wrap gap-2">
-							{#if stats.activeDownloads > 0}
-								<span class="badge badge-sm badge-accent">{stats.activeDownloads} active</span>
-							{/if}
-							{#if (stats.failedDownloads || 0) > 0}
-								<span class="badge badge-sm badge-error">{stats.failedDownloads} failed</span>
-							{/if}
+							<span class="badge badge-sm badge-accent">{stats.activeDownloads} active</span>
 						</div>
 					{:else}
 						<span class="text-base-content/50">No active downloads</span>

--- a/src/routes/api/activity/[id]/details/+server.ts
+++ b/src/routes/api/activity/[id]/details/+server.ts
@@ -1,0 +1,25 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { activityService } from '$lib/server/activity';
+import { logger } from '$lib/logging';
+
+/**
+ * GET - Get details for a unified activity row.
+ * Expects the unified activity id (e.g. queue-*, history-*, monitoring-*).
+ */
+export const GET: RequestHandler = async ({ params }) => {
+	try {
+		const activityId = params.id?.trim();
+		if (!activityId) {
+			return json({ success: false, error: 'Missing activity id' }, { status: 400 });
+		}
+
+		const details = await activityService.getActivityDetails(activityId);
+		return json({ success: true, details });
+	} catch (err) {
+		logger.error('Error fetching activity details', err instanceof Error ? err : undefined, {
+			activityId: params.id
+		});
+		return json({ success: false, error: 'Failed to fetch activity details' }, { status: 500 });
+	}
+};

--- a/src/routes/api/activity/stream/+server.ts
+++ b/src/routes/api/activity/stream/+server.ts
@@ -53,6 +53,8 @@ function getQueueErrorFromPayload(payload: unknown): string | undefined {
 
 function mapQueueStatusToActivityStatus(status: string): ActivityStatus {
 	switch (status) {
+		case 'paused':
+			return 'paused';
 		case 'failed':
 			return 'failed';
 		case 'imported':

--- a/src/routes/api/dashboard/stream/+server.ts
+++ b/src/routes/api/dashboard/stream/+server.ts
@@ -7,16 +7,18 @@ import {
 	movies,
 	series,
 	episodes,
+	episodeFiles,
 	downloadQueue,
+	downloadHistory,
 	unmatchedFiles,
 	rootFolders
 } from '$lib/server/db/schema';
-import { count, eq, desc, and, not, inArray, sql, gte, ne } from 'drizzle-orm';
+import { count, eq, desc, and, inArray, sql, gte, ne } from 'drizzle-orm';
 import { activityService, mediaResolver } from '$lib/server/activity';
 import { extractReleaseGroup } from '$lib/server/indexers/parser/patterns/releaseGroup';
 import type { UnifiedActivity, ActivityStatus } from '$lib/types/activity';
 import type { RequestHandler } from '@sveltejs/kit';
-import { getMovieAvailabilityLevel, isMovieReleased } from '$lib/utils/movieAvailability';
+import { getMovieAvailabilityLevel } from '$lib/utils/movieAvailability';
 
 interface QueueItem {
 	id: string;
@@ -37,8 +39,6 @@ interface QueueItem {
 	errorMessage?: string | null;
 	isUpgrade?: boolean;
 }
-
-const TERMINAL_STATUSES = ['imported', 'removed'];
 
 function isQueueItem(value: unknown): value is QueueItem {
 	if (!value || typeof value !== 'object') return false;
@@ -65,6 +65,8 @@ function getQueueErrorFromPayload(payload: unknown): string | undefined {
 
 function mapQueueStatusToActivityStatus(status: string): ActivityStatus {
 	switch (status) {
+		case 'paused':
+			return 'paused';
 		case 'failed':
 			return 'failed';
 		case 'imported':
@@ -104,88 +106,121 @@ async function getDashboardStats() {
 		})
 		.from(episodes);
 
-	const today = new Date().toISOString().split('T')[0];
+	const now = new Date();
+	const today = now.toISOString().split('T')[0];
+	const currentYear = now.getFullYear();
+	const nowIso = now.toISOString();
+	const releasedMovieCondition = sql`(
+		${movies.year} IS NOT NULL
+		AND (
+			${movies.year} < ${currentYear}
+			OR (
+				${movies.year} = ${currentYear}
+				AND ${movies.added} IS NOT NULL
+				AND julianday(${movies.added}) IS NOT NULL
+				AND (julianday(${nowIso}) - julianday(${movies.added})) > 120
+			)
+		)
+	)`;
 
 	// Primary counters are monitored-only (actionable). We also keep a secondary
 	// unmonitored missing counter for visibility ("ignored" in UI).
-	const [airedMissingEpisodes, unairedEpisodes, unmonitoredAiredMissingEpisodes, missingMovies] =
+	const [
+		airedMissingEpisodes,
+		unairedEpisodes,
+		unmonitoredAiredMissingEpisodes,
+		missingMovieStats
+	] = await Promise.all([
+		db
+			.select({ count: count() })
+			.from(episodes)
+			.innerJoin(series, eq(episodes.seriesId, series.id))
+			.where(
+				and(
+					eq(episodes.hasFile, false),
+					eq(episodes.monitored, true),
+					eq(series.monitored, true),
+					ne(episodes.seasonNumber, 0),
+					sql`${episodes.airDate} <= ${today}`
+				)
+			),
+		db
+			.select({ count: count() })
+			.from(episodes)
+			.innerJoin(series, eq(episodes.seriesId, series.id))
+			.where(
+				and(
+					eq(episodes.hasFile, false),
+					eq(episodes.monitored, true),
+					eq(series.monitored, true),
+					ne(episodes.seasonNumber, 0),
+					sql`${episodes.airDate} > ${today}`
+				)
+			),
+		db
+			.select({ count: count() })
+			.from(episodes)
+			.innerJoin(series, eq(episodes.seriesId, series.id))
+			.where(
+				and(
+					eq(episodes.hasFile, false),
+					ne(episodes.seasonNumber, 0),
+					sql`${episodes.airDate} <= ${today}`,
+					sql`(${episodes.monitored} = 0 OR ${series.monitored} = 0)`
+				)
+			),
+		db
+			.select({
+				monitoredReleasedMissing: count(
+					sql`CASE WHEN ${movies.monitored} = 1 AND ${releasedMovieCondition} THEN 1 END`
+				),
+				monitoredUnreleased: count(
+					sql`CASE WHEN ${movies.monitored} = 1 AND NOT (${releasedMovieCondition}) THEN 1 END`
+				),
+				unmonitoredMissing: count(sql`CASE WHEN ${movies.monitored} = 0 THEN 1 END`)
+			})
+			.from(movies)
+			.where(eq(movies.hasFile, false))
+	]);
+	const monitoredReleasedMissingMovies = missingMovieStats?.[0]?.monitoredReleasedMissing || 0;
+	const monitoredUnreleasedMovies = missingMovieStats?.[0]?.monitoredUnreleased || 0;
+	const unmonitoredMissingMovies = missingMovieStats?.[0]?.unmonitoredMissing || 0;
+
+	const oneDayAgoIso = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+	const [downloadingDownloads, queuedDownloads, downloadThroughput, completedDownloads24h] =
 		await Promise.all([
 			db
 				.select({ count: count() })
-				.from(episodes)
-				.innerJoin(series, eq(episodes.seriesId, series.id))
-				.where(
-					and(
-						eq(episodes.hasFile, false),
-						eq(episodes.monitored, true),
-						eq(series.monitored, true),
-						ne(episodes.seasonNumber, 0),
-						sql`${episodes.airDate} <= ${today}`
-					)
-				),
-			db
-				.select({ count: count() })
-				.from(episodes)
-				.innerJoin(series, eq(episodes.seriesId, series.id))
-				.where(
-					and(
-						eq(episodes.hasFile, false),
-						eq(episodes.monitored, true),
-						eq(series.monitored, true),
-						ne(episodes.seasonNumber, 0),
-						sql`${episodes.airDate} > ${today}`
-					)
-				),
-			db
-				.select({ count: count() })
-				.from(episodes)
-				.innerJoin(series, eq(episodes.seriesId, series.id))
-				.where(
-					and(
-						eq(episodes.hasFile, false),
-						ne(episodes.seasonNumber, 0),
-						sql`${episodes.airDate} <= ${today}`,
-						sql`(${episodes.monitored} = 0 OR ${series.monitored} = 0)`
-					)
-				),
+				.from(downloadQueue)
+				.where(eq(downloadQueue.status, 'downloading')),
+			db.select({ count: count() }).from(downloadQueue).where(eq(downloadQueue.status, 'queued')),
 			db
 				.select({
-					monitored: movies.monitored,
-					year: movies.year,
-					added: movies.added
+					totalSpeed: sql<number>`COALESCE(SUM(${downloadQueue.downloadSpeed}), 0)`,
+					avgProgress: sql<number>`COALESCE(AVG(CAST(${downloadQueue.progress} AS REAL)), 0)`,
+					movingCount: count(sql`CASE WHEN ${downloadQueue.downloadSpeed} > 0 THEN 1 END`)
 				})
-				.from(movies)
-				.where(eq(movies.hasFile, false))
-		]);
-
-	let monitoredReleasedMissingMovies = 0;
-	let monitoredUnreleasedMovies = 0;
-	let unmonitoredMissingMovies = 0;
-
-	for (const movie of missingMovies) {
-		if (movie.monitored) {
-			if (isMovieReleased(movie)) {
-				monitoredReleasedMissingMovies += 1;
-			} else {
-				monitoredUnreleasedMovies += 1;
-			}
-		} else {
-			unmonitoredMissingMovies += 1;
-		}
-	}
-
-	const [activeDownloads, failedDownloads] = await Promise.all([
-		db
-			.select({ count: count() })
-			.from(downloadQueue)
-			.where(
-				and(
-					not(inArray(downloadQueue.status, TERMINAL_STATUSES)),
-					not(eq(downloadQueue.status, 'failed'))
+				.from(downloadQueue)
+				.where(eq(downloadQueue.status, 'downloading')),
+			db
+				.select({ count: count() })
+				.from(downloadHistory)
+				.where(
+					and(
+						eq(downloadHistory.status, 'imported'),
+						sql`COALESCE(${downloadHistory.importedAt}, ${downloadHistory.completedAt}, ${downloadHistory.createdAt}) >= ${oneDayAgoIso}`
+					)
 				)
-			),
-		db.select({ count: count() }).from(downloadQueue).where(eq(downloadQueue.status, 'failed'))
-	]);
+		]);
+	const activeDownloads = downloadingDownloads?.[0]?.count || 0;
+	const queuedDownloadCount = queuedDownloads?.[0]?.count || 0;
+	const downloadSpeedBytes = Number(downloadThroughput?.[0]?.totalSpeed || 0);
+	const downloadAvgProgress = Math.max(
+		0,
+		Math.min(100, Math.round(Number(downloadThroughput?.[0]?.avgProgress || 0) * 100))
+	);
+	const movingDownloads = downloadThroughput?.[0]?.movingCount || 0;
+	const completedDownloadsLast24h = completedDownloads24h?.[0]?.count || 0;
 
 	const [unmatchedCount] = await db.select({ count: count() }).from(unmatchedFiles);
 
@@ -237,8 +272,12 @@ async function getDashboardStats() {
 			unmonitoredMissing: unmonitoredAiredMissingEpisodes?.[0]?.count || 0,
 			monitored: episodeStats?.monitored || 0
 		},
-		activeDownloads: activeDownloads?.[0]?.count || 0,
-		failedDownloads: failedDownloads?.[0]?.count || 0,
+		activeDownloads,
+		queuedDownloads: queuedDownloadCount,
+		downloadSpeedBytes,
+		downloadAvgProgress,
+		movingDownloads,
+		completedDownloadsLast24h,
 		unmatchedFiles: unmatchedCount?.count || 0,
 		missingRootFolders: (missingMovieRoots?.[0]?.count || 0) + (missingSeriesRoots?.[0]?.count || 0)
 	};
@@ -288,6 +327,48 @@ async function getRecentlyAdded() {
 
 	const today = new Date().toISOString().split('T')[0];
 	const recentlyAddedSeriesIds = recentlyAddedSeries.map((s) => s.id);
+	const [recentRegularEpisodes, recentEpisodeFiles] =
+		recentlyAddedSeriesIds.length > 0
+			? await Promise.all([
+					db
+						.select({
+							id: episodes.id,
+							seriesId: episodes.seriesId
+						})
+						.from(episodes)
+						.where(
+							and(inArray(episodes.seriesId, recentlyAddedSeriesIds), ne(episodes.seasonNumber, 0))
+						),
+					db
+						.select({
+							seriesId: episodeFiles.seriesId,
+							episodeIds: episodeFiles.episodeIds
+						})
+						.from(episodeFiles)
+						.where(inArray(episodeFiles.seriesId, recentlyAddedSeriesIds))
+				])
+			: [[], []];
+	const recentEpisodeIdToSeries = new Map(recentRegularEpisodes.map((ep) => [ep.id, ep.seriesId]));
+	const recentEpisodeTotals = new Map<string, number>();
+	for (const episode of recentRegularEpisodes) {
+		recentEpisodeTotals.set(episode.seriesId, (recentEpisodeTotals.get(episode.seriesId) ?? 0) + 1);
+	}
+	const recentEpisodeFilesBySeries = new Map<string, Set<string>>();
+	for (const file of recentEpisodeFiles) {
+		const linkedEpisodeIds = (file.episodeIds as string[] | null) ?? [];
+		if (linkedEpisodeIds.length === 0) continue;
+		const seriesId = file.seriesId;
+		let tracked = recentEpisodeFilesBySeries.get(seriesId);
+		if (!tracked) {
+			tracked = new Set<string>();
+			recentEpisodeFilesBySeries.set(seriesId, tracked);
+		}
+		for (const episodeId of linkedEpisodeIds) {
+			if (recentEpisodeIdToSeries.get(episodeId) === seriesId) {
+				tracked.add(episodeId);
+			}
+		}
+	}
 	const recentlyAddedSeriesMissingCounts =
 		recentlyAddedSeriesIds.length > 0
 			? await db
@@ -315,6 +396,8 @@ async function getRecentlyAdded() {
 	);
 	const recentlyAddedSeriesWithMissing = recentlyAddedSeries.map((show) => ({
 		...show,
+		episodeCount: recentEpisodeTotals.get(show.id) ?? 0,
+		episodeFileCount: recentEpisodeFilesBySeries.get(show.id)?.size ?? 0,
 		airedMissingCount: recentlyAddedSeriesMissingMap.get(show.id) ?? 0
 	}));
 


### PR DESCRIPTION
## Summary

This pull request introduces several improvements and new features to the activity management and library components, focusing on supporting a new "paused" status for downloads, improving episode and season completeness logic, and optimizing performance in the unmatched library issues component.

**Activity Management Enhancements:**

* Added support for a new `paused` status for downloads throughout the activity components, including UI badges, filters, and actions. Users can now pause, resume, retry, or remove downloads directly from the activity table, with appropriate feedback and loading states. [[1]](diffhunk://#diff-9fa766b829b1749d102c2db87afb8d197c74b57eabc3e2ad02138dd8bff450e1R9) [[2]](diffhunk://#diff-9fa766b829b1749d102c2db87afb8d197c74b57eabc3e2ad02138dd8bff450e1R55) [[3]](diffhunk://#diff-3bff21496e6fc1728d593a679267affcf073a4e10f95de14c384ff26288ddbd3R84) [[4]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R9-R12) [[5]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R25-R36) [[6]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R46-R56) [[7]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R105) [[8]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R164-R195) [[9]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R212) [[10]](diffhunk://#diff-5c8bcecbe977c6d92544a95fab49ac859931518b582dd55d5411e1c3b71e7c91R331-R374) [[11]](diffhunk://#diff-f81b1a195e5094113c944f51ae2d03e8d954b90925f928e8b37117bde75da447R816-R817) [[12]](diffhunk://#diff-c4a443e185195f5a3fa8337439adeca3f3bfde34f68bb11885d960c952dcdb48R15) [[13]](diffhunk://#diff-9fa766b829b1749d102c2db87afb8d197c74b57eabc3e2ad02138dd8bff450e1L304-R306)

**Library and Episode Improvements:**

* Refactored episode file checks to use a derived `hasEpisodeFile` value, ensuring consistent logic and reducing code duplication in `EpisodeRow.svelte`. [[1]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9R154) [[2]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L233-R234) [[3]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L316-R317) [[4]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L403-R404) [[5]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L421-R427) [[6]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L446-R454) [[7]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L549-R550)
* Updated season completeness calculations in `SeasonAccordion.svelte` to count downloaded episodes based on the visible episode list rather than cached aggregates, improving accuracy when displaying progress.

**Unmatched Library Issues Optimization:**

* Consolidated and optimized issue and selection counting in `UnmatchedLibraryIssues.svelte` by introducing a single derived object (`issueCounts`) instead of multiple individual derived values, improving performance and maintainability. All references to selection now use a Set for faster lookups. [[1]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL34-R80) [[2]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL178-R207) [[3]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL213-R242) [[4]](diffhunk://#diff-7178f315eab3fe1d470c10345a4d144b96a3977e5935669a37b78fc0f5ac0caeL404-R433)

**Miscellaneous Fixes:**

* Adjusted movie availability logic to handle missing or invalid `added` dates more robustly, ensuring that current-year movies are only marked as "released" if they've been in the library for a sufficient period.
* Cleaned up and improved query logic in the main page server load function, including a more accurate SQL condition for determining released movies. [[1]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fR7-R16) [[2]](diffhunk://#diff-659bad89abcfa4d1a3ab6dd44ad50376ae5cf0522cb90f4d832813ee1787e26fL47-R68)

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Updated ActivityService to handle 'paused' status in mapQueueStatus.
- Extended ActivityStatus type to include 'paused'.
- Modified movie availability logic to account for current year movies.
- Enhanced dashboard and page server logic to include download queue metrics.
- Implemented pause and resume functionality for download activities.
- Updated UI components to reflect new paused state and metrics.
- Added API endpoint for fetching activity details.
- Refactored library TV page to compute episode stats more efficiently.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
