### PR TITLE
fix(subtitles): authenticate before each OpenSubtitles API request

### DIFF
--- a/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
+++ b/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for OpenSubtitlesProvider authentication fix.
+ *
+ * Validates that search() and download() correctly authenticate before
+ * making API requests when username+password credentials are provided.
+ * (Bug #180: token was never set for search/download, only for test())
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenSubtitlesProvider } from './OpenSubtitlesProvider';
+import type { SubtitleProviderConfig } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<SubtitleProviderConfig> = {}): SubtitleProviderConfig {
+	return {
+		id: 'test-opensubtitles',
+		name: 'Test OpenSubtitles',
+		implementation: 'opensubtitles',
+		enabled: true,
+		priority: 1,
+		consecutiveFailures: 0,
+		requestsPerMinute: 30,
+		apiKey: 'test-api-key',
+		...overrides
+	};
+}
+
+/** Minimal valid search response */
+const SEARCH_RESPONSE = {
+	total_count: 1,
+	data: [
+		{
+			id: '1',
+			type: 'subtitle',
+			attributes: {
+				subtitle_id: '1',
+				language: 'en',
+				release: 'Inception.2010.BluRay',
+				url: 'https://opensubtitles.com/1',
+				files: [{ file_id: 123, file_name: 'Inception.srt' }],
+				feature_details: { title: 'Inception', movie_name: 'Inception' },
+				moviehash_match: false,
+				hearing_impaired: false,
+				foreign_parts_only: false,
+				from_trusted: true,
+				hd: true,
+				download_count: 50000,
+				ratings: 8,
+				upload_date: '2010-01-01',
+				uploader: { name: 'TestUploader' }
+			}
+		}
+	]
+};
+
+/** Minimal valid download response */
+const DOWNLOAD_RESPONSE = {
+	link: 'https://dl.opensubtitles.com/file.srt',
+	remaining: 19
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should send Authorization header on search() when username+password provided', async () => {
+		const config = makeConfig({ username: 'user', password: 'pass' });
+		const provider = new OpenSubtitlesProvider(config);
+
+		// Track all fetch calls
+		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
+
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
+			async (url: string, options: any) => {
+				const headers = options?.headers ?? {};
+				fetchCalls.push({ url, headers });
+
+				// Login endpoint
+				if (url.includes('/login')) {
+					return {
+						ok: true,
+						json: async () => ({
+							token: 'jwt-token-123',
+							base_url: 'https://api.opensubtitles.com/api/v1',
+							user: { allowed_downloads: 20, vip: false }
+						})
+					};
+				}
+
+				// Search endpoint
+				return {
+					ok: true,
+					json: async () => SEARCH_RESPONSE
+				};
+			}
+		);
+
+		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
+
+		const loginCall = fetchCalls.find((c) => c.url.includes('/login'));
+		const searchCall = fetchCalls.find((c) => c.url.includes('/subtitles'));
+
+		expect(loginCall).toBeDefined();
+		expect(searchCall).toBeDefined();
+		expect(searchCall!.headers['Authorization']).toBe('Bearer jwt-token-123');
+	});
+
+	it('should NOT send Authorization header on search() when only API key provided', async () => {
+		const config = makeConfig(); // no username/password
+		const provider = new OpenSubtitlesProvider(config);
+
+		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
+
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
+			async (url: string, options: any) => {
+				fetchCalls.push({ url, headers: options?.headers ?? {} });
+				return { ok: true, json: async () => SEARCH_RESPONSE };
+			}
+		);
+
+		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
+
+		const searchCall = fetchCalls.find((c) => c.url.includes('/subtitles'));
+		expect(searchCall).toBeDefined();
+		expect(searchCall!.headers['Authorization']).toBeUndefined();
+		// Only the Api-Key header should be present
+		expect(searchCall!.headers['Api-Key']).toBe('test-api-key');
+	});
+
+	it('should send Authorization header on download() when username+password provided', async () => {
+		const config = makeConfig({ username: 'user', password: 'pass' });
+		const provider = new OpenSubtitlesProvider(config);
+
+		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
+
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
+			async (url: string, options: any) => {
+				fetchCalls.push({ url, headers: options?.headers ?? {} });
+
+				if (url.includes('/login')) {
+					return {
+						ok: true,
+						json: async () => ({
+							token: 'jwt-token-456',
+							base_url: 'https://api.opensubtitles.com/api/v1',
+							user: { allowed_downloads: 20, vip: false }
+						})
+					};
+				}
+				if (url.includes('/download')) {
+					return { ok: true, json: async () => DOWNLOAD_RESPONSE };
+				}
+				// Actual subtitle file download
+				return {
+					ok: true,
+					arrayBuffer: async () => new ArrayBuffer(8)
+				};
+			}
+		);
+
+		await provider.download({
+			providerId: 'test-opensubtitles',
+			providerName: 'OpenSubtitles',
+			providerSubtitleId: '123',
+			language: 'en',
+			title: 'Inception',
+			releaseName: 'Inception.BluRay',
+			isForced: false,
+			isHearingImpaired: false,
+			format: 'srt',
+			isHashMatch: false,
+			matchScore: 80,
+			scoreBreakdown: {
+				hashMatch: 0,
+				titleMatch: 50,
+				yearMatch: 20,
+				releaseGroupMatch: 0,
+				sourceMatch: 10,
+				codecMatch: 0,
+				hiPenalty: 0,
+				forcedBonus: 0
+			}
+		});
+
+		const downloadCall = fetchCalls.find((c) => c.url.includes('/download'));
+		expect(downloadCall).toBeDefined();
+		expect(downloadCall!.headers['Authorization']).toBe('Bearer jwt-token-456');
+	});
+
+	it('should cache token and not re-authenticate on repeated calls', async () => {
+		const config = makeConfig({ username: 'user', password: 'pass' });
+		const provider = new OpenSubtitlesProvider(config);
+
+		let loginCount = 0;
+
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (url: string) => {
+			if (url.includes('/login')) {
+				loginCount++;
+				return {
+					ok: true,
+					json: async () => ({
+						token: 'cached-token',
+						base_url: 'https://api.opensubtitles.com/api/v1',
+						user: { allowed_downloads: 20, vip: false }
+					})
+				};
+			}
+			return { ok: true, json: async () => SEARCH_RESPONSE };
+		});
+
+		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
+		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
+
+		// Login should only be called once — token is cached for 23h
+		expect(loginCount).toBe(1);
+	});
+});

