### PR TITLE
fix: send correct identifier to download clients for remove/pause/resume requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@
 # Set this to your access URL, e.g., http://192.168.1.100:3000
 # ORIGIN=http://localhost:3000
 
+# Optional public base URL used when generating external-facing links/paths.
+# If unset, ORIGIN is used where applicable.
+# PUBLIC_BASE_URL=http://localhost:3000
+
 # Timezone for scheduled tasks and logs (default: UTC)
 # Use TZ database names, e.g., America/New_York, Europe/London
 # TZ=UTC
@@ -40,6 +44,15 @@
 
 # Enable/disable file logging (default: true)
 # LOG_TO_FILE=true
+
+# Include error stack traces in logs.
+# Default: enabled in development, disabled in production.
+# Set true to always include, false to always suppress.
+# LOG_INCLUDE_STACK=false
+
+# Disable sensitive value redaction in logs (debug only, NOT recommended in production).
+# Default: false (redaction enabled).
+# LOG_SENSITIVE=false
 
 # =============================================================================
 # DATA DIRECTORIES (Advanced)
@@ -61,6 +74,13 @@
 # Docker default: /config/data/indexers/definitions
 # Manual install default: ./data/indexers/definitions
 # INDEXER_DEFINITIONS_PATH=./data/indexers/definitions
+# INDEXER_CUSTOM_DEFINITIONS_PATH=./data/indexers/definitions/custom
+
+# External lists preset directory - YAML list configurations
+# Docker default: /config/data/external-lists/presets
+# Manual install default: ./data/external-lists/presets
+# EXTERNAL_LISTS_PRESETS_PATH=./data/external-lists/presets
+# EXTERNAL_LISTS_CUSTOM_PRESETS_PATH=./data/external-lists/presets/custom
 
 # IMPORTANT: For Docker, avoid mounting /app as it contains application code.
 # Use the single ./config:/config mount which includes data, logs, and indexers.
@@ -104,6 +124,9 @@
 
 # Portal scan workers - for Stalker portal scanning (default: 2)
 # WORKER_MAX_PORTAL_SCANS=2
+
+# Channel sync workers - for Live TV channel sync tasks (default: 3)
+# WORKER_MAX_CHANNEL_SYNCS=3
 
 # Worker cleanup interval in milliseconds (default: 1800000 = 30 minutes)
 # WORKER_CLEANUP_MS=1800000

--- a/docs/advanced/environment-variables.md
+++ b/docs/advanced/environment-variables.md
@@ -68,11 +68,13 @@ ORIGIN=http://localhost         # Won't work externally
 
 ## Logging Configuration
 
-| Variable          | Description                 | Default |
-| ----------------- | --------------------------- | ------- |
-| `LOG_TO_FILE`     | Enable file logging         | true    |
-| `LOG_MAX_SIZE_MB` | Max log file size           | 10      |
-| `LOG_MAX_FILES`   | Number of log files to keep | 5       |
+| Variable            | Description                                       | Default                |
+| ------------------- | ------------------------------------------------- | ---------------------- |
+| `LOG_TO_FILE`       | Enable file logging                               | true                   |
+| `LOG_MAX_SIZE_MB`   | Max log file size                                 | 10                     |
+| `LOG_MAX_FILES`     | Number of log files to keep                       | 5                      |
+| `LOG_INCLUDE_STACK` | Include stack traces in logs (`true`/`false`)     | Dev: true, Prod: false |
+| `LOG_SENSITIVE`     | Disable redaction of secrets in logs (debug only) | false                  |
 
 ### Log Rotation
 
@@ -91,10 +93,13 @@ logs/
 
 ## Media Configuration
 
