### PR TITLE
feat(livetv): add xstream URL normalization and player API URL builder

### DIFF
--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -4,20 +4,20 @@
  */
 
 .heroBanner {
-  padding: 4rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
+	padding: 4rem 0;
+	text-align: center;
+	position: relative;
+	overflow: hidden;
 }
 
 @media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+	.heroBanner {
+		padding: 2rem;
+	}
 }
 
 .buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -28,7 +28,6 @@ function HomepageHeader() {
 }
 
 export default function Home(): ReactNode {
-	const { siteConfig } = useDocusaurusContext();
 	return (
 		<Layout
 			title="Documentation"

--- a/docs-site/tsconfig.json
+++ b/docs-site/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
-  "exclude": [".docusaurus", "build"]
+	// This file is not used in compilation. It is here just for a nice editor experience.
+	"extends": "@docusaurus/tsconfig",
+	"compilerOptions": {
+		"baseUrl": "."
+	},
+	"exclude": [".docusaurus", "build"]
 }

--- a/src/lib/components/library/EpisodeRow.svelte
+++ b/src/lib/components/library/EpisodeRow.svelte
@@ -231,6 +231,11 @@
 			onDelete(episode);
 		}
 	}
+
+	function handleSubtitleAutoSearchClick() {
+		if (subtitleAutoSearching) return;
+		onSubtitleAutoSearch?.(episode);
+	}
 </script>
 
 <tr class="hover" class:opacity-60={!isAired(episode.airDate) && !hasEpisodeFile}>
@@ -435,7 +440,7 @@
 							onSync={onSubtitleSync}
 							onDelete={onSubtitleDelete}
 							onSearch={() => onSubtitleSearch?.(episode)}
-							onAutoSearch={() => onSubtitleAutoSearch?.(episode)}
+							onAutoSearch={handleSubtitleAutoSearchClick}
 						/>
 					</div>
 				</div>
@@ -493,7 +498,7 @@
 						onSync={onSubtitleSync}
 						onDelete={onSubtitleDelete}
 						onSearch={() => onSubtitleSearch?.(episode)}
-						onAutoSearch={() => onSubtitleAutoSearch?.(episode)}
+						onAutoSearch={handleSubtitleAutoSearchClick}
 					/>
 				</div>
 			</div>

--- a/src/lib/components/library/QualityBadge.svelte
+++ b/src/lib/components/library/QualityBadge.svelte
@@ -10,9 +10,22 @@
 
 	let { quality, mediaInfo = null, size = 'md' }: Props = $props();
 
-	const qualityText = $derived(getQualityDisplay(quality));
+	function sanitizeBadgeValue(value: string | null | undefined): string | null {
+		if (!value) return null;
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+
+		const normalized = trimmed.toLowerCase();
+		if (normalized === 'unknown' || normalized === 'n/a' || normalized === 'na') {
+			return null;
+		}
+
+		return trimmed;
+	}
+
+	const qualityText = $derived(sanitizeBadgeValue(getQualityDisplay(quality)));
 	const hdrText = $derived(getHdrDisplay(mediaInfo));
