### PR TITLE
fix(search): add filter to exclude non-video artifacts from movie/TV searches

### DIFF
--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -119,6 +119,27 @@ const DEFAULT_OPTIONS: Required<
 	useCache: true
 };
 
+const NON_VIDEO_ARTIFACT_TITLE_PATTERNS: RegExp[] = [
+	/\boriginal\s+soundtrack\b/i,
+	/\bsoundtrack\b/i,
+	/\b(?:film|movie|motion\s+picture|series)\s+score\b/i,
+	/\[(?:\s*(?:score|soundtrack|ost)\s*(?:,\s*(?:score|soundtrack|ost)\s*)*)\]/i,
+	/\((?:\s*(?:score|soundtrack|ost)\s*(?:,\s*(?:score|soundtrack|ost)\s*)*)\)/i,
+	/\bost\b/i,
+	/\bdiscography\b/i,
+	/\balbum\b/i,
+	/\bvinyl\b/i,
+	/\blossless\b/i,
+	/\bflac\b/i,
+	/\bmp3\b/i,
+	/\baac\b/i,
+	/\bm4a\b/i,
+	/\b(?:audio\s*)?cd\b/i
+];
+
+const VIDEO_SIGNAL_PATTERN =
+	/\b(?:\d{3,4}p|4k|8k|web[-.\s]?dl|web[-.\s]?rip|webrip|bluray|bdrip|bdremux|remux|hdtv|dvdrip|x264|x265|h\.?264|h\.?265|hevc|av1|s\d{1,2}e\d{1,3}|\d{1,2}x\d{2,3})\b/i;
+
 interface TvEpisodeCounts {
 	seriesEpisodeCount?: number;
 	seasonEpisodeCounts: Map<number, number>;
@@ -250,6 +271,7 @@ export class SearchOrchestrator {
 			const searchType = criteria.searchType as 'movie' | 'tv' | 'music' | 'book';
 			filtered = this.filterByCategoryMatch(filtered, searchType);
 		}
+		filtered = this.filterOutNonVideoArtifacts(filtered, criteriaWithSource);
 
 		// Rank
 		const ranked = this.ranker.rank(filtered);
@@ -378,6 +400,7 @@ export class SearchOrchestrator {
 			const searchType = enrichedCriteria.searchType as 'movie' | 'tv' | 'music' | 'book';
 			filtered = this.filterByCategoryMatch(filtered, searchType);
 		}
+		filtered = this.filterOutNonVideoArtifacts(filtered, enrichedCriteria);
 
 		// Hard filter by ID match with title+year fallback
 		// Completely removes releases with wrong IDs or mismatched title/year
@@ -1614,6 +1637,74 @@ export class SearchOrchestrator {
 
 			return hasMatchingCategory;
 		});
