### PR TITLE
fix: normalize path handling for client paths and add tests for Windows separator support

### DIFF
--- a/src/lib/server/downloadClients/monitoring/PathMapping.test.ts
+++ b/src/lib/server/downloadClients/monitoring/PathMapping.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+	mapClientPathToLocal,
+	mapClientPathToLocalWithResult,
+	needsPathMapping
+} from './PathMapping';
+
+describe('PathMapping windows separator handling', () => {
+	it('maps Windows client paths with backslashes to Linux local paths', () => {
+		const mapped = mapClientPathToLocal(
+			'D:\\Torrent\\www.UIndex.org - The Simpsons S37E01',
+			'/downloads',
+			'D:\\Torrent'
+		);
+
+		expect(mapped).toBe('/downloads/www.UIndex.org - The Simpsons S37E01');
+	});
+
+	it('strips a leading backslash in the relative path after prefix removal', () => {
+		const mapped = mapClientPathToLocal('D:\\Torrent\\filename.mkv', '/downloads', 'D:\\Torrent');
+		expect(mapped).toBe('/downloads/filename.mkv');
+	});
+
+	it('maps Windows-style paths in detailed mapping mode', () => {
+		const result = mapClientPathToLocalWithResult('D:\\Torrent\\Show\\Episode.mkv', {
+			completeLocalPath: '/downloads',
+			completeRemotePath: 'D:\\Torrent'
+		});
+
+		expect(result).toEqual({
+			path: '/downloads/Show/Episode.mkv',
+			exact: true
+		});
+	});
+
+	it('treats slash style differences as already local in needsPathMapping', () => {
+		expect(needsPathMapping('\\downloads\\Show\\Episode.mkv', '/downloads')).toBe(false);
+	});
+});

