### PR TITLE
fix(search): improve movie ID search reliability on Newznab indexers

### DIFF
--- a/src/lib/components/search/InteractiveSearchModal.svelte
+++ b/src/lib/components/search/InteractiveSearchModal.svelte
@@ -522,7 +522,7 @@
 								{/if}
 								{#if meta.afterFiltering !== undefined}
 									<div class="flex justify-between">
-										<span>3. After season/category filter:</span>
+										<span>3. After relevance filters (season/category/ID/title/year):</span>
 										<span class="font-mono"
 											>{meta.afterFiltering}
 											{#if meta.afterDedup !== undefined && meta.afterFiltering < meta.afterDedup}


### PR DESCRIPTION
## Summary

This pull request introduces improvements to movie search handling in the `SearchOrchestrator`, focusing on smarter ID-based searches, stricter year filtering, and better supplementation of results with text-based variants. It also adds new tests to ensure these behaviors are robust and correctly implemented.

### Movie search improvements

* Enhanced ID-based movie search: If an ID search with query/year returns no results, the orchestrator now retries with only IDs before falling back to text search, addressing over-constraining issues with some Newznab providers.
* For interactive movie searches, when ID results are found, the orchestrator supplements them with text-based variants to surface additional releases, mimicking NZBHydra behavior.

### Filtering logic enhancements

* In `filterByIdOrTitleMatch`, movie releases are now strictly filtered by year whenever a year can be parsed from the release title, even if title variants aren't provided, ensuring more accurate results.
* Refactored parsing logic to cache parsed release titles for efficiency during filtering.

### Testing

* Added tests for retrying movie ID searches without query/year and for supplementing ID results with text variants in interactive searches.
* Added tests verifying strict year filtering for movies and handling of releases with unknown years.

### UI update

* Updated the UI label in `InteractiveSearchModal.svelte` to clarify that relevance filters include season, category, ID, title, and year.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Retry movie ID searches without q/year when initial attempt returns empty
- Supplement interactive movie ID results with text variants (NZBHydra-style)
- Enforce strict year matching for movies when year is parseable
- Add lazy parsing optimization to avoid redundant parseRelease() calls

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