-| Variable                   | Description                  | Default                   |
-| -------------------------- | ---------------------------- | ------------------------- |
-| `FFPROBE_PATH`             | Path to ffprobe binary       | ffprobe (in PATH)         |
-| `INDEXER_DEFINITIONS_PATH` | Custom indexer YAML location | data/indexers/definitions |
+| Variable                             | Description                              | Default                            |
+| ------------------------------------ | ---------------------------------------- | ---------------------------------- |
+| `FFPROBE_PATH`                       | Path to ffprobe binary                   | ffprobe (in PATH)                  |
+| `INDEXER_DEFINITIONS_PATH`           | Base indexer YAML definitions path       | data/indexers/definitions          |
+| `INDEXER_CUSTOM_DEFINITIONS_PATH`    | Custom indexer definitions override path | data/indexers/definitions/custom   |
+| `EXTERNAL_LISTS_PRESETS_PATH`        | Smart list presets base directory        | data/external-lists/presets        |
+| `EXTERNAL_LISTS_CUSTOM_PRESETS_PATH` | Smart list custom presets directory      | data/external-lists/presets/custom |
 
 ### ffprobe Path
 
@@ -126,6 +131,7 @@ Control background task concurrency:
 | `WORKER_MAX_SEARCH`          | Max manual search workers         | 3                |
 | `WORKER_MAX_SUBTITLE_SEARCH` | Max subtitle search workers       | 3                |
 | `WORKER_MAX_PORTAL_SCANS`    | Max portal scan workers           | 2                |
+| `WORKER_MAX_CHANNEL_SYNCS`   | Max Live TV channel sync workers  | 3                |
 | `WORKER_CLEANUP_MS`          | Remove completed tasks after (ms) | 1800000 (30 min) |
 | `WORKER_MAX_LOGS`            | Max log entries per worker type   | 1000             |
 
@@ -250,6 +256,8 @@ FFPROBE_PATH=/usr/bin/ffprobe
 LOG_TO_FILE=true
 LOG_MAX_SIZE_MB=10
 LOG_MAX_FILES=5
+LOG_INCLUDE_STACK=false
+LOG_SENSITIVE=false
 
 # Workers
 WORKER_MAX_STREAMS=10
@@ -259,6 +267,7 @@ WORKER_MAX_MONITORING=5
 WORKER_MAX_SEARCH=3
 WORKER_MAX_SUBTITLE_SEARCH=3
 WORKER_MAX_PORTAL_SCANS=2
+WORKER_MAX_CHANNEL_SYNCS=3
 WORKER_CLEANUP_MS=1800000
 WORKER_MAX_LOGS=1000
 

--- a/docs/configuration/settings-reference.md
+++ b/docs/configuration/settings-reference.md
@@ -25,12 +25,14 @@ If deploying without Docker, or if you want to pass the environment variables to
 
 ### Logging
 
-| Variable          | Default  | Description                       |
-| ----------------- | -------- | --------------------------------- |
-| `LOG_DIR`         | `./logs` | Log file directory                |
-| `LOG_MAX_SIZE_MB` | `10`     | Max log file size before rotation |
-| `LOG_MAX_FILES`   | `5`      | Number of rotated logs to keep    |
-| `LOG_TO_FILE`     | `true`   | Enable/disable file logging       |
+| Variable            | Default                    | Description                                        |
+| ------------------- | -------------------------- | -------------------------------------------------- |
+| `LOG_DIR`           | `./logs`                   | Log file directory                                 |
+| `LOG_MAX_SIZE_MB`   | `10`                       | Max log file size before rotation                  |
+| `LOG_MAX_FILES`     | `5`                        | Number of rotated logs to keep                     |
+| `LOG_TO_FILE`       | `true`                     | Enable/disable file logging                        |
+| `LOG_INCLUDE_STACK` | Dev: `true`, Prod: `false` | Force include/suppress error stack traces          |
+| `LOG_SENSITIVE`     | `false`                    | Set `true` to bypass secret redaction (debug only) |
 
 ### Media Info
 
@@ -44,14 +46,18 @@ If ffprobe is not in your PATH, specify the full path.
 
 Controls concurrency for background tasks.
 