--- a/src/lib/server/downloadClients/monitoring/PathMapping.ts
+++ b/src/lib/server/downloadClients/monitoring/PathMapping.ts
@@ -52,8 +52,8 @@ export interface PathMappingOptions {
 }
 
 function joinMappedPath(localBasePath: string, relativePath: string): string {
-	const normalizedLocal = localBasePath.replace(/\/+$/, '');
-	const normalizedRelative = relativePath.replace(/^\/+/, '');
+	const normalizedLocal = normalizePath(localBasePath, true);
+	const normalizedRelative = normalizeRelativePath(relativePath);
 
 	if (!normalizedRelative) {
 		return normalizedLocal;
@@ -78,6 +78,15 @@ function joinMappedPath(localBasePath: string, relativePath: string): string {
 	return `${normalizedLocal}/${normalizedRelative}`;
 }
 
+function normalizePath(path: string, trimTrailingSlash = false): string {
+	const normalized = path.replace(/\\/g, '/');
+	return trimTrailingSlash ? normalized.replace(/\/+$/, '') : normalized;
+}
+
+function normalizeRelativePath(path: string): string {
+	return normalizePath(path).replace(/^\/+/, '');
+}
+
 /**
  * Map a path from client's perspective to local filesystem path.
  * Supports dual folder mapping for SABnzbd (temp + completed folders).
@@ -97,12 +106,12 @@ export function mapClientPathToLocal(
 	tempRemotePath?: string | null
 ): string {
 	// Normalize client path
-	const normalizedClientPath = clientPath.replace(/\/+$/, '');
+	const normalizedClientPath = normalizePath(clientPath, true);
 
 	// Try completed folder mapping first
 	if (localBasePath && clientBasePath) {
-		const normalizedLocal = localBasePath.replace(/\/+$/, '');
-		const normalizedRemote = clientBasePath.replace(/\/+$/, '');
+		const normalizedLocal = normalizePath(localBasePath, true);
+		const normalizedRemote = normalizePath(clientBasePath, true);
 
 		if (normalizedClientPath.startsWith(normalizedRemote)) {
 			const relativePath = normalizedClientPath.slice(normalizedRemote.length);
@@ -124,8 +133,8 @@ export function mapClientPathToLocal(
 
 	// Try temp folder mapping (SABnzbd incomplete downloads)
 	if (tempLocalPath && tempRemotePath) {
-		const normalizedTempLocal = tempLocalPath.replace(/\/+$/, '');
-		const normalizedTempRemote = tempRemotePath.replace(/\/+$/, '');
+		const normalizedTempLocal = normalizePath(tempLocalPath, true);
+		const normalizedTempRemote = normalizePath(tempRemotePath, true);
 
 		if (normalizedClientPath.startsWith(normalizedTempRemote)) {
 			const relativePath = normalizedClientPath.slice(normalizedTempRemote.length);
@@ -150,7 +159,7 @@ export function mapClientPathToLocal(
 		return clientPath;
 	}
 
-	const normalizedLocal = localBasePath.replace(/\/+$/, '');
+	const normalizedLocal = normalizePath(localBasePath, true);
 
 	// Try to intelligently detect the common directory structure
 	// Look for common torrent client folder names
@@ -231,12 +240,12 @@ export function mapClientPathToLocalWithResult(
 	const { completeLocalPath, completeRemotePath, tempLocalPath, tempRemotePath } = options;
 
 	// Normalize client path
-	const normalizedClientPath = clientPath.replace(/\/+$/, '');
+	const normalizedClientPath = normalizePath(clientPath, true);
 
 	// Try completed folder mapping first
 	if (completeLocalPath && completeRemotePath) {
-		const normalizedLocal = completeLocalPath.replace(/\/+$/, '');
-		const normalizedRemote = completeRemotePath.replace(/\/+$/, '');
+		const normalizedLocal = normalizePath(completeLocalPath, true);
+		const normalizedRemote = normalizePath(completeRemotePath, true);
 
 		if (normalizedClientPath.startsWith(normalizedRemote)) {
 			const relativePath = normalizedClientPath.slice(normalizedRemote.length);
@@ -258,8 +267,8 @@ export function mapClientPathToLocalWithResult(
 
 	// Try temp folder mapping (SABnzbd incomplete downloads)
 	if (tempLocalPath && tempRemotePath) {
-		const normalizedTempLocal = tempLocalPath.replace(/\/+$/, '');
-		const normalizedTempRemote = tempRemotePath.replace(/\/+$/, '');
+		const normalizedTempLocal = normalizePath(tempLocalPath, true);
+		const normalizedTempRemote = normalizePath(tempRemotePath, true);
 
 		if (normalizedClientPath.startsWith(normalizedTempRemote)) {
 			const relativePath = normalizedClientPath.slice(normalizedTempRemote.length);
@@ -284,7 +293,7 @@ export function mapClientPathToLocalWithResult(
 		return { path: clientPath, exact: false, warning: 'No local path configured' };
 	}
 
-	const normalizedLocal = completeLocalPath.replace(/\/+$/, '');
+	const normalizedLocal = normalizePath(completeLocalPath, true);
 
 	// Try to intelligently detect the common directory structure
 	const commonPrefixes = ['/downloads', '/data', '/torrents', '/complete', '/finished', '/media'];
@@ -387,8 +396,11 @@ export function needsPathMapping(path: string, localBasePath: string | null | un
 		return false;
 	}
 
+	const normalizedPath = normalizePath(path);
+	const normalizedLocalBasePath = normalizePath(localBasePath);
+
 	// If the path already starts with the local base, no mapping needed
-	if (path.startsWith(localBasePath)) {
+	if (normalizedPath.startsWith(normalizedLocalBasePath)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

This pull request enhances the path mapping functionality in the download client monitoring module to better handle Windows and Linux path separators and normalization. It introduces new normalization functions and updates all mapping logic to use them, ensuring consistent and reliable conversion between client and local paths. Comprehensive tests have also been added to validate these improvements.

Path normalization improvements:

* Added `normalizePath` and `normalizeRelativePath` utility functions to consistently convert backslashes to slashes and trim extraneous slashes for both base and relative paths.
* Updated all path mapping logic in `mapClientPathToLocal`, `mapClientPathToLocalWithResult`, and related functions to use the new normalization utilities, replacing previous manual string replacements. [[1]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL55-R56) [[2]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL100-R114) [[3]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL127-R137) [[4]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL153-R162) [[5]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL234-R248) [[6]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL261-R271) [[7]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aL287-R296) [[8]](diffhunk://#diff-d3dfc2bdfa58929bc8ce21f9578886cdbee7757b1bb57f045c20f2bf8943b15aR399-R403)

Testing enhancements:

* Added a new test suite in `PathMapping.test.ts` to verify correct handling of Windows-style paths, conversion to Linux paths, and behavior of mapping functions with various path formats.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
Fixes: #210 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Normalize path handling for client paths and add tests for Windows separator support.

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
