### PR TITLE
fix(search): enhance auto-search error handling and reporting

### DIFF
--- a/src/lib/server/downloads/CascadingSearchStrategy.ts
+++ b/src/lib/server/downloads/CascadingSearchStrategy.ts
@@ -124,6 +124,25 @@ class CascadingSearchStrategy {
 	private readonly DEFAULT_PACK_THRESHOLD = 50; // 50%
 	private readonly DEFAULT_MIN_SCORE = 0;
 
+	private summarizeGrabFailures(errors: string[], fallback: string): string {
+		if (errors.length === 0) return fallback;
+
+		const uniqueErrors = [...new Set(errors.map((e) => e.trim()).filter(Boolean))];
+		if (uniqueErrors.length === 0) return fallback;
+
+		// Prefer explicit client/config failures first.
+		const prioritized =
+			uniqueErrors.find((error) =>
+				error.toLowerCase().includes('no enabled torrent download client configured')
+			) ??
+			uniqueErrors.find((error) =>
+				error.toLowerCase().includes('no enabled usenet download client configured')
+			) ??
+			uniqueErrors[0];
+
+		return prioritized;
+	}
+
 	/**
 	 * Search for episodes using cascading strategy:
 	 * 1. Group by season
@@ -433,6 +452,7 @@ class CascadingSearchStrategy {
 
 			// Find best non-blocklisted season pack
 			const blocklistSpec = new ReleaseBlocklistSpecification({ seriesId: seriesData.id });
+			const grabErrors: string[] = [];
 
 			for (const release of seasonPacks) {
 				const releaseCandidate: ReleaseCandidate = {
@@ -497,9 +517,16 @@ class CascadingSearchStrategy {
 						episodesCovered: grabResult.episodesCovered || episodeIds
 					};
 				}
+
+				if (grabResult.error) {
+					grabErrors.push(grabResult.error);
+				}
 			}
 
-			return { grabbed: false, error: 'All season packs rejected or failed to grab' };
+			return {
+				grabbed: false,
+				error: this.summarizeGrabFailures(grabErrors, 'All season packs rejected or failed to grab')
+			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			return { grabbed: false, error: message };
@@ -565,6 +592,7 @@ class CascadingSearchStrategy {
 
 			// Find best non-blocklisted release
 			const blocklistSpec = new ReleaseBlocklistSpecification({ seriesId: seriesData.id });
+			const grabErrors: string[] = [];
 
 			for (const release of searchResult.releases) {
 				const releaseCandidate: ReleaseCandidate = {
@@ -648,9 +676,17 @@ class CascadingSearchStrategy {
 						episodesCovered: grabResult.episodesCovered
 					};
 				}
+
+				if (grabResult.error) {
+					grabErrors.push(grabResult.error);
+				}
 			}
 
-			return { found: true, grabbed: false, error: 'All releases rejected or failed to grab' };
+			return {
+				found: true,
+				grabbed: false,
+				error: this.summarizeGrabFailures(grabErrors, 'All releases rejected or failed to grab')
+			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			return { found: false, grabbed: false, error: message };

--- a/src/lib/server/library/autoSearchIssues.ts
+++ b/src/lib/server/library/autoSearchIssues.ts
@@ -1,0 +1,117 @@
+export interface AutoSearchIssue {
+	code:
+		| 'NO_DOWNLOAD_CLIENT'
+		| 'NO_INDEXER_AVAILABLE'
+		| 'INDEXER_TIMEOUT'
+		| 'INDEXER_RATE_LIMITED'
+		| 'GENERIC_ERROR';
+	message: string;
+	suggestion?: string;
+	count?: number;
+}
+
+function normalizeError(value: string): string {
+	return value.trim().replace(/\s+/g, ' ');
+}
+
+function classifyError(error: string): Omit<AutoSearchIssue, 'count'> | null {
+	const normalized = normalizeError(error);
+	const lower = normalized.toLowerCase();
+
+	if (lower.includes('no enabled torrent download client configured')) {
+		return {
+			code: 'NO_DOWNLOAD_CLIENT',
+			message: 'No torrent download client is enabled',
+			suggestion: 'Enable a torrent client in Settings > Integrations > Download Clients.'
+		};
+	}
+
+	if (lower.includes('no enabled usenet download client configured')) {
+		return {
+			code: 'NO_DOWNLOAD_CLIENT',
+			message: 'No usenet download client is enabled',
+			suggestion: 'Enable a usenet client in Settings > Integrations > Download Clients.'
+		};
+	}
+
+	if (
+		lower.includes('no indexers are available') ||
+		lower.includes('no eligible indexers') ||
+		lower.includes('indexer availability')
+	) {
+		return {
+			code: 'NO_INDEXER_AVAILABLE',
+			message: 'No eligible indexers are available for this search',
+			suggestion: 'Enable at least one indexer that supports this media type and profile.'
+		};
+	}
+
+	if (lower.includes('timeout')) {
+		return {
+			code: 'INDEXER_TIMEOUT',
+			message: 'Indexer search timed out',
+			suggestion: 'Try again in a moment or reduce enabled indexers/query variants.'
+		};
+	}
+
+	if (
+		lower.includes('rate limit') ||
+		lower.includes('too many requests') ||
+		lower.includes('429')
+	) {
+		return {
+			code: 'INDEXER_RATE_LIMITED',
+			message: 'Indexer rate limit reached',
+			suggestion: 'Wait briefly before retrying to avoid temporary blocking.'
+		};
+	}
+
+	// "No suitable releases found" is expected and not actionable on infra/config.
+	if (
+		lower.includes('no suitable releases found') ||
+		lower.includes('no upgrades found') ||
+		lower.includes('no releases found that')
+	) {
+		return null;
+	}
+
+	return {
+		code: 'GENERIC_ERROR',
+		message: normalized
+	};
+}
+
+export function collectAutoSearchIssues(
+	errors: Array<string | null | undefined>
+): AutoSearchIssue[] {
+	const tally = new Map<string, AutoSearchIssue>();
+
+	for (const raw of errors) {
+		if (!raw) continue;
+		const classified = classifyError(raw);
+		if (!classified) continue;
+
+		const key = `${classified.code}:${classified.message}:${classified.suggestion ?? ''}`;
+		const existing = tally.get(key);
+		if (existing) {
+			existing.count = (existing.count ?? 1) + 1;
+			continue;
+		}
+
+		tally.set(key, {
+			...classified,
+			count: 1
+		});
+	}
+
+	return [...tally.values()].sort((a, b) => {
+		const order: Record<AutoSearchIssue['code'], number> = {
+			NO_DOWNLOAD_CLIENT: 0,
+			NO_INDEXER_AVAILABLE: 1,
+			INDEXER_TIMEOUT: 2,
+			INDEXER_RATE_LIMITED: 3,
+			GENERIC_ERROR: 4
+		};
+		return order[a.code] - order[b.code];
+	});
+}

--- a/src/lib/server/library/autoSearchPreflight.ts
+++ b/src/lib/server/library/autoSearchPreflight.ts
@@ -1,0 +1,121 @@
+import { getDownloadClientManager } from '$lib/server/downloadClients/DownloadClientManager.js';
+import type { AutoSearchIssue } from '$lib/server/library/autoSearchIssues.js';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
+import {
+	CINEPHAGE_STREAM_DEFINITION_ID,
+	indexerHasCategoriesForSearchType,
+	type IndexerCapabilities,
+	type SearchType
+} from '$lib/server/indexers/types';
+
+function supportsSearchType(
+	capabilities: IndexerCapabilities | undefined,
+	searchType: SearchType
+): boolean {
+	if (!capabilities) return false;
+
+	switch (searchType) {
+		case 'movie':
+			return (
+				(capabilities.movieSearch?.available ?? false) &&
+				indexerHasCategoriesForSearchType(capabilities.categories, 'movie')
+			);
+		case 'tv':
+			return (
+				(capabilities.tvSearch?.available ?? false) &&
+				indexerHasCategoriesForSearchType(capabilities.categories, 'tv')
+			);
+		case 'music':
+			return (
+				(capabilities.musicSearch?.available ?? false) &&
+				indexerHasCategoriesForSearchType(capabilities.categories, 'music')
+			);
+		case 'book':
+			return (
+				(capabilities.bookSearch?.available ?? false) &&
+				indexerHasCategoriesForSearchType(capabilities.categories, 'book')
+			);
+		case 'basic':
+			return capabilities.search?.available ?? true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Auto-search preflight for workflows that are expected to grab downloads.
+ * Returns an actionable issue when eligible indexer protocols have no enabled client.
+ *
+ * Streamer profile is excluded because it can complete via streaming releases
+ * without download clients.
+ */
+export async function getAutoSearchPreflightIssue(
+	scoringProfileId: string | null | undefined,
+	searchType: SearchType
+): Promise<AutoSearchIssue | null> {
+	if (scoringProfileId === 'streamer') {
+		return null;
+	}
+
+	const indexerManager = await getIndexerManager();
+	const indexers = await indexerManager.getIndexers();
+	const profileScoped =
+		scoringProfileId === 'streamer'
+			? indexers.filter((indexer) => indexer.definitionId === CINEPHAGE_STREAM_DEFINITION_ID)
+			: indexers;
+	const eligibleIndexers = profileScoped.filter((indexer) => {
+		if (!indexer.enabled) return false;
+		if (indexer.enableInteractiveSearch === false) return false;
+		const capabilities = indexerManager.getDefinitionCapabilities(indexer.definitionId);
+		return supportsSearchType(capabilities, searchType);
+	});
+
+	const needsTorrent = eligibleIndexers.some((indexer) => indexer.protocol === 'torrent');
+	const needsUsenet = eligibleIndexers.some((indexer) => indexer.protocol === 'usenet');
+
+	if (!needsTorrent && !needsUsenet) {
+		return null;
+	}
+
+	const manager = getDownloadClientManager();
+	const [torrentClients, usenetClients] = await Promise.all([
+		manager.getEnabledClientsForProtocol('torrent'),
+		manager.getEnabledClientsForProtocol('usenet')
+	]);
+
+	const hasTorrent = torrentClients.length > 0;
+	const hasUsenet = usenetClients.length > 0;
+
+	if (needsTorrent && !hasTorrent && !needsUsenet) {
+		return {
+			code: 'NO_DOWNLOAD_CLIENT',
+			message: 'No torrent download client is enabled',
+			suggestion: 'Enable a torrent client in Settings > Integrations > Download Clients.'
+		};
+	}
+
+	if (needsUsenet && !hasUsenet && !needsTorrent) {
+		return {
+			code: 'NO_DOWNLOAD_CLIENT',
+			message: 'No usenet download client is enabled',
+			suggestion: 'Enable a usenet client in Settings > Integrations > Download Clients.'
+		};
+	}
+
+	if ((needsTorrent && !hasTorrent) || (needsUsenet && !hasUsenet)) {
+		// Mixed protocol indexers: allow search if at least one required protocol has a client.
+		if ((needsTorrent && hasTorrent) || (needsUsenet && hasUsenet)) {
+			return null;
+		}
+	}
+
+	if (hasTorrent || hasUsenet) {
+		return null;
+	}
+
+	return {
+		code: 'NO_DOWNLOAD_CLIENT',
+		message: 'No download client is enabled',
+		suggestion: 'Enable a torrent or usenet client in Settings > Integrations > Download Clients.'
+	};
+}

--- a/src/lib/server/library/searchOnAdd.ts
+++ b/src/lib/server/library/searchOnAdd.ts
@@ -137,6 +137,8 @@ interface MultiSearchResult {
 		individualEpisodesGrabbed?: number;
 	};
 	error?: string;
+	/** Additional operational errors collected during fallback attempts */
+	errors?: string[];
 	/** Season packs that were grabbed */
 	seasonPacks?: Array<{
 		seasonNumber: number;
@@ -154,6 +156,19 @@ class SearchOnAddService {
 	private readonly ALT_TITLE_REFRESH_CACHE_MAX_ENTRIES = 2000;
 	private readonly movieAltTitleRefreshAttempts = new Map<string, number>();
 	private readonly seriesAltTitleRefreshAttempts = new Map<string, number>();
+
+	private shouldExposeOperationalError(error: string | undefined): boolean {
+		if (!error) return false;
+		const normalized = error.trim().toLowerCase();
+		if (!normalized) return false;
+
+		// These are expected "no match" outcomes, not actionable operational failures.
+		return !(
+			normalized.includes('no suitable releases found') ||
+			normalized.includes('no upgrades found') ||
+			normalized.includes('no releases found that')
+		);
+	}
 
 	private pruneAltTitleRefreshCache(cache: Map<string, number>, now: number): void {
 		if (cache.size <= this.ALT_TITLE_REFRESH_CACHE_MAX_ENTRIES) {
@@ -1246,6 +1261,7 @@ class SearchOnAddService {
 				});
 
 				const results: AutoSearchItemResult[] = [];
+				const operationalErrors = new Set<string>();
 				let foundCount = 0;
 				let grabbedCount = 0;
 				let individualEpisodesGrabbed = 0;
@@ -1285,6 +1301,12 @@ class SearchOnAddService {
 							bypassMonitoring
 						});
 						const seasonPackWasGrabbed = seasonSearchResult.success;
+						if (
+							!seasonPackWasGrabbed &&
+							this.shouldExposeOperationalError(seasonSearchResult.error)
+						) {
+							operationalErrors.add(seasonSearchResult.error as string);
+						}
 
 						if (seasonPackWasGrabbed) {
 							seasonPacksGrabbed++;
@@ -1340,6 +1362,9 @@ class SearchOnAddService {
 							episodeId: episode.id,
 							bypassMonitoring
 						});
+						if (!searchResult.success && this.shouldExposeOperationalError(searchResult.error)) {
+							operationalErrors.add(searchResult.error as string);
+						}
 
 						const wasGrabbed = searchResult.success;
 						const wasFound = wasGrabbed;
@@ -1390,6 +1415,7 @@ class SearchOnAddService {
 						seasonPacksGrabbed,
 						individualEpisodesGrabbed
 					},
+					errors: operationalErrors.size > 0 ? [...operationalErrors] : undefined,
 					seasonPacks: seasonPacks.length > 0 ? seasonPacks : undefined
 				};
 			}
@@ -1471,6 +1497,9 @@ class SearchOnAddService {
 						searchResult.summary.completeSeriesPacksGrabbed,
 					individualEpisodesGrabbed: searchResult.summary.individualEpisodesGrabbed
 				},
+				errors: searchResult.results
+					.map((resultItem) => resultItem.error)
+					.filter((error): error is string => this.shouldExposeOperationalError(error)),
 				seasonPacks: allSeasonPacks
 			};
 		} catch (error) {
@@ -1559,6 +1588,7 @@ class SearchOnAddService {
 			}
 
 			const allResults: AutoSearchItemResult[] = [];
+			const operationalErrors = new Set<string>();
 			const allSeasonPacks: Array<{
 				seasonNumber: number;
 				releaseName: string;
@@ -1625,6 +1655,9 @@ class SearchOnAddService {
 
 				// Convert and aggregate results
 				for (const r of searchResult.results) {
+					if (this.shouldExposeOperationalError(r.error)) {
+						operationalErrors.add(r.error as string);
+					}
 					allResults.push({
 						itemId: r.episodeId,
 						itemLabel: r.episodeLabel,
@@ -1682,6 +1715,7 @@ class SearchOnAddService {
 						totalCompleteSeriesPacks + totalMultiSeasonPacks + totalSingleSeasonPacks,
 					individualEpisodesGrabbed: totalIndividualGrabbed
 				},
+				errors: operationalErrors.size > 0 ? [...operationalErrors] : undefined,
 				seasonPacks: allSeasonPacks.length > 0 ? allSeasonPacks : undefined
 			};
 		} catch (error) {

--- a/src/lib/stores/searchProgress.svelte.ts
+++ b/src/lib/stores/searchProgress.svelte.ts
@@ -26,6 +26,18 @@ export interface SearchState {
 export interface SearchResults {
 	success: boolean;
 	error?: string;
+	errors?: string[];
+	issues?: Array<{
+		code:
+			| 'NO_DOWNLOAD_CLIENT'
+			| 'NO_INDEXER_AVAILABLE'
+			| 'INDEXER_TIMEOUT'
+			| 'INDEXER_RATE_LIMITED'
+			| 'GENERIC_ERROR';
+		message: string;
+		suggestion?: string;
+		count?: number;
+	}>;
 	results?: unknown[];
 	// Movie search fields
 	found?: boolean;

--- a/src/lib/utils/autoSearchIssues.ts
+++ b/src/lib/utils/autoSearchIssues.ts
@@ -1,0 +1,21 @@
+import type { SearchResults } from '$lib/stores/searchProgress.svelte';
+
+export function getPrimaryAutoSearchIssue(
+	results: SearchResults | null | undefined
+): { message: string; description?: string } | null {
+	if (!results) return null;
+
+	const issue = results.issues?.[0];
+	if (issue) {
+		return {
+			message: issue.message,
+			description: issue.suggestion
+		};
+	}
+
+	if (results.error) {
+		return { message: results.error };
+	}
+
+	return null;
+}

--- a/src/routes/api/library/movies/[id]/auto-search/+server.ts
+++ b/src/routes/api/library/movies/[id]/auto-search/+server.ts
@@ -12,6 +12,8 @@ import { db } from '$lib/server/db/index.js';
 import { movies } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { logger } from '$lib/logging';
+import { collectAutoSearchIssues } from '$lib/server/library/autoSearchIssues.js';
+import { getAutoSearchPreflightIssue } from '$lib/server/library/autoSearchPreflight.js';
 
 /**
  * POST /api/library/movies/[id]/auto-search
@@ -70,6 +72,18 @@ export const POST: RequestHandler = async ({ params, request }) => {
 				});
 
 				try {
+					const preflightIssue = await getAutoSearchPreflightIssue(movie.scoringProfileId, 'movie');
+					if (preflightIssue) {
+						sendEvent('search:completed', {
+							success: false,
+							found: false,
+							grabbed: false,
+							error: preflightIssue.message,
+							issues: [preflightIssue]
+						});
+						return;
+					}
+
 					// Set up progress callback
 					const onProgress = (
 						phase: string,
@@ -122,6 +136,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 						},
 						'[API] Auto-search completed for movie'
 					);
+					const issues = collectAutoSearchIssues([result.error]);
 
 					// Send completion event
 					sendEvent('search:completed', {
@@ -130,6 +145,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 						grabbed: result.success && !!result.releaseName,
 						releaseName: result.releaseName,
 						queueItemId: result.queueItemId,
+						issues: issues.length > 0 ? issues : undefined,
 						error: result.error
 					});
 

--- a/src/routes/api/library/series/[id]/auto-search/+server.ts
+++ b/src/routes/api/library/series/[id]/auto-search/+server.ts
@@ -13,6 +13,8 @@ import { series } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { logger } from '$lib/logging';
 import type { SearchProgressUpdate } from '$lib/server/downloads/MultiSeasonSearchStrategy.js';
+import { collectAutoSearchIssues } from '$lib/server/library/autoSearchIssues.js';
+import { getAutoSearchPreflightIssue } from '$lib/server/library/autoSearchPreflight.js';
 
 /**
  * Auto-Search Request Types
@@ -134,6 +136,25 @@ export const POST: RequestHandler = async ({ params, request }) => {
 				};
 
 				try {
+					const preflightIssue = await getAutoSearchPreflightIssue(
+						seriesData.scoringProfileId,
+						'tv'
+					);
+					if (preflightIssue) {
+						sendEvent('search:completed', {
+							success: false,
+							results: [],
+							summary: {
+								searched: 0,
+								found: 0,
+								grabbed: 0
+							},
+							error: preflightIssue.message,
+							issues: [preflightIssue]
+						});
+						return;
+					}
+
 					switch (type) {
 						case 'episode': {
 							if (!episodeId) {
@@ -148,6 +169,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 								episodeId,
 								bypassMonitoring: true
 							});
+							const issues = collectAutoSearchIssues([result.error]);
 
 							sendEvent('search:completed', {
 								success: result.success,
@@ -161,6 +183,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 										error: result.error
 									}
 								],
+								issues: issues.length > 0 ? issues : undefined,
 								summary: {
 									searched: 1,
 									found: result.success ? 1 : 0,
@@ -184,6 +207,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 								seasonNumber,
 								bypassMonitoring: true
 							});
+							const issues = collectAutoSearchIssues([result.error]);
 
 							sendEvent('search:completed', {
 								success: result.success,
@@ -197,6 +221,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 										error: result.error
 									}
 								],
+								issues: issues.length > 0 ? issues : undefined,
 								summary: {
 									searched: 1,
 									found: result.success ? 1 : 0,
@@ -213,12 +238,20 @@ export const POST: RequestHandler = async ({ params, request }) => {
 								// Mixed/non-RuTracker setups stay on pack-first behavior.
 								searchStrategy: 'auto'
 							});
+							const itemErrors = result.results.map((item) => item.error);
+							const issues = collectAutoSearchIssues([
+								result.error,
+								...(result.errors ?? []),
+								...itemErrors
+							]);
 
 							sendEvent('search:completed', {
 								success: !result.error,
 								results: result.results,
 								summary: result.summary,
 								seasonPacks: result.seasonPacks,
+								errors: result.errors,
+								issues: issues.length > 0 ? issues : undefined,
 								error: result.error
 							});
 							break;
@@ -234,12 +267,20 @@ export const POST: RequestHandler = async ({ params, request }) => {
 							}
 
 							const result = await searchOnAdd.searchBulkEpisodes(episodeIds, onProgress);
+							const itemErrors = result.results.map((item) => item.error);
+							const issues = collectAutoSearchIssues([
+								result.error,
+								...(result.errors ?? []),
+								...itemErrors
+							]);
 
 							sendEvent('search:completed', {
 								success: !result.error,
 								results: result.results,
 								summary: result.summary,
 								seasonPacks: result.seasonPacks,
+								errors: result.errors,
+								issues: issues.length > 0 ? issues : undefined,
 								error: result.error
 							});
 							break;

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -273,6 +273,7 @@
 	}
 
 	import { createSearchProgress } from '$lib/stores/searchProgress.svelte';
+	import { getPrimaryAutoSearchIssue } from '$lib/utils/autoSearchIssues';
 
 	const searchProgress = createSearchProgress();
 
@@ -304,10 +305,11 @@
 				};
 
 				// Show toast notification
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
 				if (searchProgress.results.grabbed) {
 					toasts.success(`Found and grabbed: ${searchProgress.results.releaseName}`);
-				} else if (searchProgress.results.error) {
-					toasts.error(searchProgress.results.error);
+				} else if (issue) {
+					toasts.error(issue.message, { description: issue.description });
 				} else {
 					toasts.info('No suitable releases found');
 				}

--- a/src/routes/library/movies/+page.svelte
+++ b/src/routes/library/movies/+page.svelte
@@ -18,6 +18,7 @@
 	import { enhance } from '$app/forms';
 	import { Eye } from 'lucide-svelte';
 	import { createSearchProgress } from '$lib/stores/searchProgress.svelte';
+	import { getPrimaryAutoSearchIssue } from '$lib/utils/autoSearchIssues';
 	import { createProgressiveRenderer } from '$lib/utils/progressive-render.svelte.js';
 
 	let { data } = $props();
@@ -225,12 +226,13 @@
 			await searchProgress.startSearch(`/api/library/movies/${movieId}/auto-search`);
 
 			if (searchProgress.results) {
-				if (searchProgress.results.error) {
-					toasts.error(searchProgress.results.error);
-				} else if (searchProgress.results.grabbed) {
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
+				if (searchProgress.results.grabbed) {
 					toasts.success(
 						`Auto-grabbed "${searchProgress.results.releaseName}" for "${movie.title}"`
 					);
+				} else if (issue) {
+					toasts.error(issue.message, { description: issue.description });
 				} else if (searchProgress.results.found) {
 					toasts.info(`Found releases but none met criteria for "${movie.title}"`);
 				} else {

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -18,6 +18,7 @@
 	import { enhance } from '$app/forms';
 	import { Eye } from 'lucide-svelte';
 	import { createSearchProgress } from '$lib/stores/searchProgress.svelte';
+	import { getPrimaryAutoSearchIssue } from '$lib/utils/autoSearchIssues';
 	import { createProgressiveRenderer } from '$lib/utils/progressive-render.svelte.js';
 
 	let { data } = $props();
@@ -232,10 +233,11 @@
 
 			if (searchProgress.results) {
 				const summary = searchProgress.results.summary;
-				if (searchProgress.results.error) {
-					toasts.error(searchProgress.results.error);
-				} else if (summary && summary.grabbed > 0) {
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
+				if (summary && summary.grabbed > 0) {
 					toasts.success(`Auto-grabbed ${summary.grabbed} release(s) for "${show.title}"`);
+				} else if (issue) {
+					toasts.error(issue.message, { description: issue.description });
 				} else if (summary && summary.found > 0) {
 					toasts.info(`Found ${summary.found} releases but none met criteria for "${show.title}"`);
 				} else {

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -22,6 +22,7 @@
 	import { resolvePath } from '$lib/utils/routing';
 	import { createDynamicSSE } from '$lib/sse';
 	import { createSearchProgress } from '$lib/stores/searchProgress.svelte';
+	import { getPrimaryAutoSearchIssue } from '$lib/utils/autoSearchIssues';
 	import { layoutState, deriveMobileSseStatus } from '$lib/layout.svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -864,6 +865,7 @@
 			});
 
 			if (searchProgress.results) {
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
 				const itemResult = searchProgress.results.results?.[0] as
 					| { found?: boolean; grabbed?: boolean; releaseName?: string; error?: string }
 					| undefined;
@@ -871,7 +873,7 @@
 					found: itemResult?.found ?? false,
 					grabbed: itemResult?.grabbed ?? false,
 					releaseName: itemResult?.releaseName,
-					error: itemResult?.error ?? searchProgress.results.error
+					error: itemResult?.error ?? searchProgress.results.error ?? issue?.message
 				});
 
 				// Clear result after 5 seconds
@@ -906,6 +908,7 @@
 			});
 
 			if (searchProgress.results) {
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
 				const itemResult = searchProgress.results.results?.[0] as
 					| { found?: boolean; grabbed?: boolean; releaseName?: string; error?: string }
 					| undefined;
@@ -913,7 +916,7 @@
 					found: itemResult?.found ?? false,
 					grabbed: itemResult?.grabbed ?? false,
 					releaseName: itemResult?.releaseName,
-					error: itemResult?.error ?? searchProgress.results.error
+					error: itemResult?.error ?? searchProgress.results.error ?? issue?.message
 				});
 
 				// Clear result after 5 seconds
@@ -947,6 +950,7 @@
 			});
 
 			if (searchProgress.results) {
+				const issue = getPrimaryAutoSearchIssue(searchProgress.results);
 				const results = searchProgress.results.results as
 					| Array<{ found?: boolean; grabbed?: boolean }>
 					| undefined;
@@ -959,9 +963,16 @@
 				// Streaming grabs can complete before queue/file SSE updates arrive; refresh once so
 				// the episode/file counters reflect the completed auto-grab immediately.
 				if ((missingSearchResult.grabbed ?? 0) > 0) {
+					toasts.success(`Grabbed ${missingSearchResult.grabbed} missing release(s)`);
 					setTimeout(() => {
 						void refreshSeriesFromApi();
 					}, 500);
+				} else if (issue) {
+					toasts.error(issue.message, { description: issue.description });
+				} else if ((missingSearchResult.found ?? 0) > 0) {
+					toasts.info('Found releases, but none were grab-eligible.');
+				} else {
+					toasts.info('No suitable releases found for missing episodes.');
 				}
 			}
 


### PR DESCRIPTION
## Summary

This PR makes auto-search failures much more actionable by replacing generic errors with protocol-aware, user-friendly issues.  
It adds a preflight guard to stop searches early when no compatible download client is enabled, and surfaces clear toast feedback in movie/TV pages.

## Related Issues

Enhances: #237 
Fixes: #228 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [x] Other: UX/error reporting improvements for existing search flow

## Changes Made

- Added server-side issue classification for auto-search failures (`NO_DOWNLOAD_CLIENT`, `NO_INDEXER_AVAILABLE`, `INDEXER_TIMEOUT`, `INDEXER_RATE_LIMITED`, `GENERIC_ERROR`).
- Added auto-search preflight checks to movie/series auto-search APIs to fail fast with actionable guidance when no compatible torrent/usenet client is enabled.
- Updated cascading search strategy to preserve and prioritize specific grab failures instead of returning only generic fallback messages.
- Updated `searchOnAdd` to collect operational errors across attempts and include them in response payloads.
- Extended search progress result typing to support `errors[]` and structured `issues[]`.
- Updated movie/TV pages to show concise, human-friendly toast messages (with suggestions) from structured issue data.

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [x] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

N/A