-	const sourceText = $derived(quality?.source || null);
+	const sourceText = $derived(sanitizeBadgeValue(quality?.source));
 
 	const sizeClasses = {
 		sm: 'badge-xs text-xs',

--- a/src/lib/components/livetv/EpgStatusPanel.svelte
+++ b/src/lib/components/livetv/EpgStatusPanel.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-	import { RefreshCw, AlertTriangle, Check, Info, Loader2, Clock, Database } from 'lucide-svelte';
+	import {
+		RefreshCw,
+		AlertTriangle,
+		Check,
+		Info,
+		Loader2,
+		Clock,
+		Database,
+		X
+	} from 'lucide-svelte';
 	import type { EpgStatus } from '$lib/types/livetv';
 
 	interface Props {
@@ -7,11 +16,26 @@
 		loading: boolean;
 		syncingAll: boolean;
 		syncingAccountIds: string[];
+		cancelRequestedAll: boolean;
+		cancelRequestedAccountIds: string[];
 		onSync: () => void;
 		onSyncAccount: (accountId: string) => void;
+		onCancel: () => void;
+		onCancelAccount: (accountId: string) => void;
 	}
 
-	let { status, loading, syncingAll, syncingAccountIds, onSync, onSyncAccount }: Props = $props();
+	let {
+		status,
+		loading,
+		syncingAll,
+		syncingAccountIds,
+		cancelRequestedAll,
+		cancelRequestedAccountIds,
+		onSync,
+		onSyncAccount,
+		onCancel,
+		onCancelAccount
+	}: Props = $props();
 
 	function formatRelativeTime(isoDate: string | null): string {
 		if (!isoDate) return 'Never';
@@ -55,7 +79,16 @@
 		await onSyncAccount(accountId);
 	}
 
+	async function handleCancel() {
+		await onCancel();
+	}
+
+	async function handleCancelAccount(accountId: string) {
+		await onCancelAccount(accountId);
+	}
+
 	const syncingAccountIdSet = $derived(new Set(syncingAccountIds));
+	const cancelRequestedAccountIdSet = $derived(new Set(cancelRequestedAccountIds));
 	const hasAccountSyncRunning = $derived(syncingAccountIds.length > 0);
 	const anySyncing = $derived(syncingAll || hasAccountSyncRunning);
 
@@ -205,18 +238,35 @@
 					<div class="badge badge-sm badge-warning">{accountsWithoutEpg} no EPG</div>
 				{/if}
 			</div>
-			<button class="btn btn-sm btn-primary" onclick={onSync} disabled={anySyncing}>
-				{#if syncingAll}
-					<Loader2 class="h-4 w-4 animate-spin" />
-					Syncing All...
-				{:else if hasAccountSyncRunning}
-					<Loader2 class="h-4 w-4 animate-spin" />
-					Sync In Progress...
-				{:else}
-					<RefreshCw class="h-4 w-4" />
-					Sync All Accounts
+			<div class="flex items-center gap-2">
+				{#if anySyncing}
+					<button
+						class="btn btn-outline btn-sm btn-error"
+						onclick={handleCancel}
+						disabled={cancelRequestedAll}
+					>
+						{#if cancelRequestedAll}
+							<Loader2 class="h-4 w-4 animate-spin" />
+							Cancelling...
+						{:else}
+							<X class="h-4 w-4" />
+							Cancel Sync
+						{/if}
+					</button>
 				{/if}
-			</button>
+				<button class="btn btn-sm btn-primary" onclick={onSync} disabled={anySyncing}>
+					{#if syncingAll}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Syncing All...
+					{:else if hasAccountSyncRunning}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Sync In Progress...
+					{:else}
+						<RefreshCw class="h-4 w-4" />
+						Sync All Accounts
+					{/if}
+				</button>
+			</div>
 		</div>
 
 		<!-- Account list -->
@@ -224,6 +274,8 @@
 			<div class="space-y-2">
 				{#each status.accounts as account (account.id)}
 					{@const isAccountSyncing = syncingAll || syncingAccountIdSet.has(account.id)}
+					{@const isCancelRequested =
+						cancelRequestedAll || cancelRequestedAccountIdSet.has(account.id)}
 					<div class="card bg-base-200">
 						<div class="card-body flex-row items-center justify-between p-4">
 							<div class="flex items-center gap-4">
@@ -256,12 +308,25 @@
 							</div>
 							<button
 								class="btn btn-ghost btn-sm"
-								onclick={() => handleSyncAccount(account.id)}
-								disabled={anySyncing}
-								title={anySyncing ? 'Another EPG sync is currently running' : 'Sync this account'}
+								onclick={() =>
+									isAccountSyncing
+										? handleCancelAccount(account.id)
+										: handleSyncAccount(account.id)}
+								disabled={isAccountSyncing ? isCancelRequested : anySyncing}
+								title={isAccountSyncing
+									? isCancelRequested
+										? 'Cancellation requested'
+										: 'Cancel sync for this account'
+									: anySyncing
+										? 'Another EPG sync is currently running'
+										: 'Sync this account'}
 							>
 								{#if isAccountSyncing}
-									<Loader2 class="h-4 w-4 animate-spin" />
+									{#if isCancelRequested}
+										<Loader2 class="h-4 w-4 animate-spin" />
+									{:else}
+										<X class="h-4 w-4" />
+									{/if}
 								{:else}
 									<RefreshCw class="h-4 w-4" />
 								{/if}

--- a/src/lib/components/livetv/LiveTvAccountModal.svelte
+++ b/src/lib/components/livetv/LiveTvAccountModal.svelte
@@ -120,7 +120,7 @@
 			// Common fields
 			name = account?.name ?? '';
 			enabled = account?.enabled ?? true;
-			epgUrl = account?.m3uConfig?.epgUrl ?? '';
+			epgUrl = account?.m3uConfig?.epgUrl ?? account?.xstreamConfig?.epgUrl ?? '';
 
 			// Stalker fields
 			portalUrl = account?.stalkerConfig?.portalUrl ?? '';
@@ -223,6 +223,9 @@
 				config.baseUrl = baseUrl.trim();
 				config.username = username.trim();
 				config.password = password.trim() || account?.xstreamConfig?.password || '';
+				if (epgUrl.trim()) {
+					config.epgUrl = epgUrl.trim();
+				}
 				break;
 			case 'm3u':
 				if (epgUrl.trim()) {

--- a/src/lib/components/livetv/forms/XstreamAccountForm.svelte
+++ b/src/lib/components/livetv/forms/XstreamAccountForm.svelte
@@ -173,7 +173,9 @@
 				{/if}
 			</div>
 			<div class="label py-1">
-				<span class="label-text-alt text-xs">Override EPG source (XMLTV format)</span>
+				<span class="label-text-alt block text-xs wrap-break-word whitespace-normal"
+					>Override EPG source (XMLTV format)</span
+				>
 			</div>
 		</div>
 

--- a/src/lib/components/subtitles/SubtitlePopover.svelte
+++ b/src/lib/components/subtitles/SubtitlePopover.svelte
@@ -1,13 +1,5 @@
 <script lang="ts">
-	import {
-		RefreshCw,
-		Trash2,
-		Search,
-		Subtitles,
-		Loader2,
-		CheckCircle2,
-		Clock3
-	} from 'lucide-svelte';
+	import { RefreshCw, Trash2, Search, Subtitles, Loader2, Clock3 } from 'lucide-svelte';
 	import SubtitleBadge from './SubtitleBadge.svelte';
 	import SubtitleSyncBadge from './SubtitleSyncBadge.svelte';
 
@@ -71,7 +63,6 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
 	tabindex="0"
 	role="dialog"

--- a/src/lib/components/subtitles/SubtitleSyncModal.svelte
+++ b/src/lib/components/subtitles/SubtitleSyncModal.svelte
@@ -75,16 +75,16 @@
 
 	// Bulk sync state
 	let bulkSyncStatus = $state<BulkSyncStatus>('idle');
-	let bulkSyncStates = $state(new SvelteMap<string, SubtitleSyncState>());
-	let bulkSyncResults = $state(new SvelteMap<string, { offsetMs: number; error?: string }>());
+	let bulkSyncStates = new SvelteMap<string, SubtitleSyncState>();
+	let bulkSyncResults = new SvelteMap<string, { offsetMs: number; error?: string }>();
 	let bulkSyncProgress = $state({ completed: 0, total: 0 });
 
 	// Group expansion state
-	let expandedGroups = $state(new SvelteSet<string>());
+	let expandedGroups = new SvelteSet<string>();
 
 	// Group subtitles by episode label
 	const groupedSubtitles = $derived.by(() => {
-		const groups = new Map<string, SubtitleItem[]>();
+		const groups = new SvelteMap<string, SubtitleItem[]>();
 
 		for (const sub of subtitles) {
 			const label = sub.label || 'Unknown';
@@ -103,11 +103,14 @@
 	$effect(() => {
 		if (open) {
 			bulkSyncStatus = 'idle';
-			bulkSyncStates = new SvelteMap();
-			bulkSyncResults = new SvelteMap();
+			bulkSyncStates.clear();
+			bulkSyncResults.clear();
 			bulkSyncProgress = { completed: 0, total: 0 };
 			// Expand all groups by default
-			expandedGroups = new SvelteSet(groupedSubtitles.keys());
+			expandedGroups.clear();
+			for (const label of groupedSubtitles.keys()) {
+				expandedGroups.add(label);
+			}
 		}
 	});
 
@@ -152,12 +155,11 @@
 		bulkSyncProgress = { completed: 0, total: ids.length };
 
 		// Initialize all as pending
-		const newStates = new SvelteMap<string, SubtitleSyncState>();
+		bulkSyncStates.clear();
 		for (const id of ids) {
-			newStates.set(id, 'pending');
+			bulkSyncStates.set(id, 'pending');
 		}
-		bulkSyncStates = newStates;
-		bulkSyncResults = new SvelteMap();
+		bulkSyncResults.clear();
 
 		onBulkSync(
 			ids,

--- a/src/lib/livetv/errorMessages.ts
+++ b/src/lib/livetv/errorMessages.ts
@@ -1,0 +1,103 @@
+import type { LiveTvProviderType } from '$lib/types/livetv';
+
+function extractHttpStatus(raw: string): number | null {
+	const match = raw.match(/\bHTTP\s+(\d{3})\b/i) ?? raw.match(/\b(\d{3})\b/);
+	if (!match) return null;
+	const status = Number.parseInt(match[1], 10);
+	return Number.isFinite(status) ? status : null;
+}
+
+function getProviderLabel(providerType?: LiveTvProviderType): string {
+	switch (providerType) {
+		case 'm3u':
+			return 'playlist';
+		case 'xstream':
+			return 'XStream server';
+		case 'stalker':
+			return 'Stalker portal';
+		case 'iptvorg':
+			return 'IPTV-Org source';
+		default:
+			return 'provider';
+	}
+}
+
+/**
+ * Normalize Live TV test errors into user-friendly messages for UI surfaces.
+ */
+export function toFriendlyLiveTvTestError(
+	error?: string | null,
+	providerType?: LiveTvProviderType
+): string {
+	const raw = (error ?? '').trim();
+	if (!raw) {
+		return 'Connection test failed. Please review the settings and try again.';
+	}
+
+	const msg = raw.toLowerCase();
+	const providerLabel = getProviderLabel(providerType);
+	const status = extractHttpStatus(raw);
+
+	if (msg.includes('account not found')) {
+		return 'Live TV account not found. Refresh the page and try again.';
+	}
+
+	if (
+		msg.includes('timed out') ||
+		msg.includes('timeout') ||
+		msg.includes('aborterror') ||
+		msg.includes('request timed out')
+	) {
+		return `Connection timed out while contacting the ${providerLabel}. Check URL and network access.`;
+	}
+
+	if (
+		msg.includes('fetch failed') ||
+		msg.includes('failed to fetch') ||
+		msg.includes('failed to connect') ||
+		msg.includes('econnrefused') ||
+		msg.includes('enotfound') ||
+		msg.includes('ehostunreach') ||
+		msg.includes('network error')
+	) {
+		return `Unable to reach the ${providerLabel}. Check host, port, protocol (http/https), and firewall.`;
+	}
+
+	if (
+		msg.includes('authentication failed') ||
+		msg.includes('invalid credentials') ||
+		msg.includes('unauthorized') ||
+		msg.includes('forbidden')
+	) {
+		return 'Authentication failed. Check username/password or access token.';
+	}
+
+	if (status === 401 || status === 403) {
+		return 'Authentication failed. Verify credentials and account permissions.';
+	}
+
+	if (status === 404) {
+		if (providerType === 'm3u') {
+			return 'Playlist URL was not found (HTTP 404). Check the full M3U URL and any required base path.';
+		}
+		return 'Endpoint not found (HTTP 404). Check the base URL/path for this provider.';
+	}
+
+	if (status !== null && status >= 500) {
+		return `The ${providerLabel} returned a server error (HTTP ${status}). Try again shortly or check provider status.`;
+	}
+
+	if (providerType === 'm3u' && msg.includes('no m3u url or file content')) {
+		return 'Provide an M3U playlist URL or upload playlist content before testing.';
+	}
+
+	if (providerType === 'm3u' && msg.includes('empty xmltv response')) {
+		return 'The EPG URL responded but returned empty data. Check that the XMLTV source is valid.';
+	}
+
+	if (providerType === 'm3u' && msg.includes('invalid xmltv')) {
+		return 'EPG URL is reachable, but it did not return valid XMLTV data.';
+	}
+
+	return raw;
+}

--- a/src/lib/logging/index.ts
+++ b/src/lib/logging/index.ts
@@ -3,6 +3,7 @@ import type { AsyncLocalStorage as NodeAsyncLocalStorage } from 'node:async_hook
 import pino, { stdSerializers, type Logger as PinoLogger, type LoggerOptions } from 'pino';
 
 import type { CapturedLogEntry } from './log-capture';
+import { PLACEHOLDER_PACKAGE_VERSION } from '$lib/version.js';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -135,6 +136,22 @@ function shouldIncludeErrorStack(): boolean {
 	if (configured === 'true') return true;
 	if (configured === 'false') return false;
 	return isDev();
+}
+
+function readVersion(value: string | undefined): string | null {
+	const normalized = value?.trim();
+	if (!normalized) return null;
+	if (normalized === '0.0.0') return null;
+	if (normalized === PLACEHOLDER_PACKAGE_VERSION) return null;
+	return normalized;
+}
+
+function resolveLogVersion(): string {
+	return (
+		readVersion(getRuntimeEnv('APP_VERSION')) ??
+		readVersion(getRuntimeEnv('npm_package_version')) ??
+		'dev-local'
+	);
 }
 
 function isRedactionBypassed(): boolean {
@@ -298,7 +315,7 @@ function getBasePinoOptions(): LoggerOptions {
 		base: {
 			service: 'cinephage',
 			env: getRuntimeEnv('NODE_ENV') || 'development',
-			version: getRuntimeEnv('npm_package_version') || '0.0.0'
+			version: resolveLogVersion()
 		},
 		timestamp: pino.stdTimeFunctions.isoTime,
 		messageKey: 'msg',

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -2906,6 +2906,7 @@ export const livetvAccounts = sqliteTable(
 			baseUrl: string;
 			username: string;
 			password: string;
+			epgUrl?: string;
 			authToken?: string;
 			tokenExpiry?: string;
 		}>(),
@@ -3010,6 +3011,7 @@ export const livetvChannels = sqliteTable(
 		xstreamData: text('xstream_data', { mode: 'json' }).$type<{
 			streamId: string;
 			streamType: string;
+			epgChannelId?: string;
 			directStreamUrl?: string;
 			containerExtension?: string;
 		}>(),

--- a/src/lib/server/livetv/LiveTvAccountManager.ts
+++ b/src/lib/server/livetv/LiveTvAccountManager.ts
@@ -9,6 +9,7 @@ import { and, eq, inArray, lte, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { epgPrograms, livetvAccounts, type LivetvAccountRecord } from '$lib/server/db/schema';
 import { createChildLogger } from '$lib/logging';
+import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
 import { randomUUID } from 'crypto';
 import { getProvider, getProviderForAccount } from './providers';
 import { liveTvEvents } from './LiveTvEvents';
@@ -316,9 +317,10 @@ export class LiveTvAccountManager implements BackgroundService {
 			};
 		} else if (input.providerType === 'xstream' && input.xstreamConfig) {
 			xstreamConfig = {
-				baseUrl: input.xstreamConfig.baseUrl.replace(/\/$/, ''),
+				baseUrl: input.xstreamConfig.baseUrl,
 				username: input.xstreamConfig.username,
-				password: input.xstreamConfig.password
+				password: input.xstreamConfig.password,
+				epgUrl: input.xstreamConfig.epgUrl
 			};
 		} else if (input.providerType === 'm3u' && input.m3uConfig) {
 			m3uConfig = {
@@ -547,7 +549,13 @@ export class LiveTvAccountManager implements BackgroundService {
 
 		try {
 			const provider = getProviderForAccount(account);
-			const result = await provider.testConnection(account);
+			const providerResult = await provider.testConnection(account);
+			const result = providerResult.success
+				? providerResult
+				: {
+						...providerResult,
+						error: toFriendlyLiveTvTestError(providerResult.error, account.providerType)
+					};
 
 			// Update account with test results
 			const now = new Date().toISOString();
@@ -576,7 +584,7 @@ export class LiveTvAccountManager implements BackgroundService {
 			const message = error instanceof Error ? error.message : String(error);
 			return {
 				success: false,
-				error: message
+				error: toFriendlyLiveTvTestError(message, account.providerType)
 			};
 		}
 	}

--- a/src/lib/server/livetv/epg/EpgScheduler.ts
+++ b/src/lib/server/livetv/epg/EpgScheduler.ts
@@ -213,7 +213,10 @@ export class EpgScheduler extends EventEmitter implements BackgroundService {
 			liveTvEvents.emitEpgSyncStarted();
 
 			const epgService = getEpgService();
-			const results = await epgService.syncAll();
+			const results = await epgService.syncAll({
+				shouldCancelAll: () => syncState.isCancelRequestedAll(),
+				shouldCancelAccount: (accountId) => syncState.isCancelRequestedForAccount(accountId)
+			});
 
 			const successful = results.filter((r) => r.success).length;
 			const totalAdded = results.reduce((sum, r) => sum + r.programsAdded, 0);

--- a/src/lib/server/livetv/epg/EpgService.ts
+++ b/src/lib/server/livetv/epg/EpgService.ts
@@ -38,6 +38,16 @@ const BATCH_SIZE = 1000;
 const DEFAULT_RETENTION_HOURS = 48;
 const DEFAULT_LOOKAHEAD_HOURS = 72;
 const DEFAULT_LOOKBACK_HOURS = DEFAULT_RETENTION_HOURS;
+export const EPG_SYNC_CANCELLED_MESSAGE = 'Sync cancelled by user';
+
+interface EpgSyncAccountOptions {
+	shouldCancel?: () => boolean;
+}
+
+interface EpgSyncAllOptions {
+	shouldCancelAll?: () => boolean;
+	shouldCancelAccount?: (accountId: string) => boolean;
+}
 
 export class EpgService {
 	/**
@@ -181,8 +191,16 @@ export class EpgService {
 	/**
 	 * Sync EPG data for a single account
 	 */
-	async syncAccount(accountId: string): Promise<EpgSyncResult> {
+	async syncAccount(
+		accountId: string,
+		options: EpgSyncAccountOptions = {}
+	): Promise<EpgSyncResult> {
 		const startTime = Date.now();
+		const throwIfCancelled = () => {
+			if (options.shouldCancel?.()) {
+				throw new Error(EPG_SYNC_CANCELLED_MESSAGE);
+			}
+		};
 
 		// Get account from new unified table
 		const account = await db
@@ -219,6 +237,7 @@ export class EpgService {
 				error: 'Account is disabled'
 			};
 		}
+		throwIfCancelled();
 
 		// Get the appropriate provider
 		const provider = getProvider(account.providerType);
@@ -282,7 +301,9 @@ export class EpgService {
 			const endTime = new Date(now.getTime() + DEFAULT_LOOKAHEAD_HOURS * 60 * 60 * 1000);
 
 			// Fetch EPG data from provider
+			throwIfCancelled();
 			const epgPrograms = await provider.fetchEpg!(liveTvAccount, rangeStart, endTime);
+			throwIfCancelled();
 
 			if (epgPrograms.length === 0) {
 				const accountStats = await this.getAccountEpgStats(accountId);
@@ -329,8 +350,16 @@ export class EpgService {
 			}
 
 			// Process and store EPG data
-			const result = await this.storeEpgData(accountId, epgPrograms, channelMap);
+			throwIfCancelled();
+			const result = await this.storeEpgData(
+				accountId,
+				epgPrograms,
+				channelMap,
+				options.shouldCancel
+			);
+			throwIfCancelled();
 			const autoAttachedCount = await this.autoAttachMissingLineupEpgSources(accountId);
+			throwIfCancelled();
 			const accountStats = await this.getAccountEpgStats(accountId);
 
 			logger.info(
@@ -365,6 +394,7 @@ export class EpgService {
 			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
+			const cancelled = message === EPG_SYNC_CANCELLED_MESSAGE;
 			logger.error(
 				{
 					accountId,
@@ -372,14 +402,16 @@ export class EpgService {
 					providerType: account.providerType,
 					error: message
 				},
-				'EPG sync failed'
+				cancelled ? 'EPG sync cancelled' : 'EPG sync failed'
 			);
 
-			// Update account status - sync failed
-			await this.updateAccountEpgStatus(accountId, {
-				success: false,
-				error: message
-			});
+			// Keep account status intact for user-initiated cancellations.
+			if (!cancelled) {
+				await this.updateAccountEpgStatus(accountId, {
+					success: false,
+					error: message
+				});
+			}
 
 			return {
 				success: false,
@@ -398,7 +430,7 @@ export class EpgService {
 	/**
 	 * Sync EPG data for all enabled accounts that support EPG
 	 */
-	async syncAll(): Promise<EpgSyncResult[]> {
+	async syncAll(options: EpgSyncAllOptions = {}): Promise<EpgSyncResult[]> {
 		const accounts = await db.select().from(livetvAccounts).where(eq(livetvAccounts.enabled, true));
 
 		logger.info(
@@ -411,9 +443,32 @@ export class EpgService {
 		const results: EpgSyncResult[] = [];
 
 		for (const account of accounts) {
+			if (options.shouldCancelAll?.()) {
+				logger.info('Stopping EPG all-accounts sync due to cancellation request');
+				break;
+			}
+
 			const provider = getProvider(account.providerType);
 			if (provider.hasEpgSupport()) {
-				const result = await this.syncAccount(account.id);
+				if (options.shouldCancelAccount?.(account.id)) {
+					results.push({
+						success: false,
+						accountId: account.id,
+						accountName: account.name,
+						providerType: account.providerType,
+						programsAdded: 0,
+						programsUpdated: 0,
+						programsRemoved: 0,
+						duration: 0,
+						error: EPG_SYNC_CANCELLED_MESSAGE
+					});
+					continue;
+				}
+
+				const result = await this.syncAccount(account.id, {
+					shouldCancel: () =>
+						Boolean(options.shouldCancelAll?.() || options.shouldCancelAccount?.(account.id))
+				});
 				results.push(result);
 			}
 		}
@@ -441,7 +496,8 @@ export class EpgService {
 	private async storeEpgData(
 		accountId: string,
 		epgProgramsData: EpgProgram[],
-		channelMap: Map<string, string>
+		channelMap: Map<string, string>,
+		shouldCancel?: () => boolean
 	): Promise<{ programsAdded: number; programsUpdated: number; programsRemoved: number }> {
 		let programsAdded = 0;
 		let programsUpdated = 0;
@@ -474,6 +530,10 @@ export class EpgService {
 		>();
 
 		for (const program of epgProgramsData) {
+			if (shouldCancel?.()) {
+				throw new Error(EPG_SYNC_CANCELLED_MESSAGE);
+			}
+
 			const localChannelId = channelMap.get(program.externalChannelId);
 			if (!localChannelId) {
 				unmatchedExternalChannelIds.add(program.externalChannelId);
@@ -555,6 +615,10 @@ export class EpgService {
 
 		// Upsert programs in batches
 		for (let i = 0; i < allPrograms.length; i += BATCH_SIZE) {
+			if (shouldCancel?.()) {
+				throw new Error(EPG_SYNC_CANCELLED_MESSAGE);
+			}
+
 			const batch = allPrograms.slice(i, i + BATCH_SIZE);
 			if (batch.length === 0) {
 				continue;

--- a/src/lib/server/livetv/epg/EpgSyncState.ts
+++ b/src/lib/server/livetv/epg/EpgSyncState.ts
@@ -9,22 +9,30 @@
 export interface EpgSyncStateSnapshot {
 	syncingAll: boolean;
 	syncingAccountIds: string[];
+	cancelRequestedAll: boolean;
+	cancelRequestedAccountIds: string[];
 }
 
 class EpgSyncState {
 	private syncingAll = false;
 	private readonly syncingAccountIds = new Set<string>();
+	private cancelRequestedAll = false;
+	private readonly cancelRequestedAccountIds = new Set<string>();
 
 	tryStartAll(): boolean {
 		if (this.syncingAll || this.syncingAccountIds.size > 0) {
 			return false;
 		}
 		this.syncingAll = true;
+		this.cancelRequestedAll = false;
+		this.cancelRequestedAccountIds.clear();
 		return true;
 	}
 
 	finishAll(): void {
 		this.syncingAll = false;
+		this.cancelRequestedAll = false;
+		this.cancelRequestedAccountIds.clear();
 	}
 
 	tryStartAccount(accountId: string): boolean {
@@ -32,11 +40,40 @@ class EpgSyncState {
 			return false;
 		}
 		this.syncingAccountIds.add(accountId);
+		this.cancelRequestedAccountIds.delete(accountId);
 		return true;
 	}
 
 	finishAccount(accountId: string): void {
 		this.syncingAccountIds.delete(accountId);
+		this.cancelRequestedAccountIds.delete(accountId);
+		if (this.syncingAccountIds.size === 0) {
+			this.cancelRequestedAll = false;
+		}
+	}
+
+	requestCancelAll(): boolean {
+		if (!this.syncingAll && this.syncingAccountIds.size === 0) {
+			return false;
+		}
+		this.cancelRequestedAll = true;
+		return true;
+	}
+
+	requestCancelAccount(accountId: string): boolean {
+		if (!this.syncingAll && !this.syncingAccountIds.has(accountId)) {
+			return false;
+		}
+		this.cancelRequestedAccountIds.add(accountId);
+		return true;
+	}
+
+	isCancelRequestedAll(): boolean {
+		return this.cancelRequestedAll;
+	}
+
+	isCancelRequestedForAccount(accountId: string): boolean {
+		return this.cancelRequestedAll || this.cancelRequestedAccountIds.has(accountId);
 	}
 
 	isSyncingAll(): boolean {
@@ -50,7 +87,9 @@ class EpgSyncState {
 	getSnapshot(): EpgSyncStateSnapshot {
 		return {
 			syncingAll: this.syncingAll,
-			syncingAccountIds: Array.from(this.syncingAccountIds)
+			syncingAccountIds: Array.from(this.syncingAccountIds),
+			cancelRequestedAll: this.cancelRequestedAll,
+			cancelRequestedAccountIds: Array.from(this.cancelRequestedAccountIds)
 		};
 	}
 }

--- a/src/lib/server/livetv/providers/XstreamProvider.ts
+++ b/src/lib/server/livetv/providers/XstreamProvider.ts
@@ -10,6 +10,7 @@ import { livetvAccounts, livetvChannels, livetvCategories } from '$lib/server/db
 import { and, eq, inArray, notInArray } from 'drizzle-orm';
 import { createChildLogger } from '$lib/logging';
 import { randomUUID } from 'crypto';
+import { XMLParser } from 'fast-xml-parser';
 
 const logger = createChildLogger({ logDomain: 'livetv' as const });
 import type {
@@ -27,6 +28,7 @@ import type {
 	XstreamChannelData
 } from '$lib/types/livetv';
 import { recordToAccount } from '../LiveTvAccountManager.js';
+import { buildXstreamPlayerApiUrl, normalizeXstreamBaseUrl } from './xstream-url.js';
 
 // XStream API Response Types
 interface XstreamAuthResponse {
@@ -85,6 +87,8 @@ interface XstreamEpgEntry {
 	description?: string;
 	name?: string;
 }
+
+type XstreamEpgTestStatus = NonNullable<NonNullable<LiveTvAccountTestResult['profile']>['epg']>;
 
 export class XstreamProvider implements LiveTvProvider {
 	readonly type = 'xstream';
@@ -167,6 +171,8 @@ export class XstreamProvider implements LiveTvProvider {
 
 			let categoryCount = 0;
 			let channelCount = 0;
+			const configuredEpgUrl = config.epgUrl?.trim();
+			const epg = await this.testConfiguredXmltvEpg(configuredEpgUrl || null);
 
 			try {
 				const [categories, streams] = await Promise.all([
@@ -202,7 +208,8 @@ export class XstreamProvider implements LiveTvProvider {
 					categoryCount,
 					expiresAt: expDate,
 					serverTimezone: result.server_info?.timezone || 'UTC',
-					streamVerified: false
+					streamVerified: false,
+					epg
 				}
 			};
 		} catch (error) {
@@ -381,6 +388,7 @@ export class XstreamProvider implements LiveTvProvider {
 				const xstreamData: XstreamChannelData = {
 					streamId: stream.stream_id.toString(),
 					streamType: stream.stream_type,
+					epgChannelId: stream.epg_channel_id,
 					directStreamUrl: stream.direct_source,
 					containerExtension: ''
 				};
@@ -547,7 +555,7 @@ export class XstreamProvider implements LiveTvProvider {
 				};
 			}
 
-			const baseUrl = config.baseUrl.replace(/\/$/, '');
+			const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
 			const format = config.outputFormat || 'ts';
 			const url = `${baseUrl}/live/${config.username}/${config.password}/${xstreamData.streamId}.${format}`;
 
@@ -578,6 +586,27 @@ export class XstreamProvider implements LiveTvProvider {
 				return [];
 			}
 
+			const configuredEpgUrl = config.epgUrl?.trim();
+			if (configuredEpgUrl) {
+				const xmltvPrograms = await this.fetchConfiguredXmltvEpg(
+					account.id,
+					configuredEpgUrl,
+					startTime,
+					endTime
+				);
+				if (xmltvPrograms.length > 0) {
+					return xmltvPrograms;
+				}
+
+				logger.warn(
+					{
+						accountId: account.id,
+						epgUrl: configuredEpgUrl
+					},
+					'[XstreamProvider] Configured XMLTV returned no programs, falling back to player_api EPG'
+				);
+			}
+
 			const channels = await db
 				.select()
 				.from(livetvChannels)
@@ -589,7 +618,7 @@ export class XstreamProvider implements LiveTvProvider {
 			}
 
 			const programs: EpgProgram[] = [];
-			const baseUrl = config.baseUrl.replace(/\/$/, '');
+			const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
 			let actionOrder: string[] = ['get_epg', 'get_simple_data_table', 'get_short_epg'];
 			const failedChannelSamples: Array<{ channelId: string; streamId: string }> = [];
 			const errorChannelSamples: Array<{ channelId: string; streamId: string; error: string }> = [];
@@ -741,7 +770,7 @@ export class XstreamProvider implements LiveTvProvider {
 				};
 			}
 
-			const baseUrl = config.baseUrl.replace(/\/$/, '');
+			const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
 			const startTimestamp = Math.floor(startTime.getTime() / 1000);
 			const url = `${baseUrl}/timeshift/${config.username}/${config.password}/${duration}/${startTimestamp}/${xstreamData.streamId}.ts`;
 
@@ -768,12 +797,16 @@ export class XstreamProvider implements LiveTvProvider {
 		actionOrder: string[]
 	): Promise<{ entries: XstreamEpgEntry[]; usedAction: string | null } | null> {
 		for (const action of actionOrder) {
-			const extraParams = action === 'get_short_epg' ? '&limit=200' : '';
-			const url =
-				`${baseUrl}/player_api.php?username=${encodeURIComponent(username)}` +
-				`&password=${encodeURIComponent(password)}&action=${action}&stream_id=${streamId}${extraParams}`;
+			const url = new URL('player_api.php', `${baseUrl}/`);
+			url.searchParams.set('username', username);
+			url.searchParams.set('password', password);
+			url.searchParams.set('action', action);
+			url.searchParams.set('stream_id', streamId);
+			if (action === 'get_short_epg') {
+				url.searchParams.set('limit', '200');
+			}
 
-			const response = await fetch(url, {
+			const response = await fetch(url.toString(), {
 				headers: {
 					'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
 				},
@@ -843,14 +876,325 @@ export class XstreamProvider implements LiveTvProvider {
 		}
 	}
 
+	private async testConfiguredXmltvEpg(epgUrl: string | null): Promise<XstreamEpgTestStatus> {
+		if (!epgUrl) {
+			return {
+				status: 'not_configured'
+			};
+		}
+
+		try {
+			const response = await fetch(epgUrl, {
+				headers: {
+					'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+				},
+				signal: AbortSignal.timeout(30000)
+			});
+
+			if (!response.ok) {
+				return {
+					status: 'unreachable',
+					source: 'configured',
+					error: `HTTP ${response.status}`
+				};
+			}
+
+			const xmlContent = await response.text();
+			if (!xmlContent.trim()) {
+				return {
+					status: 'unreachable',
+					source: 'configured',
+					error: 'Empty XMLTV response'
+				};
+			}
+
+			const parser = new XMLParser({
+				ignoreAttributes: false,
+				attributeNamePrefix: '@_',
+				textNodeName: '#text',
+				parseAttributeValue: false,
+				trimValues: true
+			});
+			const parsed = parser.parse(xmlContent);
+			if (!parsed?.tv) {
+				return {
+					status: 'unreachable',
+					source: 'configured',
+					error: 'Invalid XMLTV format: missing <tv> root'
+				};
+			}
+
+			return {
+				status: 'reachable',
+				source: 'configured'
+			};
+		} catch (error) {
+			return {
+				status: 'unreachable',
+				source: 'configured',
+				error: error instanceof Error ? error.message : String(error)
+			};
+		}
+	}
+
+	private async fetchConfiguredXmltvEpg(
+		accountId: string,
+		epgUrl: string,
+		startTime: Date,
+		endTime: Date
+	): Promise<EpgProgram[]> {
+		try {
+			logger.info({ accountId, epgUrl }, '[XstreamProvider] Fetching configured XMLTV EPG');
+
+			const response = await fetch(epgUrl, {
+				headers: {
+					'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+				},
+				signal: AbortSignal.timeout(60000)
+			});
+
+			if (!response.ok) {
+				throw new Error(`Failed to fetch XMLTV: HTTP ${response.status}`);
+			}
+
+			const xmlContent = await response.text();
+			if (!xmlContent.trim()) {
+				logger.warn({ accountId }, '[XstreamProvider] Configured XMLTV returned empty response');
+				return [];
+			}
+
+			const parser = new XMLParser({
+				ignoreAttributes: false,
+				attributeNamePrefix: '@_',
+				textNodeName: '#text',
+				parseAttributeValue: false,
+				trimValues: true
+			});
+			const parsed = parser.parse(xmlContent);
+			if (!parsed?.tv) {
+				logger.warn({ accountId }, '[XstreamProvider] Configured XMLTV missing <tv> root');
+				return [];
+			}
+
+			const channels = await db
+				.select()
+				.from(livetvChannels)
+				.where(eq(livetvChannels.accountId, accountId));
+
+			const channelMap = new Map<string, Map<string, { id: string; externalId: string }>>();
+			const normalizedLookup = new Map<string, Map<string, { id: string; externalId: string }>>();
+			const addChannelMapEntry = (
+				xmltvChannelId: string | undefined,
+				channelInfo: { id: string; externalId: string }
+			) => {
+				if (!xmltvChannelId) return;
+				const key = xmltvChannelId.trim();
+				if (!key) return;
+				if (!channelMap.has(key)) {
+					channelMap.set(key, new Map());
+				}
+				channelMap.get(key)!.set(channelInfo.id, channelInfo);
+			};
+			const addNormalizedLookupEntry = (
+				value: string | undefined,
+				channelInfo: { id: string; externalId: string }
+			) => {
+				const key = this.normalizeChannelLookupKey(value);
+				if (!key) return;
+				if (!normalizedLookup.has(key)) {
+					normalizedLookup.set(key, new Map());
+				}
+				normalizedLookup.get(key)!.set(channelInfo.id, channelInfo);
+			};
+
+			for (const channel of channels) {
+				const channelInfo = { id: channel.id, externalId: channel.externalId };
+				addChannelMapEntry(channel.xstreamData?.epgChannelId, channelInfo);
+				addChannelMapEntry(channel.externalId, channelInfo);
+				addNormalizedLookupEntry(channel.name, channelInfo);
+				addNormalizedLookupEntry(channel.externalId, channelInfo);
+				addNormalizedLookupEntry(channel.xstreamData?.epgChannelId, channelInfo);
+			}
+
+			const xmlChannels = Array.isArray(parsed.tv.channel)
+				? parsed.tv.channel
+				: parsed.tv.channel
+					? [parsed.tv.channel]
+					: [];
+			for (const xmlChannel of xmlChannels) {
+				const xmltvChannelId = xmlChannel?.['@_id']?.toString().trim();
+				if (!xmltvChannelId || channelMap.has(xmltvChannelId)) continue;
+
+				const resolvedMatches = new Map<string, { id: string; externalId: string }>();
+				const lookupKeys = new Set<string>();
+
+				const normalizedXmlId = this.normalizeChannelLookupKey(xmltvChannelId);
+				if (normalizedXmlId) {
+					lookupKeys.add(normalizedXmlId);
+				}
+
+				const displayNameValues = Array.isArray(xmlChannel?.['display-name'])
+					? xmlChannel['display-name']
+					: xmlChannel?.['display-name']
+						? [xmlChannel['display-name']]
+						: [];
+				for (const value of displayNameValues) {
+					const displayName = this.extractXmltvText(value);
+					const normalizedName = this.normalizeChannelLookupKey(displayName ?? undefined);
+					if (normalizedName) {
+						lookupKeys.add(normalizedName);
+					}
+				}
+
+				for (const key of lookupKeys) {
+					const matches = normalizedLookup.get(key);
+					if (!matches) continue;
+					for (const [channelId, channelInfo] of matches) {
+						resolvedMatches.set(channelId, channelInfo);
+					}
+				}
+
+				if (resolvedMatches.size > 0) {
+					channelMap.set(xmltvChannelId, resolvedMatches);
+				}
+			}
+
+			const programmes = Array.isArray(parsed.tv.programme)
+				? parsed.tv.programme
+				: parsed.tv.programme
+					? [parsed.tv.programme]
+					: [];
+			const programs: EpgProgram[] = [];
+
+			for (const programme of programmes) {
+				const xmltvChannelId = programme?.['@_channel']?.toString().trim();
+				if (!xmltvChannelId) continue;
+
+				const channelInfos = channelMap.get(xmltvChannelId);
+				if (!channelInfos || channelInfos.size === 0) continue;
+
+				const startRaw = programme?.['@_start'];
+				const endRaw = programme?.['@_stop'];
+				if (!startRaw || !endRaw) continue;
+
+				const programmeStart = this.parseXmltvTime(startRaw);
+				const programmeEnd = this.parseXmltvTime(endRaw);
+				if (!programmeStart || !programmeEnd) continue;
+				if (programmeEnd < startTime || programmeStart > endTime) continue;
+
+				const title = this.extractXmltvText(programme?.title) ?? 'Unknown';
+				const description = this.extractXmltvText(programme?.desc);
+				const category = this.extractXmltvText(programme?.category);
+
+				for (const channelInfo of channelInfos.values()) {
+					programs.push({
+						id: randomUUID(),
+						channelId: channelInfo.id,
+						externalChannelId: channelInfo.externalId,
+						accountId,
+						providerType: 'xstream',
+						title,
+						description: description ?? null,
+						category: category ?? null,
+						director: null,
+						actor: null,
+						startTime: programmeStart.toISOString(),
+						endTime: programmeEnd.toISOString(),
+						duration: Math.floor((programmeEnd.getTime() - programmeStart.getTime()) / 1000),
+						hasArchive: false,
+						cachedAt: new Date().toISOString(),
+						updatedAt: new Date().toISOString()
+					});
+				}
+			}
+
+			logger.info(
+				{
+					accountId,
+					programsFound: programs.length
+				},
+				'[XstreamProvider] Configured XMLTV EPG parsed successfully'
+			);
+
+			return programs;
+		} catch (error) {
+			logger.warn(
+				{
+					accountId,
+					epgUrl,
+					error: error instanceof Error ? error.message : String(error)
+				},
+				'[XstreamProvider] Configured XMLTV fetch failed'
+			);
+			return [];
+		}
+	}
+
+	private parseXmltvTime(timeStr: string): Date | null {
+		try {
+			const cleaned = timeStr.replace(/\s+/g, ' ').trim();
+			const match = cleaned.match(/^(\d{14})(?:\s*([+-]\d{4}|UTC))?$/);
+			if (!match) return null;
+
+			const dateStr = match[1];
+			const timezone = match[2];
+
+			const year = parseInt(dateStr.substring(0, 4), 10);
+			const month = parseInt(dateStr.substring(4, 6), 10) - 1;
+			const day = parseInt(dateStr.substring(6, 8), 10);
+			const hour = parseInt(dateStr.substring(8, 10), 10);
+			const minute = parseInt(dateStr.substring(10, 12), 10);
+			const second = parseInt(dateStr.substring(12, 14), 10);
+
+			const date = new Date(Date.UTC(year, month, day, hour, minute, second));
+			if (Number.isNaN(date.getTime())) return null;
+
+			if (timezone && timezone !== 'UTC') {
+				const tzOffsetHours = parseInt(timezone.substring(0, 3), 10);
+				const tzOffsetMinutes = parseInt(timezone.substring(3, 5), 10);
+				const totalOffsetMinutes =
+					tzOffsetHours * 60 + (tzOffsetHours < 0 ? -tzOffsetMinutes : tzOffsetMinutes);
+				date.setUTCMinutes(date.getUTCMinutes() - totalOffsetMinutes);
+			}
+
+			return date;
+		} catch {
+			return null;
+		}
+	}
+
+	private extractXmltvText(value: unknown): string | null {
+		if (!value) return null;
+		if (typeof value === 'string') return value;
+		if (typeof value === 'object' && value !== null) {
+			if ('#text' in value) {
+				return String((value as Record<string, unknown>)['#text']);
+			}
+			if (Array.isArray(value) && value.length > 0) {
+				return this.extractXmltvText(value[0]);
+			}
+		}
+		return null;
+	}
+
+	private normalizeChannelLookupKey(value: string | undefined): string | null {
+		if (!value) return null;
+		const normalized = value
+			.normalize('NFKD')
+			.replace(/[\u0300-\u036f]/g, '')
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '');
+		return normalized || null;
+	}
+
 	private async makeAuthRequest(account: LiveTvAccount): Promise<XstreamAuthResponse> {
 		const config = account.xstreamConfig;
 		if (!config) {
 			throw new Error('XStream config not found');
 		}
 
-		const baseUrl = config.baseUrl.replace(/\/$/, '');
-		const url = `${baseUrl}/player_api.php?username=${encodeURIComponent(config.username)}&password=${encodeURIComponent(config.password)}`;
+		const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
+		const url = buildXstreamPlayerApiUrl(config);
 
 		logger.debug({ url: baseUrl }, '[XstreamProvider] Making auth request');
 
@@ -868,8 +1212,8 @@ export class XstreamProvider implements LiveTvProvider {
 	}
 
 	private async fetchXstreamCategories(config: XstreamConfig): Promise<XstreamCategory[]> {
-		const baseUrl = config.baseUrl.replace(/\/$/, '');
-		const url = `${baseUrl}/player_api.php?username=${encodeURIComponent(config.username)}&password=${encodeURIComponent(config.password)}&action=get_live_categories`;
+		const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
+		const url = buildXstreamPlayerApiUrl(config, { action: 'get_live_categories' });
 
 		logger.debug({ serverUrl: baseUrl }, '[XstreamProvider] Fetching categories');
 
@@ -888,8 +1232,8 @@ export class XstreamProvider implements LiveTvProvider {
 	}
 
 	private async fetchXstreamStreams(config: XstreamConfig): Promise<XstreamStream[]> {
-		const baseUrl = config.baseUrl.replace(/\/$/, '');
-		const url = `${baseUrl}/player_api.php?username=${encodeURIComponent(config.username)}&password=${encodeURIComponent(config.password)}&action=get_live_streams`;
+		const baseUrl = normalizeXstreamBaseUrl(config.baseUrl);
+		const url = buildXstreamPlayerApiUrl(config, { action: 'get_live_streams' });
 
 		logger.info(
 			{ serverUrl: baseUrl },
@@ -914,8 +1258,10 @@ export class XstreamProvider implements LiveTvProvider {
 		config: XstreamConfig,
 		categoryId: string
 	): Promise<XstreamStream[]> {
-		const baseUrl = config.baseUrl.replace(/\/$/, '');
-		const url = `${baseUrl}/player_api.php?username=${encodeURIComponent(config.username)}&password=${encodeURIComponent(config.password)}&action=get_live_streams&category_id=${categoryId}`;
+		const url = buildXstreamPlayerApiUrl(config, {
+			action: 'get_live_streams',
+			category_id: categoryId
+		});
 
 		const response = await fetch(url, {
 			headers: {

--- a/src/lib/server/livetv/providers/xstream-url.test.ts
+++ b/src/lib/server/livetv/providers/xstream-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildXstreamPlayerApiUrl, normalizeXstreamBaseUrl } from './xstream-url.js';
+
+describe('normalizeXstreamBaseUrl', () => {
+	it('strips get.php endpoint input', () => {
+		expect(normalizeXstreamBaseUrl('http://ky-tv.cc:80/get.php?')).toBe('http://ky-tv.cc');
+	});
+
+	it('strips xmltv.php endpoint input', () => {
+		expect(normalizeXstreamBaseUrl('http://ky-tv.cc:80/xmltv.php?')).toBe('http://ky-tv.cc');
+	});
+
+	it('preserves panel base paths while stripping endpoint files', () => {
+		expect(normalizeXstreamBaseUrl('http://example.com/panel/get.php?username=test')).toBe(
+			'http://example.com/panel'
+		);
+	});
+});
+
+describe('buildXstreamPlayerApiUrl', () => {
+	it('prevents endpoint doubling when input already contains get.php', () => {
+		const url = buildXstreamPlayerApiUrl(
+			{
+				baseUrl: 'http://ky-tv.cc:80/get.php?',
+				username: 'user',
+				password: 'pass'
+			},
+			{ action: 'get_live_categories' }
+		);
+
+		expect(url).toContain('/player_api.php?');
+		expect(url).not.toContain('get.php?/player_api.php');
+		expect(url).toContain('username=user');
+		expect(url).toContain('password=pass');
+		expect(url).toContain('action=get_live_categories');
+	});
+});

--- a/src/lib/server/livetv/providers/xstream-url.ts
+++ b/src/lib/server/livetv/providers/xstream-url.ts
@@ -1,0 +1,52 @@
+import type { XstreamConfig } from '$lib/types/livetv';
+
+const XTREAM_ENDPOINT_FILES = new Set(['get.php', 'xmltv.php', 'player_api.php', 'panel_api.php']);
+
+/**
+ * Normalize user-supplied XStream URL input.
+ *
+ * Supports users pasting:
+ * - Server root (recommended): http://host:port
+ * - Endpoint URLs: get.php, xmltv.php, player_api.php
+ *
+ * Returns a clean server base path without trailing slash and without endpoint file names.
+ */
+export function normalizeXstreamBaseUrl(input: string): string {
+	const trimmed = input.trim();
+	if (!trimmed) return trimmed;
+
+	try {
+		const parsed = new URL(trimmed);
+		let pathname = parsed.pathname.replace(/\/+$/, '');
+
+		const lastSegment = pathname.split('/').filter(Boolean).pop()?.toLowerCase();
+		if (lastSegment && XTREAM_ENDPOINT_FILES.has(lastSegment)) {
+			pathname = pathname.slice(0, -lastSegment.length).replace(/\/+$/, '');
+		}
+
+		return `${parsed.origin}${pathname}`;
+	} catch {
+		// Fallback for unexpected non-URL strings.
+		return trimmed.replace(/[?#].*$/, '').replace(/\/+$/, '');
+	}
+}
+
+/**
+ * Build a robust player_api.php URL from XStream config and params.
+ */
+export function buildXstreamPlayerApiUrl(
+	config: Pick<XstreamConfig, 'baseUrl' | 'username' | 'password'>,
+	params: Record<string, string | number | boolean | null | undefined> = {}
+): string {
+	const normalizedBaseUrl = normalizeXstreamBaseUrl(config.baseUrl);
+	const url = new URL('player_api.php', `${normalizedBaseUrl}/`);
+	url.searchParams.set('username', config.username);
+	url.searchParams.set('password', config.password);
+
+	for (const [key, value] of Object.entries(params)) {
+		if (value === null || value === undefined) continue;
+		url.searchParams.set(key, String(value));
+	}
+
+	return url.toString();
+}

--- a/src/lib/server/logos/LogoDownloadService.ts
+++ b/src/lib/server/logos/LogoDownloadService.ts
@@ -5,8 +5,8 @@ import { createChildLogger } from '$lib/logging';
 const logger = createChildLogger({ logDomain: 'system' as const });
 import { EventEmitter } from 'node:events';
 import { invalidateLogoLibraryCache } from './logo-library.js';
+import { LOGO_REPO_PATH_PREFIX, LOGOS_DIR } from './constants.js';
 
-const LOGOS_DIR = 'data/channel-logos';
 const GITHUB_REPO = 'MoldyTaint/Cinephage';
 const GITHUB_BRANCH = 'main';
 
@@ -125,7 +125,7 @@ export class LogoDownloadService extends EventEmitter {
 			const logoFiles = treeData.tree.filter(
 				(item: { path: string; type: string }) =>
 					item.type === 'blob' &&
-					item.path.startsWith('data/channel-logos/') &&
+					item.path.startsWith(LOGO_REPO_PATH_PREFIX) &&
 					/\.(png|jpg|jpeg)$/i.test(item.path)
 			);
 
@@ -143,7 +143,7 @@ export class LogoDownloadService extends EventEmitter {
 
 				// Get the raw content URL
 				const rawUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/${file.path}`;
-				const localPath = join(LOGOS_DIR, file.path.replace('data/channel-logos/', ''));
+				const localPath = join(LOGOS_DIR, file.path.replace(LOGO_REPO_PATH_PREFIX, ''));
 
 				try {
 					// Ensure subdirectory exists

--- a/src/lib/server/logos/constants.ts
+++ b/src/lib/server/logos/constants.ts
@@ -1,0 +1,6 @@
+import { join } from 'node:path';
+
+const DATA_DIR = process.env.DATA_DIR || 'data';
+
+export const LOGO_REPO_PATH_PREFIX = 'data/channel-logos/';
+export const LOGOS_DIR = join(DATA_DIR, 'channel-logos');

--- a/src/lib/server/logos/logo-library.ts
+++ b/src/lib/server/logos/logo-library.ts
@@ -1,7 +1,7 @@
 import { readdir, stat } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
+import { LOGOS_DIR } from './constants.js';
 
-const LOGOS_DIR = 'data/channel-logos';
 const CACHE_TTL_MS = 15_000;
 
 export interface LogoInfo {

--- a/src/lib/types/livetv.ts
+++ b/src/lib/types/livetv.ts
@@ -133,6 +133,8 @@ export interface XstreamConfig {
 	baseUrl: string;
 	username: string;
 	password: string;
+	/** Optional XMLTV override (e.g. /xmltv.php?username=...&password=...) */
+	epgUrl?: string;
 	authToken?: string;
 	tokenExpiry?: string;
 	/** Output format for stream URLs: 'ts' (MPEG-TS), 'm3u8' (HLS), or 'mp4'. Defaults to 'ts'. */
@@ -289,6 +291,7 @@ export interface StalkerChannelData {
 export interface XstreamChannelData {
 	streamId: string;
 	streamType: string;
+	epgChannelId?: string;
 	directStreamUrl?: string;
 	containerExtension?: string;
 }
@@ -715,6 +718,8 @@ export interface EpgStatus {
 	isEnabled: boolean;
 	isSyncing: boolean;
 	syncingAccountIds?: string[];
+	cancelRequestedAll?: boolean;
+	cancelRequestedAccountIds?: string[];
 	syncIntervalHours: number;
 	retentionHours: number;
 	lastSyncAt: string | null;

--- a/src/routes/api/livetv/accounts/+server.ts
+++ b/src/routes/api/livetv/accounts/+server.ts
@@ -36,7 +36,8 @@ const liveTvAccountCreateSchema = z.object({
 		.object({
 			baseUrl: z.string().url(),
 			username: z.string().min(1),
-			password: z.string().min(1)
+			password: z.string().min(1),
+			epgUrl: z.string().url().optional()
 		})
 		.optional(),
 	// M3U-specific config

--- a/src/routes/api/livetv/accounts/[id]/+server.ts
+++ b/src/routes/api/livetv/accounts/[id]/+server.ts
@@ -39,7 +39,11 @@ const liveTvAccountUpdateSchema = z.object({
 		.object({
 			baseUrl: z.string().url().optional(),
 			username: z.string().min(1).optional(),
-			password: z.string().min(1).optional()
+			password: z.string().min(1).optional(),
+			epgUrl: z.preprocess(
+				(value) => (typeof value === 'string' ? value.trim() : value),
+				z.union([z.string().url(), z.literal('')]).optional()
+			)
 		})
 		.optional(),
 	// M3U-specific config updates
@@ -85,9 +89,21 @@ function queueAccountEpgSync(accountId: string): void {
 		try {
 			const epgService = getEpgService();
 			liveTvEvents.emitEpgSyncStarted(accountId);
-			await epgService.syncAccount(accountId);
-			liveTvEvents.emitEpgSyncCompleted(accountId);
-			logger.info({ accountId }, '[API] Background EPG sync complete after account update');
+			const result = await epgService.syncAccount(accountId, {
+				shouldCancel: () => syncState.isCancelRequestedForAccount(accountId)
+			});
+
+			if (result.success) {
+				liveTvEvents.emitEpgSyncCompleted(accountId);
+				logger.info({ accountId }, '[API] Background EPG sync complete after account update');
+			} else {
+				const errorMessage = result.error ?? 'EPG sync failed';
+				liveTvEvents.emitEpgSyncFailed(accountId, errorMessage);
+				logger.warn(
+					{ accountId, error: errorMessage },
+					'[API] Background EPG sync finished with failure after account update'
+				);
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			liveTvEvents.emitEpgSyncFailed(accountId, message);
@@ -155,24 +171,46 @@ export const PUT: RequestHandler = async ({ params, request }) => {
 		}
 
 		const updates = parsed.data;
-		const hasExplicitEpgField =
+		const hasExplicitM3uEpgField =
 			typeof body === 'object' &&
 			body !== null &&
 			'm3uConfig' in body &&
 			typeof body.m3uConfig === 'object' &&
 			body.m3uConfig !== null &&
 			Object.prototype.hasOwnProperty.call(body.m3uConfig, 'epgUrl');
-		const requestedEpgUrl =
-			hasExplicitEpgField &&
+		const requestedM3uEpgUrl =
+			hasExplicitM3uEpgField &&
 			typeof body.m3uConfig === 'object' &&
 			body.m3uConfig !== null &&
 			typeof body.m3uConfig.epgUrl === 'string'
 				? body.m3uConfig.epgUrl.trim()
 				: null;
 
+		const hasExplicitXstreamEpgField =
+			typeof body === 'object' &&
+			body !== null &&
+			'xstreamConfig' in body &&
+			typeof body.xstreamConfig === 'object' &&
+			body.xstreamConfig !== null &&
+			Object.prototype.hasOwnProperty.call(body.xstreamConfig, 'epgUrl');
+		const requestedXstreamEpgUrl =
+			hasExplicitXstreamEpgField &&
+			typeof body.xstreamConfig === 'object' &&
+			body.xstreamConfig !== null &&
+			typeof body.xstreamConfig.epgUrl === 'string'
+				? body.xstreamConfig.epgUrl.trim()
+				: null;
+
 		// Empty epgUrl in update payload means "clear existing epgUrl".
-		if (hasExplicitEpgField && updates.m3uConfig && updates.m3uConfig.epgUrl === '') {
+		if (hasExplicitM3uEpgField && updates.m3uConfig && updates.m3uConfig.epgUrl === '') {
 			updates.m3uConfig.epgUrl = undefined;
+		}
+		if (
+			hasExplicitXstreamEpgField &&
+			updates.xstreamConfig &&
+			updates.xstreamConfig.epgUrl === ''
+		) {
+			updates.xstreamConfig.epgUrl = undefined;
 		}
 
 		const manager = getLiveTvAccountManager();
@@ -187,12 +225,19 @@ export const PUT: RequestHandler = async ({ params, request }) => {
 			);
 		}
 
-		const previousEpgUrl = (existingAccount.m3uConfig?.epgUrl ?? '').trim();
-		const shouldTriggerAccountEpgSync =
-			hasExplicitEpgField &&
+		const previousM3uEpgUrl = (existingAccount.m3uConfig?.epgUrl ?? '').trim();
+		const shouldTriggerM3uEpgSync =
+			hasExplicitM3uEpgField &&
 			existingAccount.providerType === 'm3u' &&
-			requestedEpgUrl !== null &&
-			previousEpgUrl !== requestedEpgUrl;
+			requestedM3uEpgUrl !== null &&
+			previousM3uEpgUrl !== requestedM3uEpgUrl;
+		const previousXstreamEpgUrl = (existingAccount.xstreamConfig?.epgUrl ?? '').trim();
+		const shouldTriggerXstreamEpgSync =
+			hasExplicitXstreamEpgField &&
+			existingAccount.providerType === 'xstream' &&
+			requestedXstreamEpgUrl !== null &&
+			previousXstreamEpgUrl !== requestedXstreamEpgUrl;
+		const shouldTriggerAccountEpgSync = shouldTriggerM3uEpgSync || shouldTriggerXstreamEpgSync;
 		const account = await manager.updateAccount(params.id, updates);
 
 		if (!account) {

--- a/src/routes/api/livetv/accounts/[id]/test/+server.ts
+++ b/src/routes/api/livetv/accounts/[id]/test/+server.ts
@@ -8,6 +8,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvAccountManager } from '$lib/server/livetv/LiveTvAccountManager';
 import { logger } from '$lib/logging';
+import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
 
 /**
  * Test an existing Live TV account by ID
@@ -28,9 +29,16 @@ export const POST: RequestHandler = async ({ params }) => {
 			);
 		}
 
+		const responseResult = result.success
+			? result
+			: {
+					...result,
+					error: toFriendlyLiveTvTestError(result.error)
+				};
+
 		return json({
 			success: true,
-			result
+			result: responseResult
 		});
 	} catch (error) {
 		logger.error(
@@ -41,7 +49,9 @@ export const POST: RequestHandler = async ({ params }) => {
 		return json(
 			{
 				success: false,
-				error: error instanceof Error ? error.message : 'Failed to test account'
+				error: toFriendlyLiveTvTestError(
+					error instanceof Error ? error.message : 'Failed to test account'
+				)
 			},
 			{ status: 500 }
 		);

--- a/src/routes/api/livetv/accounts/test/+server.ts
+++ b/src/routes/api/livetv/accounts/test/+server.ts
@@ -8,6 +8,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getProvider } from '$lib/server/livetv/providers';
 import { logger } from '$lib/logging';
+import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
 import { z } from 'zod';
 import { ValidationError } from '$lib/errors';
 import type { LiveTvAccount } from '$lib/types/livetv';
@@ -34,7 +35,8 @@ const liveTvAccountTestSchema = z.object({
 		.object({
 			baseUrl: z.string().url('Please enter a valid server URL'),
 			username: z.string().min(1, 'Username is required'),
-			password: z.string().min(1, 'Password is required')
+			password: z.string().min(1, 'Password is required'),
+			epgUrl: z.string().url().optional()
 		})
 		.optional(),
 	// M3U-specific config
@@ -119,8 +121,14 @@ function getFriendlyValidationMessage(error: ValidationError): string {
  * Useful for validating credentials before creating an account
  */
 export const POST: RequestHandler = async ({ request }) => {
+	let providerType: LiveTvAccount['providerType'] | undefined;
+
 	try {
 		const body = await request.json();
+		providerType =
+			typeof body === 'object' && body && 'providerType' in body
+				? ((body as { providerType?: LiveTvAccount['providerType'] }).providerType ?? undefined)
+				: undefined;
 
 		// Validate input
 		const parsed = liveTvAccountTestSchema.safeParse(body);
@@ -161,7 +169,13 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		// Get provider and test
 		const provider = getProvider(parsed.data.providerType);
-		const result = await provider.testConnection(tempAccount);
+		const providerResult = await provider.testConnection(tempAccount);
+		const result = providerResult.success
+			? providerResult
+			: {
+					...providerResult,
+					error: toFriendlyLiveTvTestError(providerResult.error, parsed.data.providerType)
+				};
 
 		return json({
 			success: true,
@@ -197,7 +211,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		return json(
 			{
 				success: false,
-				error: error instanceof Error ? error.message : 'Failed to test account configuration'
+				error: toFriendlyLiveTvTestError(
+					error instanceof Error ? error.message : 'Failed to test account configuration',
+					providerType
+				)
 			},
 			{ status: 500 }
 		);

--- a/src/routes/api/livetv/epg/status/+server.ts
+++ b/src/routes/api/livetv/epg/status/+server.ts
@@ -60,6 +60,8 @@ export const GET: RequestHandler = async () => {
 				syncSnapshot.syncingAll ||
 				syncSnapshot.syncingAccountIds.length > 0,
 			syncingAccountIds: syncSnapshot.syncingAccountIds,
+			cancelRequestedAll: syncSnapshot.cancelRequestedAll,
+			cancelRequestedAccountIds: syncSnapshot.cancelRequestedAccountIds,
 			syncIntervalHours: schedulerStatus.syncIntervalHours,
 			retentionHours: schedulerStatus.retentionHours,
 			lastSyncAt: schedulerStatus.lastSyncAt,

--- a/src/routes/api/livetv/epg/stream/+server.ts
+++ b/src/routes/api/livetv/epg/stream/+server.ts
@@ -30,6 +30,8 @@ interface EpgStatusData {
 	isEnabled: boolean;
 	isSyncing: boolean;
 	syncingAccountIds: string[];
+	cancelRequestedAll: boolean;
+	cancelRequestedAccountIds: string[];
 	syncIntervalHours: number;
 	retentionHours: number;
 	lastSyncAt: string | null;
@@ -87,6 +89,8 @@ async function getEpgStatus(): Promise<EpgStatusData> {
 			syncSnapshot.syncingAll ||
 			syncSnapshot.syncingAccountIds.length > 0,
 		syncingAccountIds: syncSnapshot.syncingAccountIds,
+		cancelRequestedAll: syncSnapshot.cancelRequestedAll,
+		cancelRequestedAccountIds: syncSnapshot.cancelRequestedAccountIds,
 		syncIntervalHours: schedulerStatus.syncIntervalHours,
 		retentionHours: schedulerStatus.retentionHours,
 		lastSyncAt: schedulerStatus.lastSyncAt,

--- a/src/routes/api/livetv/epg/sync/+server.ts
+++ b/src/routes/api/livetv/epg/sync/+server.ts
@@ -3,6 +3,8 @@
  *
  * POST /api/livetv/epg/sync - Trigger EPG sync for all accounts (non-blocking)
  * POST /api/livetv/epg/sync?accountId=xxx - Trigger EPG sync for specific account (non-blocking)
+ * DELETE /api/livetv/epg/sync - Cancel currently running sync for all accounts
+ * DELETE /api/livetv/epg/sync?accountId=xxx - Cancel currently running sync for one account
  *
  * Returns immediately while sync runs in background.
  * Use GET /api/livetv/epg/status to check sync progress.
@@ -11,6 +13,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getEpgService, getEpgScheduler } from '$lib/server/livetv/epg';
+import { EPG_SYNC_CANCELLED_MESSAGE } from '$lib/server/livetv/epg/EpgService';
 import { getEpgSyncState } from '$lib/server/livetv/epg/EpgSyncState';
 import { liveTvEvents } from '$lib/server/livetv/LiveTvEvents';
 import { logger } from '$lib/logging';
@@ -66,9 +69,23 @@ export const POST: RequestHandler = async ({ url }) => {
 				logger.info({ accountId }, '[EPG] Starting background sync for account');
 				liveTvEvents.emitEpgSyncStarted(accountId);
 				try {
-					await epgService.syncAccount(accountId);
-					liveTvEvents.emitEpgSyncCompleted(accountId);
-					logger.info({ accountId }, '[EPG] Background sync complete for account');
+					const result = await epgService.syncAccount(accountId, {
+						shouldCancel: () => syncState.isCancelRequestedForAccount(accountId)
+					});
+					if (result.success) {
+						liveTvEvents.emitEpgSyncCompleted(accountId);
+						logger.info({ accountId }, '[EPG] Background sync complete for account');
+					} else {
+						const errorMessage = result.error ?? 'EPG sync failed';
+						liveTvEvents.emitEpgSyncFailed(accountId, errorMessage);
+						logger.warn(
+							{
+								accountId,
+								error: errorMessage
+							},
+							'[EPG] Background sync finished with failure for account'
+						);
+					}
 				} catch (err) {
 					liveTvEvents.emitEpgSyncFailed(
 						accountId,
@@ -80,7 +97,10 @@ export const POST: RequestHandler = async ({ url }) => {
 				logger.info('[EPG] Starting background sync for all accounts');
 				liveTvEvents.emitEpgSyncStarted();
 				try {
-					const results = await epgService.syncAll();
+					const results = await epgService.syncAll({
+						shouldCancelAll: () => syncState.isCancelRequestedAll(),
+						shouldCancelAccount: (id) => syncState.isCancelRequestedForAccount(id)
+					});
 					liveTvEvents.emitEpgSyncCompleted();
 					const successful = results.filter((r) => r.success).length;
 					const totalAdded = results.reduce((sum, r) => sum + r.programsAdded, 0);
@@ -125,4 +145,46 @@ export const POST: RequestHandler = async ({ url }) => {
 			? `EPG sync started for account ${accountId}`
 			: 'EPG sync started for all accounts'
 	});
+};
+
+export const DELETE: RequestHandler = async ({ url }) => {
+	const accountId = url.searchParams.get('accountId');
+	const syncState = getEpgSyncState();
+
+	const cancelRequested = accountId
+		? syncState.requestCancelAccount(accountId)
+		: syncState.requestCancelAll();
+
+	if (!cancelRequested) {
+		return json(
+			{
+				success: true,
+				cancelRequested: false,
+				message: accountId
+					? `No running EPG sync found for account ${accountId}`
+					: 'No running EPG sync found'
+			},
+			{ status: 202 }
+		);
+	}
+
+	logger.info(
+		{ accountId: accountId ?? 'all' },
+		accountId
+			? '[EPG] Cancel requested for account sync'
+			: '[EPG] Cancel requested for running sync'
+	);
+
+	liveTvEvents.emitEpgSyncFailed(accountId ?? undefined, EPG_SYNC_CANCELLED_MESSAGE);
+
+	return json(
+		{
+			success: true,
+			cancelRequested: true,
+			message: accountId
+				? `Cancellation requested for account ${accountId}`
+				: 'Cancellation requested for running EPG sync'
+		},
+		{ status: 202 }
+	);
 };

--- a/src/routes/api/logos/file/[country]/[filename]/+server.ts
+++ b/src/routes/api/logos/file/[country]/[filename]/+server.ts
@@ -2,8 +2,7 @@ import type { RequestHandler } from './$types';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { logger } from '$lib/logging';
-
-const LOGOS_DIR = 'data/channel-logos';
+import { LOGOS_DIR } from '$lib/server/logos/constants.js';
 
 /**
  * GET /api/logos/file/[country]/[filename]

--- a/src/routes/api/subtitles/sync/bulk/+server.ts
+++ b/src/routes/api/subtitles/sync/bulk/+server.ts
@@ -50,7 +50,6 @@ export const POST: RequestHandler = async ({ request }) => {
 
 			// Process with limited concurrency
 			let nextIndex = 0;
-			let completedCount = 0;
 
 			async function processOne(): Promise<void> {
 				while (nextIndex < total) {
@@ -82,8 +81,6 @@ export const POST: RequestHandler = async ({ request }) => {
 							total
 						});
 					}
-
-					completedCount++;
 				}
 			}
 

--- a/src/routes/livetv/accounts/+page.svelte
+++ b/src/routes/livetv/accounts/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Plus, RefreshCw, Loader2, Wifi, WifiOff } from 'lucide-svelte';
 	import { LiveTvAccountTable, LiveTvAccountModal } from '$lib/components/livetv';
+	import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import type { LiveTvAccount, LiveTvAccountTestResult } from '$lib/types/livetv';
 	import type { FormData, TestConfig } from '$lib/components/livetv/LiveTvAccountModal.svelte';
@@ -138,14 +139,17 @@
 						epgUrl: data.epgUrl || undefined
 					};
 					break;
-				case 'xstream':
+				case 'xstream': {
+					const normalizedXstreamEpgUrl = data.epgUrl.trim();
 					body.xstreamConfig = {
 						baseUrl: data.baseUrl,
 						username: data.username,
 						password: data.password,
-						epgUrl: data.epgUrl || undefined
+						// In edit mode, send empty string to explicitly clear an existing EPG URL.
+						epgUrl: normalizedXstreamEpgUrl || (modalMode === 'edit' ? '' : undefined)
 					};
 					break;
+				}
 				case 'm3u':
 					if (data.selectedCountries?.length) {
 						// IPTV-Org mode
@@ -276,20 +280,29 @@
 
 			if (!response.ok) {
 				throw new Error(
-					typeof payload?.error === 'string' ? payload.error : 'Failed to test account'
+					toFriendlyLiveTvTestError(
+						typeof payload?.error === 'string' ? payload.error : 'Failed to test account',
+						account.providerType
+					)
 				);
 			}
 
-			const testResult =
+			const rawTestResult =
 				payload?.result && typeof payload.result.success === 'boolean'
 					? payload.result
 					: payload && typeof payload.success === 'boolean'
 						? payload
 						: null;
 
-			if (!testResult) {
+			if (!rawTestResult) {
 				throw new Error('Invalid test response');
 			}
+			const testResult = rawTestResult.success
+				? rawTestResult
+				: {
+						...rawTestResult,
+						error: toFriendlyLiveTvTestError(rawTestResult.error, account.providerType)
+					};
 
 			const now = new Date().toISOString();
 			accounts = accounts.map((existing) => {
@@ -323,7 +336,10 @@
 			}
 		} catch (e) {
 			toasts.error(`Connection test failed: ${account.name}`, {
-				description: e instanceof Error ? e.message : 'Failed to test account'
+				description: toFriendlyLiveTvTestError(
+					e instanceof Error ? e.message : 'Failed to test account',
+					account.providerType
+				)
 			});
 		} finally {
 			testingId = null;
@@ -370,7 +386,8 @@
 				body.xstreamConfig = {
 					baseUrl: config.baseUrl,
 					username: config.username,
-					password: config.password
+					password: config.password,
+					epgUrl: config.epgUrl
 				};
 				break;
 			case 'm3u':
@@ -389,36 +406,62 @@
 				break;
 		}
 
-		const response = await fetch('/api/livetv/accounts/test', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body)
-		});
+		try {
+			const response = await fetch('/api/livetv/accounts/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			});
 
-		const result = await response.json();
+			const result = await response.json();
 
-		if (!response.ok) {
+			if (!response.ok) {
+				return {
+					success: false,
+					error: toFriendlyLiveTvTestError(
+						typeof result?.error === 'string'
+							? result.error
+							: 'Failed to test account configuration',
+						config.providerType
+					)
+				};
+			}
+
+			// API currently returns { success, result }, but keep backward compatibility
+			// in case the endpoint returns LiveTvAccountTestResult directly.
+			if (result?.result && typeof result.result.success === 'boolean') {
+				const testResult = result.result as LiveTvAccountTestResult;
+				return testResult.success
+					? testResult
+					: {
+							...testResult,
+							error: toFriendlyLiveTvTestError(testResult.error, config.providerType)
+						};
+			}
+
+			if (typeof result?.success === 'boolean') {
+				const testResult = result as LiveTvAccountTestResult;
+				return testResult.success
+					? testResult
+					: {
+							...testResult,
+							error: toFriendlyLiveTvTestError(testResult.error, config.providerType)
+						};
+			}
+
 			return {
 				success: false,
-				error:
-					typeof result?.error === 'string' ? result.error : 'Failed to test account configuration'
+				error: 'Invalid response from test endpoint'
+			};
+		} catch (error) {
+			return {
+				success: false,
+				error: toFriendlyLiveTvTestError(
+					error instanceof Error ? error.message : 'Failed to test account configuration',
+					config.providerType
+				)
 			};
 		}
-
-		// API currently returns { success, result }, but keep backward compatibility
-		// in case the endpoint returns LiveTvAccountTestResult directly.
-		if (result?.result && typeof result.result.success === 'boolean') {
-			return result.result as LiveTvAccountTestResult;
-		}
-
-		if (typeof result?.success === 'boolean') {
-			return result as LiveTvAccountTestResult;
-		}
-
-		return {
-			success: false,
-			error: 'Invalid response from test endpoint'
-		};
 	}
 </script>
 

--- a/src/routes/livetv/channels/+page.svelte
+++ b/src/routes/livetv/channels/+page.svelte
@@ -36,7 +36,7 @@
 		ChannelCleanNamePreview,
 		UpdateChannelRequest
 	} from '$lib/types/livetv';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { createSSE } from '$lib/sse';
 	import { resolvePath } from '$lib/utils/routing';
 	import { copyToClipboard as copyTextToClipboard } from '$lib/utils/clipboard';
@@ -127,7 +127,7 @@
 	let loadingLogos = $state(false);
 	let downloadingLogos = $state(false);
 	let logoDownloadProgress = $state<LogoDownloadProgress | null>(null);
-	let logoDownloadEventSource: ReturnType<typeof createSSE> | null = $state(null);
+	let logoDownloadEventSource = $state<EventSource | null>(null);
 
 	function syncLineupChannelIds(ids: string[]) {
 		lineupChannelIds.clear();
@@ -161,6 +161,10 @@
 
 	onMount(() => {
 		loadLogoStatus();
+	});
+
+	onDestroy(() => {
+		closeLogoDownloadStream();
 	});
 
 	async function loadLogoStatus() {
@@ -214,60 +218,76 @@
 	}
 
 	function connectToLogoDownloadStream() {
-		// Close any existing connection
-		if (logoDownloadEventSource) {
-			logoDownloadEventSource.close();
-		}
+		closeLogoDownloadStream();
 
-		logoDownloadEventSource = createSSE<{
-			'logos:status': LogoDownloadProgress;
-			'logos:started': LogoDownloadProgress;
-			'logos:progress': LogoDownloadProgress;
-			'logos:completed': LogoDownloadProgress;
-			'logos:error': LogoDownloadProgress;
-		}>('/api/logos/download/stream', {
-			'logos:status': (payload) => {
-				logoDownloadProgress = payload;
-				if (payload.status === 'completed') {
-					logoDownloaded = true;
-					downloadingLogos = false;
-					logoCount = payload.downloaded;
-					logoDownloadEventSource?.close();
-					logoDownloadEventSource = null;
-					void loadLogoStatus();
-				}
-			},
-			'logos:started': (payload) => {
-				logoDownloadProgress = payload;
-			},
-			'logos:progress': (payload) => {
-				logoDownloadProgress = payload;
-			},
-			'logos:completed': (payload) => {
-				logoDownloadProgress = payload;
+		const stream = new EventSource(resolvePath('/api/logos/download/stream'));
+		logoDownloadEventSource = stream;
+
+		const parsePayload = (event: MessageEvent): LogoDownloadProgress | null => {
+			try {
+				return JSON.parse(event.data) as LogoDownloadProgress;
+			} catch {
+				return null;
+			}
+		};
+
+		stream.addEventListener('logos:status', (event) => {
+			const payload = parsePayload(event as MessageEvent);
+			if (!payload) return;
+			logoDownloadProgress = payload;
+			if (payload.status === 'completed') {
 				logoDownloaded = true;
 				downloadingLogos = false;
 				logoCount = payload.downloaded;
-				logoDownloadEventSource?.close();
-				logoDownloadEventSource = null;
-				toasts.success(`Downloaded ${payload.downloaded} logos`);
+				closeLogoDownloadStream();
 				void loadLogoStatus();
-			},
-			'logos:error': (payload) => {
-				logoDownloadProgress = payload;
-				downloadingLogos = false;
-				logoDownloadEventSource?.close();
-				logoDownloadEventSource = null;
-				toasts.error(payload.error || 'Download failed');
-			},
-			error: () => {
-				if (logoDownloadEventSource) {
-					downloadingLogos = false;
-					logoDownloadEventSource.close();
-					logoDownloadEventSource = null;
-				}
 			}
 		});
+
+		stream.addEventListener('logos:started', (event) => {
+			const payload = parsePayload(event as MessageEvent);
+			if (!payload) return;
+			logoDownloadProgress = payload;
+		});
+
+		stream.addEventListener('logos:progress', (event) => {
+			const payload = parsePayload(event as MessageEvent);
+			if (!payload) return;
+			logoDownloadProgress = payload;
+		});
+
+		stream.addEventListener('logos:completed', (event) => {
+			const payload = parsePayload(event as MessageEvent);
+			if (!payload) return;
+			logoDownloadProgress = payload;
+			logoDownloaded = true;
+			downloadingLogos = false;
+			logoCount = payload.downloaded;
+			closeLogoDownloadStream();
+			toasts.success(`Downloaded ${payload.downloaded} logos`);
+			void loadLogoStatus();
+		});
+
+		stream.addEventListener('logos:error', (event) => {
+			const payload = parsePayload(event as MessageEvent);
+			logoDownloadProgress = payload;
+			downloadingLogos = false;
+			closeLogoDownloadStream();
+			toasts.error(payload?.error || 'Download failed');
+		});
+
+		stream.onerror = () => {
+			if (logoDownloadEventSource) {
+				downloadingLogos = false;
+				closeLogoDownloadStream();
+			}
+		};
+	}
+
+	function closeLogoDownloadStream() {
+		if (!logoDownloadEventSource) return;
+		logoDownloadEventSource.close();
+		logoDownloadEventSource = null;
 	}
 
 	// SSE Connection - internally handles browser/SSR

--- a/src/routes/livetv/epg/+page.svelte
+++ b/src/routes/livetv/epg/+page.svelte
@@ -31,8 +31,11 @@
 	let epgStatusLoading = $state(true);
 	let epgSyncingAll = $state(false);
 	let epgSyncingAccountIds = new SvelteSet<string>();
+	let epgCancelRequestedAll = $state(false);
+	let epgCancelRequestedAccountIds = new SvelteSet<string>();
 	const epgSyncingAny = $derived(epgSyncingAll || epgSyncingAccountIds.size > 0);
 	const epgSyncingAccountList = $derived([...epgSyncingAccountIds]);
+	const epgCancelRequestedAccountList = $derived([...epgCancelRequestedAccountIds]);
 
 	// EPG now/next data for coverage tab
 	let epgData = new SvelteMap<string, NowNextEntry>();
@@ -50,12 +53,18 @@
 	function applySyncStateFromStatus(status: EpgStatus | null | undefined) {
 		if (!status) return;
 		const syncingIds = status.syncingAccountIds ?? [];
+		const cancelRequestedIds = status.cancelRequestedAccountIds ?? [];
 		epgSyncingAll = status.isSyncing && syncingIds.length === 0;
+		epgCancelRequestedAll = status.cancelRequestedAll ?? false;
 		if (status.syncingAccountIds !== undefined) {
 			epgSyncingAccountIds.clear();
 			for (const id of syncingIds) {
 				epgSyncingAccountIds.add(id);
 			}
+		}
+		epgCancelRequestedAccountIds.clear();
+		for (const id of cancelRequestedIds) {
+			epgCancelRequestedAccountIds.add(id);
 		}
 	}
 
@@ -154,6 +163,8 @@
 
 	async function triggerEpgSync() {
 		if (epgSyncingAny) return;
+		epgCancelRequestedAll = false;
+		epgCancelRequestedAccountIds.clear();
 		epgSyncingAll = true;
 		try {
 			const response = await fetch('/api/livetv/epg/sync', { method: 'POST' });
@@ -171,6 +182,7 @@
 
 	async function triggerAccountSync(accountId: string) {
 		if (epgSyncingAny) return;
+		epgCancelRequestedAccountIds.delete(accountId);
 		epgSyncingAccountIds.add(accountId);
 		try {
 			const response = await fetch(`/api/livetv/epg/sync?accountId=${accountId}`, {
@@ -182,6 +194,44 @@
 			await response.json();
 		} catch {
 			epgSyncingAccountIds.delete(accountId);
+		}
+	}
+
+	async function cancelEpgSync() {
+		if (!epgSyncingAny) return;
+		epgCancelRequestedAll = true;
+
+		try {
+			const response = await fetch('/api/livetv/epg/sync', { method: 'DELETE' });
+			if (!response.ok) {
+				throw new Error('Failed to cancel EPG sync');
+			}
+			const payload = (await response.json()) as { cancelRequested?: boolean };
+			if (payload?.cancelRequested === false) {
+				epgCancelRequestedAll = false;
+			}
+		} catch {
+			epgCancelRequestedAll = false;
+		}
+	}
+
+	async function cancelAccountSync(accountId: string) {
+		if (!epgSyncingAll && !epgSyncingAccountIds.has(accountId)) return;
+		epgCancelRequestedAccountIds.add(accountId);
+
+		try {
+			const response = await fetch(`/api/livetv/epg/sync?accountId=${accountId}`, {
+				method: 'DELETE'
+			});
+			if (!response.ok) {
+				throw new Error('Failed to cancel EPG sync');
+			}
+			const payload = (await response.json()) as { cancelRequested?: boolean };
+			if (payload?.cancelRequested === false) {
+				epgCancelRequestedAccountIds.delete(accountId);
+			}
+		} catch {
+			epgCancelRequestedAccountIds.delete(accountId);
 		}
 	}
 
@@ -272,8 +322,12 @@
 			loading={epgStatusLoading}
 			syncingAll={epgSyncingAll}
 			syncingAccountIds={epgSyncingAccountList}
+			cancelRequestedAll={epgCancelRequestedAll}
+			cancelRequestedAccountIds={epgCancelRequestedAccountList}
 			onSync={triggerEpgSync}
 			onSyncAccount={triggerAccountSync}
+			onCancel={cancelEpgSync}
+			onCancelAccount={cancelAccountSync}
 		/>
 	{:else if activeTab === 'coverage'}
 		<EpgCoverageTable


### PR DESCRIPTION
## Summary

This pull request introduces several improvements and enhancements across the Live TV and subtitles components, as well as logging and error handling. The most significant changes are grouped below by theme.

### Live TV: Enhanced Sync Controls & EPG Configuration

* Added cancellation controls for EPG sync operations, including UI buttons and state tracking for both global and per-account sync cancellation in `EpgStatusPanel.svelte`. [[1]](diffhunk://#diff-b1f59c1e96e45a65ab65e08e5cf32e4b6aa83e4ac63e122f7f66f43a7a0b6c48L2-R38) [[2]](diffhunk://#diff-b1f59c1e96e45a65ab65e08e5cf32e4b6aa83e4ac63e122f7f66f43a7a0b6c48R82-R91) [[3]](diffhunk://#diff-b1f59c1e96e45a65ab65e08e5cf32e4b6aa83e4ac63e122f7f66f43a7a0b6c48R241-R256) [[4]](diffhunk://#diff-b1f59c1e96e45a65ab65e08e5cf32e4b6aa83e4ac63e122f7f66f43a7a0b6c48R270-R278) [[5]](diffhunk://#diff-b1f59c1e96e45a65ab65e08e5cf32e4b6aa83e4ac63e122f7f66f43a7a0b6c48L259-R329)
* Improved EPG URL handling for XStream accounts, allowing fallback to `xstreamConfig.epgUrl` and proper saving of this field in both modal and backend logic. [[1]](diffhunk://#diff-67f1f0294f6fb86b9601617519bd560388ba03c0746159d6b57f3acccf695053L123-R123) [[2]](diffhunk://#diff-67f1f0294f6fb86b9601617519bd560388ba03c0746159d6b57f3acccf695053R226-R228) [[3]](diffhunk://#diff-52103a1d95c4e41a805e7c276b8a6547940d24d420fecac1df339f90a8b93942L319-R323)
* Updated database schema to support optional `epgUrl` for XStream accounts and `epgChannelId` for channels. [[1]](diffhunk://#diff-bfcd9b7537135d04bf11ec331e61e43db9a834ee401e7b3d7e3dc05c94c7b4e0R2909) [[2]](diffhunk://#diff-bfcd9b7537135d04bf11ec331e61e43db9a834ee401e7b3d7e3dc05c94c7b4e0R3014)
* Improved error messaging for Live TV connection tests by adding a normalization function that translates technical errors into user-friendly messages. [[1]](diffhunk://#diff-0b58341ec4be9b61167c4f7db630b449c41ef71f9a3f91f330b0096a13a5c740R1-R103) [[2]](diffhunk://#diff-52103a1d95c4e41a805e7c276b8a6547940d24d420fecac1df339f90a8b93942R12) [[3]](diffhunk://#diff-52103a1d95c4e41a805e7c276b8a6547940d24d420fecac1df339f90a8b93942L550-R558) [[4]](diffhunk://#diff-52103a1d95c4e41a805e7c276b8a6547940d24d420fecac1df339f90a8b93942L579-R587)

### Subtitles: Quality-of-life Improvements

* Added a guard to prevent duplicate subtitle auto-search actions and refactored event handling for subtitle auto-search in `EpisodeRow.svelte`. [[1]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9R234-R238) [[2]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L438-R443) [[3]](diffhunk://#diff-fe014dccae5069739f1bd2f61da81d7e36a0d3f973fd95f28382fb1579b0a1a9L496-R501)
* Improved badge value sanitization for subtitle quality and source, preventing display of meaningless values (e.g., "unknown", "n/a") in `QualityBadge.svelte`.
* Refactored bulk sync modal state management for subtitles, switching from re-instantiating maps/sets to clearing them for more predictable state handling in `SubtitleSyncModal.svelte`. [[1]](diffhunk://#diff-b27137466405f181aee4d8e4fb0c3bf3bca4570dfd5bcbb641c8a133997ed147L78-R87) [[2]](diffhunk://#diff-b27137466405f181aee4d8e4fb0c3bf3bca4570dfd5bcbb641c8a133997ed147L106-R113) [[3]](diffhunk://#diff-b27137466405f181aee4d8e4fb0c3bf3bca4570dfd5bcbb641c8a133997ed147L155-R162)

### Logging: Version Resolution

* Enhanced logging to resolve and display a meaningful application version, avoiding placeholder or empty values, and defaulting to `dev-local` when necessary. [[1]](diffhunk://#diff-857465318a59146f019471c84092fa4f851e8778aa5d91e5d9855e62f8a654e7R6) [[2]](diffhunk://#diff-857465318a59146f019471c84092fa4f851e8778aa5d91e5d9855e62f8a654e7R141-R156) [[3]](diffhunk://#diff-857465318a59146f019471c84092fa4f851e8778aa5d91e5d9855e62f8a654e7L301-R318)

### UI/UX Minor Improvements

* Improved label rendering for EPG source override in the XStream account form for better readability.
* Cleaned up icon imports and removed unused icons in subtitles components.
* Minor accessibility and code cleanup in subtitle popover.

These changes collectively improve reliability, user experience, and maintainability for Live TV and subtitle management features.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Implemented `normalizeXstreamBaseUrl` to clean user-supplied XStream URLs.
- Added `buildXstreamPlayerApiUrl` to construct player API URLs with credentials.
- Created tests for both functions to ensure correct behavior.
- Moved logo directory path constants to `constants.ts` for better maintainability.
- Updated references in `LogoDownloadService`, `logo-library.ts`, and API routes.
- Added cancel functionality for EPG sync operations, allowing users to cancel ongoing syncs.
- Updated EPG sync status API to include cancellation state.
- Modified account update logic to handle EPG URL updates and cancellations.
- Enhanced error messages returned during account testing to be more user-friendly.
- Ensured that the frontend handles errors gracefully and provides clear feedback to users.
- Removed unnecessary variables and streamlined logic in various components.
- Improved type safety and consistency across the codebase.

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