+	}
+
+	/**
+	 * Filter non-video artifacts (soundtracks/scores/audio collections) for movie/TV searches.
+	 * This is a safety net for indexers that mislabel categories or provide incomplete metadata.
+	 */
+	private filterOutNonVideoArtifacts(
+		releases: ReleaseResult[],
+		criteria: SearchCriteria
+	): ReleaseResult[] {
+		if (!isMovieSearch(criteria) && !isTvSearch(criteria)) {
+			return releases;
+		}
+
+		const beforeCount = releases.length;
+		const filtered = releases.filter((release) => {
+			const title = release.title ?? '';
+			if (!this.matchesNonVideoArtifactTitle(title)) {
+				return true;
+			}
+
+			const releaseWithCache = release as ReleaseResult & {
+				_parsedRelease?: ReturnType<typeof parseRelease>;
+			};
+			if (!releaseWithCache._parsedRelease) {
+				releaseWithCache._parsedRelease = parseRelease(title);
+			}
+			const parsed = releaseWithCache._parsedRelease;
+
+			// Keep only when there are strong video signals.
+			// We intentionally avoid trusting weak parser hints here because
+			// soundtrack-style titles can contain ambiguous tokens.
+			const hasVideoSignals =
+				VIDEO_SIGNAL_PATTERN.test(title) ||
+				parsed.episode !== undefined ||
+				(parsed.resolution !== null && parsed.resolution !== 'unknown');
+
+			if (!hasVideoSignals) {
+				logger.debug(
+					{
+						title: release.title,
+						searchType: criteria.searchType,
+						indexer: release.indexerName
+					},
+					'[SearchOrchestrator] Rejecting non-video artifact release'
+				);
+			}
+
+			return hasVideoSignals;
+		});
+
+		if (filtered.length < beforeCount) {
+			logger.info(
+				{
+					before: beforeCount,
+					after: filtered.length,
+					removed: beforeCount - filtered.length,
+					searchType: criteria.searchType
+				},
+				'[SearchOrchestrator] Non-video artifact filter removed releases'
+			);
+		}
+
+		return filtered;
+	}
+
+	private matchesNonVideoArtifactTitle(title: string): boolean {
+		return NON_VIDEO_ARTIFACT_TITLE_PATTERNS.some((pattern) => pattern.test(title));
 	}
 
 	/**

--- a/src/lib/server/indexers/search/searchorchestrator.spec.ts
+++ b/src/lib/server/indexers/search/searchorchestrator.spec.ts
@@ -660,6 +660,64 @@ describe('SearchOrchestrator.filterByIdOrTitleMatch', () => {
 	});
 });
 
+describe('SearchOrchestrator.filterOutNonVideoArtifacts', () => {
+	const orchestrator = new SearchOrchestrator();
+
+	it('rejects soundtrack/audio collection releases for movie searches', () => {
+		const releases = [
+			{
+				title: '(Score, Soundtrack) [CD] The Matrix Soundtrack Collection'
+			},
+			{
+				title: 'The.Matrix.1999.1080p.BluRay.x264'
+			}
+		] as any[];
+
+		const criteria = {
+			searchType: 'movie',
+			query: 'The Matrix'
+		} as any;
+
+		const filtered = (orchestrator as any).filterOutNonVideoArtifacts(releases, criteria);
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].title).toBe('The.Matrix.1999.1080p.BluRay.x264');
+	});
+
+	it('keeps video releases even when title contains ambiguous words', () => {
+		const releases = [
+			{
+				title: 'The.Score.2001.1080p.BluRay.x264'
+			}
+		] as any[];
+
+		const criteria = {
+			searchType: 'movie',
+			query: 'The Score'
+		} as any;
+
+		const filtered = (orchestrator as any).filterOutNonVideoArtifacts(releases, criteria);
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].title).toBe('The.Score.2001.1080p.BluRay.x264');
+	});
+
+	it('does not apply non-video artifact filter to music searches', () => {
+		const releases = [
+			{
+				title: 'The Matrix Soundtrack OST FLAC'
+			}
+		] as any[];
+
+		const criteria = {
+			searchType: 'music',
+			query: 'The Matrix Soundtrack'
+		} as any;
+
+		const filtered = (orchestrator as any).filterOutNonVideoArtifacts(releases, criteria);
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].title).toBe('The Matrix Soundtrack OST FLAC');
+	});
+});
+
 describe('SearchOrchestrator.filterByTitleRelevance', () => {
 	const orchestrator = new SearchOrchestrator();
 


### PR DESCRIPTION
## Summary

Adds a safety filter in the search pipeline to exclude non-video artifacts (for example soundtrack/score/audio collection releases) from `movie` and `tv` searches, so irrelevant audio-only results no longer appear in normal media results.

## Related Issues

Enhances: #235 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Added non-video artifact title patterns and strong video-signal heuristics in `SearchOrchestrator`.
- Added `filterOutNonVideoArtifacts(...)` and applied it in both regular and enriched search pipelines for movie/TV searches.
- Added/updated tests to verify soundtrack-style releases are excluded, valid video releases are kept, and music searches are unaffected.

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

Before:

<img width="1246" height="1113" alt="image" src="https://github.com/user-attachments/assets/c1d6d687-62ca-4be3-b60e-794b4ab5cb08" /><br>

After:
<img width="1235" height="1131" alt="image" src="https://github.com/user-attachments/assets/f368c280-e220-4cc1-9c84-014a2462cd19" />