--- a/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
+++ b/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
@@ -4,6 +4,7 @@
  * Validates that search() and download() correctly authenticate before
  * making API requests when username+password credentials are provided.
  * (Bug #180: token was never set for search/download, only for test())
+ *
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
+++ b/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
@@ -79,7 +79,9 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
 		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (url: string, options: any) => {
+			async (...args: unknown[]) => {
+				const url = args[0] as string;
+				const options = args[1] as any;
 				const headers = options?.headers ?? {};
 				fetchCalls.push({ url, headers });
 
@@ -120,7 +122,9 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
 		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (url: string, options: any) => {
+			async (...args: unknown[]) => {
+				const url = args[0] as string;
+				const options = args[1] as any;
 				fetchCalls.push({ url, headers: options?.headers ?? {} });
 				return { ok: true, json: async () => SEARCH_RESPONSE };
 			}
@@ -142,7 +146,9 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
 		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (url: string, options: any) => {
+			async (...args: unknown[]) => {
+				const url = args[0] as string;
+				const options = args[1] as any;
 				fetchCalls.push({ url, headers: options?.headers ?? {} });
 
 				if (url.includes('/login')) {
@@ -201,7 +207,8 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 
 		let loginCount = 0;
 
-		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (url: string) => {
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (...args: unknown[]) => {
+			const url = args[0] as string;
 			if (url.includes('/login')) {
 				loginCount++;
 				return {

--- a/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
+++ b/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.test.ts
@@ -78,32 +78,30 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 		// Track all fetch calls
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
-		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (...args: unknown[]) => {
-				const url = args[0] as string;
-				const options = args[1] as any;
-				const headers = options?.headers ?? {};
-				fetchCalls.push({ url, headers });
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (...args: unknown[]) => {
+			const url = args[0] as string;
+			const options = args[1] as any;
+			const headers = options?.headers ?? {};
+			fetchCalls.push({ url, headers });
 
-				// Login endpoint
-				if (url.includes('/login')) {
-					return {
-						ok: true,
-						json: async () => ({
-							token: 'jwt-token-123',
-							base_url: 'https://api.opensubtitles.com/api/v1',
-							user: { allowed_downloads: 20, vip: false }
-						})
-					};
-				}
-
-				// Search endpoint
+			// Login endpoint
+			if (url.includes('/login')) {
 				return {
 					ok: true,
-					json: async () => SEARCH_RESPONSE
+					json: async () => ({
+						token: 'jwt-token-123',
+						base_url: 'https://api.opensubtitles.com/api/v1',
+						user: { allowed_downloads: 20, vip: false }
+					})
 				};
 			}
-		);
+
+			// Search endpoint
+			return {
+				ok: true,
+				json: async () => SEARCH_RESPONSE
+			};
+		});
 
 		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
 
@@ -121,14 +119,12 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
-		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (...args: unknown[]) => {
-				const url = args[0] as string;
-				const options = args[1] as any;
-				fetchCalls.push({ url, headers: options?.headers ?? {} });
-				return { ok: true, json: async () => SEARCH_RESPONSE };
-			}
-		);
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (...args: unknown[]) => {
+			const url = args[0] as string;
+			const options = args[1] as any;
+			fetchCalls.push({ url, headers: options?.headers ?? {} });
+			return { ok: true, json: async () => SEARCH_RESPONSE };
+		});
 
 		await provider.search({ title: 'Inception', year: 2010, languages: ['en'] });
 
@@ -145,32 +141,30 @@ describe('OpenSubtitlesProvider - authentication (Bug #180)', () => {
 
 		const fetchCalls: { url: string; headers: Record<string, string> }[] = [];
 
-		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(
-			async (...args: unknown[]) => {
-				const url = args[0] as string;
-				const options = args[1] as any;
-				fetchCalls.push({ url, headers: options?.headers ?? {} });
+		vi.spyOn(provider as any, 'fetchWithTimeout').mockImplementation(async (...args: unknown[]) => {
+			const url = args[0] as string;
+			const options = args[1] as any;
+			fetchCalls.push({ url, headers: options?.headers ?? {} });
 
-				if (url.includes('/login')) {
-					return {
-						ok: true,
-						json: async () => ({
-							token: 'jwt-token-456',
-							base_url: 'https://api.opensubtitles.com/api/v1',
-							user: { allowed_downloads: 20, vip: false }
-						})
-					};
-				}
-				if (url.includes('/download')) {
-					return { ok: true, json: async () => DOWNLOAD_RESPONSE };
-				}
-				// Actual subtitle file download
+			if (url.includes('/login')) {
 				return {
 					ok: true,
-					arrayBuffer: async () => new ArrayBuffer(8)
+					json: async () => ({
+						token: 'jwt-token-456',
+						base_url: 'https://api.opensubtitles.com/api/v1',
+						user: { allowed_downloads: 20, vip: false }
+					})
 				};
 			}
-		);
+			if (url.includes('/download')) {
+				return { ok: true, json: async () => DOWNLOAD_RESPONSE };
+			}
+			// Actual subtitle file download
+			return {
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(8)
+			};
+		});
 
 		await provider.download({
 			providerId: 'test-opensubtitles',

--- a/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.ts
+++ b/src/lib/server/subtitles/providers/opensubtitles/OpenSubtitlesProvider.ts
@@ -293,13 +293,16 @@ export class OpenSubtitlesProvider extends BaseSubtitleProvider {
 			throw new ConfigurationError('opensubtitles', 'API key is required');
 		}
 
+		// Ensure authentication is performed before every request
+		await this.authenticate();
+
 		const headers: Record<string, string> = {
 			'Api-Key': apiKey,
 			'User-Agent': DEFAULT_USER_AGENT,
 			Accept: 'application/json'
 		};
 
-		// Add auth token if available
+		// Add auth token if available (set by authenticate() when username+password provided)
 		if (this.token) {
 			headers['Authorization'] = `Bearer ${this.token}`;
 		}


### PR DESCRIPTION
## Problem

`search()` and `download()` never called `authenticate()`, so `this.token` was always `null` when username+password credentials were configured. Requests went out without the `Authorization` header, causing 401/403 errors.

Only `test()` called `authenticate()`, which is why the connection test could pass but actual subtitle retrieval would fail.

## Fix

Call `authenticate()` at the start of `makeRequest()` — the single code path all requests go through. Token caching (23h) is preserved, so no extra requests are made.

## Tests

Added 4 unit tests covering:
- `search()` sends `Authorization: Bearer` when username+password provided
- `search()` does NOT send `Authorization` when only API key provided
- `download()` sends `Authorization: Bearer` when username+password provided
- Token is cached — repeated calls only authenticate once

Fixes #180

---
Co-authored-by: Lautaro Busto <lautarobusto@gmail.com>
Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>