-| Variable                | Default   | Description                      |
-| ----------------------- | --------- | -------------------------------- |
-| `WORKER_MAX_STREAMS`    | `10`      | Max concurrent stream resolution |
-| `WORKER_MAX_IMPORTS`    | `5`       | Max concurrent file imports      |
-| `WORKER_MAX_SCANS`      | `2`       | Max concurrent library scans     |
-| `WORKER_MAX_MONITORING` | `5`       | Max concurrent monitoring tasks  |
-| `WORKER_CLEANUP_MS`     | `1800000` | Worker cleanup interval (30 min) |
-| `WORKER_MAX_LOGS`       | `1000`    | Max log entries per worker       |
+| Variable                     | Default   | Description                      |
+| ---------------------------- | --------- | -------------------------------- |
+| `WORKER_MAX_STREAMS`         | `10`      | Max concurrent stream resolution |
+| `WORKER_MAX_IMPORTS`         | `5`       | Max concurrent file imports      |
+| `WORKER_MAX_SCANS`           | `2`       | Max concurrent library scans     |
+| `WORKER_MAX_MONITORING`      | `5`       | Max concurrent monitoring tasks  |
+| `WORKER_MAX_SEARCH`          | `3`       | Max concurrent search tasks      |
+| `WORKER_MAX_SUBTITLE_SEARCH` | `3`       | Max concurrent subtitle searches |
+| `WORKER_MAX_PORTAL_SCANS`    | `2`       | Max concurrent portal scans      |
+| `WORKER_MAX_CHANNEL_SYNCS`   | `3`       | Max concurrent channel syncs     |
+| `WORKER_CLEANUP_MS`          | `1800000` | Worker cleanup interval (30 min) |
+| `WORKER_MAX_LOGS`            | `1000`    | Max log entries per worker       |
 
 **Tuning tips:**
 

