### PR TITLE
fix(indexers): update Kinozal and RuTracker configurations for improved Cyrillic handling and search strategies

### DIFF
--- a/data/indexers/definitions/kinozal-magnet.yaml
+++ b/data/indexers/definitions/kinozal-magnet.yaml
@@ -86,7 +86,7 @@ settings:
   - name: stripcyrillic
     type: checkbox
     label: Strip Cyrillic Letters
-    default: true
+    default: false
   - name: sort
     type: select
     label: Sort requested from site
@@ -211,11 +211,17 @@ search:
         - name: re_replace
           args:
             [
-              '(\([А-Яа-яЁё\W]+\))|(^[А-Яа-яЁё\W\d]+/ ((?:[12][0-9]{3}-?){1,}))|(^[А-Яа-яЁё\W\d]+/ )|([а-яА-ЯЁё \-]+,+)|([а-яА-ЯЁё]+)',
+              '(?i)\s*\([^\)]*?[А-Яа-яЁё]{2,}[^\)]*?\)',
               '{{ if .Config.stripcyrillic }}{{ else }}$0{{ end }}'
             ]
+        - name: re_replace
+          args: ['[А-Яа-яЁё]+', '{{ if .Config.stripcyrillic }}{{ else }}$&{{ end }}']
         - name: replace
-          args: [' / ', ' ']
+          args: [' / ', '{{ if .Config.stripcyrillic }} {{ else }} / {{ end }}']
+        - name: re_replace
+          args: ['^\s*[-–—]+\s*/\s*', '']
+        - name: re_replace
+          args: ['^\s*/\s*', '']
         - name: re_replace
           args: ['^-\s+', ' ']
         - name: re_replace
@@ -230,6 +236,7 @@ search:
           args: ['WEBDLRip', 'WEBDL']
         - name: replace
           args: ['HDTVRip', 'HDTV']
+        - name: trim
     details:
       selector: 'td.nam a[href^="/details.php?"]'
       attribute: href

--- a/data/indexers/definitions/kinozal.yaml
+++ b/data/indexers/definitions/kinozal.yaml
@@ -90,7 +90,7 @@ settings:
   - name: stripcyrillic
     type: checkbox
     label: Strip Cyrillic Letters
-    default: true
+    default: false
   - name: sort
     type: select
     label: Sort requested from site
@@ -197,11 +197,17 @@ search:
         - name: re_replace
           args:
             [
-              "(\\([А-Яа-яЁё\\W]+\\))|(^[А-Яа-яЁё\\W\\d]+\\/ ((?:[12][0-9]{3}-?){1,}))|(^[А-Яа-яЁё\\W\\d]+\\/ )|([а-яА-ЯЁё \\-]+,+)|([а-яА-ЯЁё]+)",
+              '(?i)\\s*\\([^\\)]*?[А-Яа-яЁё]{2,}[^\\)]*?\\)',
               '{{ if .Config.stripcyrillic }}{{ else }}$0{{ end }}'
             ]
+        - name: re_replace
+          args: ['[А-Яа-яЁё]+', '{{ if .Config.stripcyrillic }}{{ else }}$&{{ end }}']
         - name: replace
-          args: [' / ', ' ']
+          args: [' / ', '{{ if .Config.stripcyrillic }} {{ else }} / {{ end }}']
+        - name: re_replace
+          args: ['^\s*[-–—]+\s*/\s*', '']
+        - name: re_replace
+          args: ['^\s*/\s*', '']
         - name: re_replace
           args: ["^-\\s+", ' ']
         - name: re_replace
@@ -216,6 +222,7 @@ search:
           args: ['WEBDLRip', 'WEBDL']
         - name: replace
           args: ['HDTVRip', 'HDTV']
+        - name: trim
     details:
       selector: td.nam a[href^="/details.php?"]
       attribute: href

--- a/data/indexers/definitions/rutracker.yaml
+++ b/data/indexers/definitions/rutracker.yaml
@@ -20,7 +20,7 @@ settings:
     label: Password
   - name: stripcyrillic
     type: checkbox
-    label: Strip Russian letters
+    label: Strip Cyrillic Letters
     default: false
   - name: usemagnetlinks
     type: checkbox

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -1363,7 +1363,7 @@ export class SearchOrchestrator {
 							title,
 							error: message
 						},
