### PR TITLE
fix(workflows): enhance validation for stable source tags in GHCR retag workflow

### DIFF
--- a/.github/workflows/ghcr-retag-latest.yml
+++ b/.github/workflows/ghcr-retag-latest.yml
@@ -68,7 +68,8 @@ jobs:
             exit 1
           fi
 
-          if [[ "$SOURCE_TAG" != v* ]]; then
+          # Normalize plain semver input (e.g. 1.0.0 -> v1.0.0) without touching channel tags.
+          if [[ "$SOURCE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             SOURCE_TAG="v${SOURCE_TAG}"
           fi
 
@@ -162,24 +163,48 @@ jobs:
           echo "Version label: ${VERSION_LABEL:-<empty>}"
           echo "App version env: ${APP_VERSION_ENV:-<empty>}"
 
-          is_non_stable() {
+          is_dev_or_prerelease() {
             local value="$1"
             if [ -z "$value" ]; then
               return 1
             fi
-            # Block dev/edge channel values and common prerelease suffixes.
-            [[ "$value" =~ (^dev-|^edge-|-dev($|[.-])|-rc($|[.-])|-beta($|[.-])|-alpha($|[.-])|-pre($|[.-])|-preview($|[.-])) ]]
+            # Always block dev and prerelease variants.
+            [[ "$value" =~ (^dev-|-dev($|[.-])|-rc($|[.-])|-beta($|[.-])|-alpha($|[.-])|-pre($|[.-])|-preview($|[.-])) ]]
           }
 
-          if [ "$ALLOW_EDGE_ROLLBACK" != 'true' ] && is_non_stable "$SOURCE_TAG"; then
-            echo "Refusing retag: source tag appears to be dev/edge/prerelease."
+          is_edge_channel() {
+            local value="$1"
+            if [ -z "$value" ]; then
+              return 1
+            fi
+            [[ "$value" =~ (^edge-|-edge($|[.-])) ]]
+          }
+
+          IS_EDGE_ROLLBACK='false'
+          if [ "$ALLOW_EDGE_ROLLBACK" = 'true' ] && [[ "$SOURCE_TAG" =~ ^edge-[0-9]{8}-[0-9]+$ ]]; then
+            IS_EDGE_ROLLBACK='true'
+          fi
+
+          if is_dev_or_prerelease "$SOURCE_TAG"; then
+            echo "Refusing retag: source tag appears to be dev/prerelease."
             exit 1
           fi
 
-          if is_non_stable "$VERSION_LABEL" || is_non_stable "$APP_VERSION_ENV"; then
-            echo "Refusing retag: source image appears to be dev/edge/prerelease."
+          if [ "$IS_EDGE_ROLLBACK" != 'true' ] && is_edge_channel "$SOURCE_TAG"; then
+            echo "Refusing retag: source tag appears to be edge, but edge rollback is not enabled."
             exit 1
           fi
+
+          for value in "$VERSION_LABEL" "$APP_VERSION_ENV"; do
+            if is_dev_or_prerelease "$value"; then
+              echo "Refusing retag: source image metadata appears to be dev/prerelease."
+              exit 1
+            fi
+            if [ "$IS_EDGE_ROLLBACK" != 'true' ] && is_edge_channel "$value"; then
+              echo "Refusing retag: source image metadata appears to be edge, but edge rollback is not enabled."
+              exit 1
+            fi
+          done
 
       - name: Retag latest
         env:


### PR DESCRIPTION
## Summary

This pull request refines the tag validation and retagging logic in the `ghcr-retag-latest.yml` GitHub Actions workflow. The changes improve how tags and version labels are normalized and checked for stability, ensuring only appropriate images are retagged as "latest" and handling edge channel rollbacks more robustly.

Tag normalization and validation improvements:

* Updated the semver normalization logic to only prepend a `v` for plain semver tags (e.g., `1.0.0` becomes `v1.0.0`), without affecting channel tags.
* Split the tag stability checks into distinct functions: `is_dev_or_prerelease` (for dev/prerelease variants) and `is_edge_channel` (for edge channel variants), improving clarity and maintainability.
* Added explicit handling for edge channel rollbacks, allowing them only if `ALLOW_EDGE_ROLLBACK` is enabled and the tag matches the expected edge format.
* Improved validation logic to refuse retagging if either the tag or metadata is dev/prerelease, or edge (unless rollback is enabled), providing clearer error messages and exit conditions.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

#186 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->


## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

<img width="1044" height="324" alt="image" src="https://github.com/user-attachments/assets/8b837f88-5320-449a-8f46-cd7c104ad218" />