--- a/src/lib/server/indexers/http/EncodingUtils.ts
+++ b/src/lib/server/indexers/http/EncodingUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import iconv from 'iconv-lite';
+import { logger } from '$lib/logging/index.js';
 
 // Encoding name normalization mapping
 const ENCODING_ALIASES: Record<string, string> = {
@@ -93,7 +94,7 @@ export function decodeBuffer(
 			};
 		} catch {
 			// Fall through to UTF-8 if decoding fails
-			console.warn(`Failed to decode with ${normalizedEncoding}, falling back to UTF-8`);
+			logger.warn(`Failed to decode with ${normalizedEncoding}, falling back to UTF-8`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

This pull request introduces several improvements and new features across logging, download queue management, configuration, and UI data freshness. The most notable changes are the addition of sensitive value redaction in logs (with an option to disable for debugging), improved handling of download client identifiers, new environment variables for configuration, and enhancements to the activity page to ensure up-to-date data.

**Logging and Security Improvements:**

* Added automatic redaction of sensitive values (such as API keys, passwords, tokens, etc.) from logs in `src/lib/logging/index.ts`, with the ability to bypass redaction using the new `LOG_SENSITIVE` environment variable. Also, improved error stack trace inclusion control via `LOG_INCLUDE_STACK`. [[1]](diffhunk://#diff-857465318a59146f019471c84092fa4f851e8778aa5d91e5d9855e62f8a654e7R38-R191) [[2]](diffhunk://#diff-857465318a59146f019471c84092fa4f851e8778aa5d91e5d9855e62f8a654e7L56-R231)
* Updated `.env.example` and documentation to include `LOG_INCLUDE_STACK` and `LOG_SENSITIVE` variables, explaining their purpose and defaults. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR48-R56) [[2]](diffhunk://#diff-1a39172d79244c66077479357f2e5db072e37e87742da1e0dfeef97a8eb7c480L72-R77) [[3]](diffhunk://#diff-1a39172d79244c66077479357f2e5db072e37e87742da1e0dfeef97a8eb7c480R259-R260)

**Download Queue and Client Management:**

* Refactored `DownloadMonitorService` to consistently resolve the correct download identifier (infoHash for torrents, downloadId for usenet) when issuing pause, resume, or remove commands to download clients, improving compatibility and reliability. [[1]](diffhunk://#diff-9604f7e4ebd3c7345324e5f9fdc94882aae65c0ec85375ee3d725258ad42643eL1426-R1445) [[2]](diffhunk://#diff-9604f7e4ebd3c7345324e5f9fdc94882aae65c0ec85375ee3d725258ad42643eL1470-R1478) [[3]](diffhunk://#diff-9604f7e4ebd3c7345324e5f9fdc94882aae65c0ec85375ee3d725258ad42643eL1503-R1512) [[4]](diffhunk://#diff-9604f7e4ebd3c7345324e5f9fdc94882aae65c0ec85375ee3d725258ad42643eR1524-R1543)
* Enhanced logging for download client removal failures, providing clearer messages and context for easier troubleshooting.

**Configuration and Documentation:**

* Added new environment variables for advanced configuration, including `PUBLIC_BASE_URL`, `INDEXER_CUSTOM_DEFINITIONS_PATH`, `EXTERNAL_LISTS_PRESETS_PATH`, `EXTERNAL_LISTS_CUSTOM_PRESETS_PATH`, and `WORKER_MAX_CHANNEL_SYNCS`, with corresponding updates to `.env.example` and documentation files. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR24-R27) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR77-R83) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR128-R130) [[4]](diffhunk://#diff-1a39172d79244c66077479357f2e5db072e37e87742da1e0dfeef97a8eb7c480L95-R102) [[5]](diffhunk://#diff-1a39172d79244c66077479357f2e5db072e37e87742da1e0dfeef97a8eb7c480R134) [[6]](diffhunk://#diff-1a39172d79244c66077479357f2e5db072e37e87742da1e0dfeef97a8eb7c480R270) [[7]](diffhunk://#diff-52ca67866e6544aa18472119bb9bea39ec9ff79631bc48e9550b189d3e0a7c28L48-R58)

**UI and Data Freshness:**

* Improved the `/activity` page (`src/routes/activity/+page.svelte`) to automatically refresh data on mount, tab focus, visibility change, and page show events, preventing display of stale client-side data after navigation or inactivity. [[1]](diffhunk://#diff-d1f2eaae26ea20535172f770d1268a5f526ec525c1048dd067751f159de006e0R3) [[2]](diffhunk://#diff-d1f2eaae26ea20535172f770d1268a5f526ec525c1048dd067751f159de006e0R42) [[3]](diffhunk://#diff-d1f2eaae26ea20535172f770d1268a5f526ec525c1048dd067751f159de006e0R255-R293)
* Enhanced error handling in the activity page's remove action to display more informative error messages based on API response content.

**Miscellaneous:**

* Replaced a direct `console.warn` with the unified logger in `EncodingUtils.ts` for consistent logging output. [[1]](diffhunk://#diff-2cd6c60c8288d90927b7218839df9ce6adf7a27f316ddac8340de1b68167a0c7R9) [[2]](diffhunk://#diff-2cd6c60c8288d90927b7218839df9ce6adf7a27f316ddac8340de1b68167a0c7L96-R97)

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Add structured log redaction for sensitive values (API keys, passwords, tokens) across all log output with LOG_SENSITIVE env var bypass
- Switch EncodingUtils.ts from console.warn to structured logger
- Add LOG_INCLUDE_STACK env var for controlling error stack trace output
- Refresh activity page data on mount/focus/visibility to prevent stale state after navigation
- Surface server error messages in activity remove action UI
- Document new env vars (LOG_SENSITIVE, LOG_INCLUDE_STACK, WORKER_MAX_CHANNEL_SYNCS, EXTERNAL_LISTS_*, INDEXER_CUSTOM_*, PUBLIC_BASE_URL) in .env.example, settings-reference, and environment-variables docs

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [x] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [x] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
