### PR TITLE
fix: improve clipboard copy functionality and enhance user feedback in settings page

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -339,6 +339,7 @@ const customHandler: Handle = async ({ event, resolve }) => {
 
 	// Attach to locals for use in routes
 	event.locals.correlationId = correlationId;
+	const pathname = event.url.pathname;
 
 	// Fetch session from Better Auth - check API key first, then cookie
 	let session = null;
@@ -387,7 +388,6 @@ const customHandler: Handle = async ({ event, resolve }) => {
 
 	// Check if setup is complete
 	const setupComplete = await isSetupComplete();
-	const pathname = event.url.pathname;
 
 	// Auth routes are already handled by authHandler
 	if (pathname.startsWith(AUTH_BASE_PATH)) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -548,7 +548,7 @@
 						<div
 							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
-							{#each Array(6) as _}
+							{#each Array.from({ length: 6 }, (_, index) => index) as index (index)}
 								<div class="aspect-2/3 overflow-hidden rounded-lg">
 									<Skeleton class="h-full w-full" />
 								</div>
@@ -569,7 +569,7 @@
 						<div
 							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
-							{#each recentlyAdded.movies as movie, index (movie.id)}
+							{#each recentlyAdded.movies as movie (movie.id)}
 								{@const typedMovie = movie as RecentlyAddedMovie}
 								<a
 									href={resolve(`/library/movie/${typedMovie.id}`)}
@@ -621,7 +621,7 @@
 						<div
 							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
-							{#each Array(6) as _}
+							{#each Array.from({ length: 6 }, (_, index) => index) as index (index)}
 								<div class="aspect-2/3 overflow-hidden rounded-lg">
 									<Skeleton class="h-full w-full" />
 								</div>
@@ -643,13 +643,14 @@
 							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
 							{#each recentlyAdded.series as show (show.id)}
+								{@const typedShow = show as RecentlyAddedSeries}
 								<a
-									href={resolve(`/library/tv/${show.id}`)}
+									href={resolve(`/library/tv/${typedShow.id}`)}
 									class="group relative aspect-2/3 overflow-hidden rounded-lg"
 								>
 									<TmdbImage
-										path={show.posterPath}
-										alt={show.title}
+										path={typedShow.posterPath}
+										alt={typedShow.title}
 										size="w185"
 										class="h-full w-full object-cover transition-transform group-hover:scale-105"
 									/>
@@ -657,16 +658,16 @@
 										class="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100"
 									>
 										<div class="absolute right-0 bottom-0 left-0 p-2">
-											<p class="truncate text-xs font-medium text-white">{show.title}</p>
+											<p class="truncate text-xs font-medium text-white">{typedShow.title}</p>
 											<p class="text-xs text-white/70">
-												{show.episodeFileCount ?? 0}/{show.episodeCount ?? 0} episodes
+												{typedShow.episodeFileCount ?? 0}/{typedShow.episodeCount ?? 0} episodes
 											</p>
 										</div>
 									</div>
-									{#if (show.airedMissingCount ?? 0) > 0}
+									{#if (typedShow.airedMissingCount ?? 0) > 0}
 										<div class="absolute top-1 right-1">
 											<span class="badge badge-xs badge-warning">
-												{show.airedMissingCount} missing
+												{typedShow.airedMissingCount} missing
 											</span>
 										</div>
 									{/if}
@@ -686,7 +687,7 @@
 							Missing Episodes
 						</h2>
 						<div class="divide-y divide-base-300">
-							{#each Array(5) as _}
+							{#each Array.from({ length: 5 }, (_, index) => index) as index (index)}
 								<div class="flex items-center gap-3 py-2">
 									<Skeleton variant="rect" class="h-12 w-8 shrink-0" />
 									<div class="min-w-0 flex-1">
@@ -708,12 +709,13 @@
 						</h2>
 						<div class="divide-y divide-base-300">
 							{#each missingEpisodes.slice(0, 5) as episode (episode.id)}
+								{@const typedEpisode = episode as MissingEpisode}
 								<div class="flex items-center gap-3 py-2">
-									{#if episode.series?.posterPath}
+									{#if typedEpisode.series?.posterPath}
 										<div class="h-12 w-8 shrink-0 overflow-hidden rounded">
 											<TmdbImage
-												path={episode.series.posterPath}
-												alt={episode.series.title || ''}
+												path={typedEpisode.series.posterPath}
+												alt={typedEpisode.series.title || ''}
 												size="w92"
 												class="h-full w-full object-cover"
 											/>
@@ -721,17 +723,17 @@
 									{/if}
 									<div class="min-w-0 flex-1">
 										<p class="font-medium wrap-break-word whitespace-normal">
-											{episode.series?.title || 'Unknown Series'}
+											{typedEpisode.series?.title || 'Unknown Series'}
 										</p>
 										<p class="wrap-break-words text-sm whitespace-normal text-base-content/70">
-											S{String(episode.seasonNumber).padStart(2, '0')}E{String(
-												episode.episodeNumber
+											S{String(typedEpisode.seasonNumber).padStart(2, '0')}E{String(
+												typedEpisode.episodeNumber
 											).padStart(2, '0')}
-											{episode.title ? ` - ${episode.title}` : ''}
+											{typedEpisode.title ? ` - ${typedEpisode.title}` : ''}
 										</p>
 									</div>
 									<div class="text-right text-sm text-base-content/50">
-										{formatDate(episode.airDate)}
+										{formatDate(typedEpisode.airDate)}
 									</div>
 								</div>
 							{/each}
@@ -785,7 +787,7 @@
 								</tr>
 							</thead>
 							<tbody>
-								{#each Array(6) as _}
+								{#each Array.from({ length: 6 }, (_, index) => index) as index (index)}
 									<tr>
 										<td><Skeleton variant="text" class="w-16" /></td>
 										<td><Skeleton variant="text" class="w-24" /></td>

--- a/src/routes/api/queue/+server.ts
+++ b/src/routes/api/queue/+server.ts
@@ -89,14 +89,16 @@ export const GET: RequestHandler = async ({ url }) => {
 						.from(series)
 						.where(inArray(series.id, seriesIds))
 				: [],
-			db
-				.select({
-					id: downloadClients.id,
-					name: downloadClients.name,
-					implementation: downloadClients.implementation
-				})
-				.from(downloadClients)
-				.where(inArray(downloadClients.id, clientIds))
+			clientIds.length
+				? db
+						.select({
+							id: downloadClients.id,
+							name: downloadClients.name,
+							implementation: downloadClients.implementation
+						})
+						.from(downloadClients)
+						.where(inArray(downloadClients.id, clientIds))
+				: []
 		]);
 
 		// Build lookup maps for O(1) access

--- a/src/routes/settings/system/+page.svelte
+++ b/src/routes/settings/system/+page.svelte
@@ -12,6 +12,8 @@
 		AlertCircle
 	} from 'lucide-svelte';
 	import type { PageData } from './$types';
+	import { copyToClipboard as copyTextToClipboard } from '$lib/utils/clipboard.js';
+	import { toasts } from '$lib/stores/toast.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -34,17 +36,18 @@
 	});
 
 	async function copyToClipboard(text: string, type: 'main' | 'streaming') {
-		try {
-			await navigator.clipboard.writeText(text);
-			if (type === 'main') {
-				copiedMain = true;
-				setTimeout(() => (copiedMain = false), 2000);
-			} else {
-				copiedStreaming = true;
-				setTimeout(() => (copiedStreaming = false), 2000);
-			}
-		} catch {
-			// Clipboard API not available
+		const copied = await copyTextToClipboard(text);
+		if (!copied) {
+			toasts.error('Failed to copy API key');
+			return;
+		}
+
+		if (type === 'main') {
+			copiedMain = true;
+			setTimeout(() => (copiedMain = false), 2000);
+		} else {
+			copiedStreaming = true;
+			setTimeout(() => (copiedStreaming = false), 2000);
 		}
 	}
 
@@ -283,7 +286,7 @@
 							disabled={!data.mainApiKey?.key}
 						>
 							{#if copiedMain}
-								<span class="text-xs text-success">Copied!</span>
+								<Check class="h-4 w-4 text-success" />
 							{:else}
 								<Copy class="h-4 w-4" />
 							{/if}
@@ -366,7 +369,7 @@
 							disabled={!data.streamingApiKey?.key}
 						>
 							{#if copiedStreaming}
-								<span class="text-xs text-success">Copied!</span>
+								<Check class="h-4 w-4 text-success" />
 							{:else}
 								<Copy class="h-4 w-4" />
 							{/if}


### PR DESCRIPTION
## Summary

This pull request introduces several improvements to the SvelteKit application's UI consistency, type safety, and error handling, particularly in the home page and system settings. The changes focus on improving skeleton loading states, enhancing type usage in templates, optimizing database queries, and providing better feedback for clipboard actions.

**UI improvements and type safety in home page:**

- Updated all skeleton loading placeholders in `+page.svelte` to use `Array.from({ length: N }, ...)` with keyed `each` blocks, ensuring unique keys and preventing Svelte warnings about duplicate keys. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL551-R551) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL624-R624) [[3]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL689-R690) [[4]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL788-R790)
- Improved type safety in `+page.svelte` by explicitly casting items in `each` blocks (e.g., `typedShow`, `typedEpisode`), ensuring correct property access and reducing potential runtime errors. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR646-R670) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR712-R736) [[3]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL572-R572)

**System settings clipboard improvements:**

- Replaced direct use of the Clipboard API with a utility function (`copyToClipboard`) that provides robust error handling and user feedback via toast notifications for failed copy attempts. [[1]](diffhunk://#diff-ab8c23e8946cfa4127a005534a453d4f8303ee9ef9fbd180528f13a15717d637R15-R16) [[2]](diffhunk://#diff-ab8c23e8946cfa4127a005534a453d4f8303ee9ef9fbd180528f13a15717d637L37-L48)
- Updated the copy button UI to show a checkmark icon instead of text when a key is successfully copied, enhancing visual feedback. [[1]](diffhunk://#diff-ab8c23e8946cfa4127a005534a453d4f8303ee9ef9fbd180528f13a15717d637L286-R289) [[2]](diffhunk://#diff-ab8c23e8946cfa4127a005534a453d4f8303ee9ef9fbd180528f13a15717d637L369-R372)

**Backend and routing improvements:**

- Optimized the queue API handler to only query the database for download clients if `clientIds` are present, preventing unnecessary database calls.
- Minor refactor in `src/hooks.server.ts` to move the `pathname` extraction earlier and avoid duplicate assignments. [[1]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR342) [[2]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aL390)

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->
- Fix API key copy button not working in System page
- Fix lint issues

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