-						'RuTracker season pointer search variant failed'
+						'Pointer-indexer season search variant failed'
 					);
 				}
 			}
@@ -1490,14 +1490,14 @@ export class SearchOrchestrator {
 	 *
 	 * For TV searches with season/episode specified:
 	 * - Season-only search: Returns single-season packs that exactly match the target season
-	 *   (multi-season packs and complete series are excluded; RuTracker packs must be verifiably complete)
+	 *   (multi-season packs and complete series are excluded; pointer-indexer packs must be verifiably complete)
 	 * - Season+episode search:
-	 *   - RuTracker: returns episode pointers from matching season packs (never raw season packs)
+	 *   - RuTracker/Kinozal: returns episode pointers from matching season packs (never raw season packs)
 	 *   - Other indexers:
 	 *     - interactive: returns exact episodes, falls back to season-pack pointers
 	 *     - automatic: returns exact episodes and season-pack candidates
 	 * - Episode-only search:
-	 *   - RuTracker: returns episode pointers from matching season packs (never raw season packs)
+	 *   - RuTracker/Kinozal: returns episode pointers from matching season packs (never raw season packs)
 	 *   - Other indexers:
 	 *     - interactive: returns exact episodes, falls back to season-pack pointers
 	 *     - automatic: returns exact episodes and season-pack candidates
@@ -1745,7 +1745,7 @@ export class SearchOrchestrator {
 					indexer: release.indexerName,
 					expectedSeasonEpisodeCount
 				},
-				'[SearchOrchestrator] Rejecting incomplete RuTracker season pack for season-only search'
+				'[SearchOrchestrator] Rejecting incomplete pointer-indexer season pack for season-only search'
 			);
 		}
 
@@ -1778,7 +1778,7 @@ export class SearchOrchestrator {
 				? expectedSeasonEpisodeCount
 				: explicitTotal;
 
-		// For RuTracker season-pack grabs we require a verifiable complete-season signal.
+		// For pointer-indexer season-pack grabs we require a verifiable complete-season signal.
 		if (expectedTotal === undefined || expectedTotal <= 0) {
 			return false;
 		}
@@ -1831,7 +1831,11 @@ export class SearchOrchestrator {
 	}
 
 	private isRuTrackerIndexerName(indexerName: string | undefined): boolean {
-		return typeof indexerName === 'string' && indexerName.toLowerCase().includes('rutracker');
+		if (typeof indexerName !== 'string') {
+			return false;
+		}
+		const normalized = indexerName.toLowerCase();
+		return normalized.includes('rutracker') || normalized.includes('kinozal');
 	}
 
 	private isRuTrackerHost(baseUrl: string | undefined): boolean {
@@ -1839,9 +1843,11 @@ export class SearchOrchestrator {
 			return false;
 		}
 		try {
-			return new URL(baseUrl).hostname.toLowerCase().includes('rutracker.');
+			const hostname = new URL(baseUrl).hostname.toLowerCase();
+			return hostname.includes('rutracker.') || hostname.includes('kinozal.');
 		} catch {
-			return baseUrl.toLowerCase().includes('rutracker.');
+			const normalized = baseUrl.toLowerCase();
+			return normalized.includes('rutracker.') || normalized.includes('kinozal.');
 		}
 	}
 

--- a/src/lib/server/library/searchOnAdd.test.ts
+++ b/src/lib/server/library/searchOnAdd.test.ts
@@ -728,6 +728,74 @@ describe('SearchOnAddService.searchForMissingEpisodes monitoring behavior', () =
 		expect(searchForEpisodeSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it('uses episode-only strategy in auto mode when Kinozal is the only eligible TV indexer', async () => {
+		const kinozalOnlyIndexerManager = createIndexerManagerMockWith([
+			{
+				...TEST_INDEXER_CONFIG,
+				id: 'indexer-kinozal',
+				name: 'Kinozal',
+				definitionId: 'kinozal',
+				protocol: 'torrent',
+				baseUrl: 'https://kinozal.tv'
+			}
+		]);
+		mocks.getIndexerManager.mockResolvedValue(kinozalOnlyIndexerManager);
+		mocks.seriesFindFirst.mockResolvedValue({
+			id: 'series-1',
+			title: 'Afro Samurai',
+			tmdbId: 19544,
+			tvdbId: 79755,
+			imdbId: 'tt0465316',
+			scoringProfileId: 'balanced'
+		});
+		mocks.episodesFindMany
+			.mockResolvedValueOnce([
+				{
+					id: 'ep-1',
+					seriesId: 'series-1',
+					seasonNumber: 1,
+					episodeNumber: 1,
+					hasFile: false,
+					monitored: true,
+					airDate: '2007-01-03'
+				}
+			])
+			.mockResolvedValueOnce([
+				{
+					id: 'ep-1',
+					seriesId: 'series-1',
+					seasonNumber: 1,
+					episodeNumber: 1,
+					hasFile: false,
+					monitored: true,
+					airDate: '2007-01-03'
+				},
+				{
+					id: 'ep-2',
+					seriesId: 'series-1',
+					seasonNumber: 1,
+					episodeNumber: 2,
+					hasFile: true,
+					monitored: true,
+					airDate: '2007-01-10'
+				}
+			]);
+
+		const searchForEpisodeSpy = vi
+			.spyOn(searchOnAdd, 'searchForEpisode')
+			.mockResolvedValue({ success: false, error: 'No suitable releases found' });
+		const searchForSeasonSpy = vi.spyOn(searchOnAdd, 'searchForSeason');
+
+		await searchOnAdd.searchForMissingEpisodes('series-1', undefined, {
+			bypassMonitoring: true,
+			searchStrategy: 'auto'
+		});
+
+		expect(mocks.searchWithMultiSeasonPriority).not.toHaveBeenCalled();
+		expect(searchForSeasonSpy).not.toHaveBeenCalled();
+		expect(searchForEpisodeSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it('keeps pack-first strategy in auto mode when non-RuTracker TV indexers are also eligible', async () => {
 		const mixedIndexerManager = createIndexerManagerMockWith([
 			{

--- a/src/lib/server/library/searchOnAdd.ts
+++ b/src/lib/server/library/searchOnAdd.ts
@@ -107,7 +107,7 @@ interface SearchForMissingEpisodesOptions {
 	 * - 'pack-first': complete/multi-season/single-season packs, then episodes
 	 * - 'episode-only': targeted episode searches, but if an entire aired season is missing
 	 *   we attempt a single-season pack grab first
-	 * - 'auto': use episode-only only when RuTracker is the sole eligible TV indexer
+	 * - 'auto': use episode-only only when RuTracker/Kinozal is the sole eligible TV indexer
 	 */
 	searchStrategy?: 'pack-first' | 'episode-only' | 'auto';
 }
@@ -1772,7 +1772,11 @@ class SearchOnAddService {
 	}
 
 	private isRuTrackerIndexerName(indexerName: string | undefined): boolean {
-		return typeof indexerName === 'string' && indexerName.toLowerCase().includes('rutracker');
+		if (typeof indexerName !== 'string') {
+			return false;
+		}
+		const normalized = indexerName.toLowerCase();
+		return normalized.includes('rutracker') || normalized.includes('kinozal');
 	}
 
 	private isRuTrackerHost(baseUrl: string | undefined): boolean {
@@ -1780,9 +1784,11 @@ class SearchOnAddService {
 			return false;
 		}
 		try {
-			return new URL(baseUrl).hostname.toLowerCase().includes('rutracker.');
+			const hostname = new URL(baseUrl).hostname.toLowerCase();
+			return hostname.includes('rutracker.') || hostname.includes('kinozal.');
 		} catch {
-			return baseUrl.toLowerCase().includes('rutracker.');
+			const normalized = baseUrl.toLowerCase();
+			return normalized.includes('rutracker.') || normalized.includes('kinozal.');
 		}
 	}
 }

--- a/src/lib/server/monitoring/search/MonitoringSearchService.ts
+++ b/src/lib/server/monitoring/search/MonitoringSearchService.ts
@@ -728,8 +728,9 @@ export class MonitoringSearchService {
 			const missingPercent = (missingEpisodes.length / totalEpisodes) * 100;
 			const isEntireSeasonMissing = totalEpisodes > 0 && missingEpisodes.length >= totalEpisodes;
 
-			// When RuTracker is the only automatic TV source, avoid season-pack requests unless
-			// the full season is missing. Partial seasons should use episode-pointer flow.
+			// When RuTracker/Kinozal is the only automatic TV source, avoid season-pack
+			// requests unless the full season is missing. Partial seasons should use
+			// episode-pointer flow.
 			if (useRuTrackerEpisodePointerPolicy && !isEntireSeasonMissing) {
 				logger.debug(
 					{
@@ -739,7 +740,7 @@ export class MonitoringSearchService {
 						totalEpisodes,
 						missingPercent: missingPercent.toFixed(1)
 					},
-					'[MonitoringSearch] Skipping season pack search - RuTracker pointer policy (partial season)'
+					'[MonitoringSearch] Skipping season pack search - pointer policy (partial season)'
 				);
 				continue;
 			}
@@ -991,7 +992,7 @@ export class MonitoringSearchService {
 							missingEpisodes: missingEpisodes.length,
 							seasonEpisodeCount
 						},
-						'[MonitoringSearch] Skipping RuTracker season pack for partial-missing season'
+						'[MonitoringSearch] Skipping pointer-indexer season pack for partial-missing season'
 					);
 					continue;
 				}
@@ -2692,7 +2693,8 @@ export class MonitoringSearchService {
 				const isSeasonPack = parsedEpisode?.isSeasonPack ?? false;
 				const isEpisodePointer = this.isEpisodePointerRelease(release);
 
-				// RuTracker episode-targeted missing-content search should not grab full season packs.
+				// Pointer-indexer episode-targeted missing-content search should not grab
+				// full season packs.
 				// Allow virtual episode pointers because they resolve to per-episode file selection.
 				if (this.isRuTrackerIndexerName(release.indexerName) && isSeasonPack && !isEpisodePointer) {
 					logger.debug(
@@ -2701,7 +2703,7 @@ export class MonitoringSearchService {
 							episodeId: episode.id,
 							title: release.title
 						},
-						'[MonitoringSearch] Skipping RuTracker season pack in episode-targeted search'
+						'[MonitoringSearch] Skipping pointer-indexer season pack in episode-targeted search'
 					);
 					continue;
 				}
@@ -2814,7 +2816,11 @@ export class MonitoringSearchService {
 	}
 
 	private isRuTrackerIndexerName(indexerName: string | undefined): boolean {
-		return typeof indexerName === 'string' && indexerName.toLowerCase().includes('rutracker');
+		if (typeof indexerName !== 'string') {
+			return false;
+		}
+		const normalized = indexerName.toLowerCase();
+		return normalized.includes('rutracker') || normalized.includes('kinozal');
 	}
 
 	private isRuTrackerHost(baseUrl: string | undefined): boolean {
@@ -2822,9 +2828,11 @@ export class MonitoringSearchService {
 			return false;
 		}
 		try {
-			return new URL(baseUrl).hostname.toLowerCase().includes('rutracker.');
+			const hostname = new URL(baseUrl).hostname.toLowerCase();
+			return hostname.includes('rutracker.') || hostname.includes('kinozal.');
 		} catch {
-			return baseUrl.toLowerCase().includes('rutracker.');
+			const normalized = baseUrl.toLowerCase();
+			return normalized.includes('rutracker.') || normalized.includes('kinozal.');
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR improves tracker behavior for Cyrillic and pointer-based episode workflows by aligning Kinozal with the same handling strategy used for RuTracker. It preserves bilingual release naming more cleanly, avoids over-stripping localized text by default, and applies pointer-indexer logic consistently in missing-episode automation paths.

## Related Issues

Enhances: #236 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Updated `kinozal.yaml` and `kinozal-magnet.yaml` Cyrillic/title cleanup behavior:
  - `stripcyrillic` now defaults to `false`
  - improved regex cleanup for Cyrillic parentheticals
  - preserved ` / ` separator when Cyrillic stripping is disabled
  - added cleanup for leading slash/dash artifacts and final `trim`
- Updated `rutracker.yaml` setting label from “Strip Russian letters” to “Strip Cyrillic Letters” for consistency.
- Expanded RuTracker-specific pointer policy to include Kinozal in:
  - `SearchOrchestrator`
  - `SearchOnAddService`
  - `MonitoringSearchService`
  (including host/indexer checks and related logging/messages).
- Added test coverage in `searchOnAdd.test.ts` for auto strategy behavior when Kinozal is the only eligible TV indexer.

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
N/A 
