### PR TITLE
feat(ui): move scan banner to visible location, minor ui/backend tweaks

### DIFF
--- a/src/lib/components/libraries/LibraryList.svelte
+++ b/src/lib/components/libraries/LibraryList.svelte
@@ -141,7 +141,7 @@
 												<span
 													class={hasAssignedRootFolders(library.rootFolders)
 														? ''
-														: 'badge badge-warning '}
+														: 'badge badge-sm badge-warning'}
 												>
 													{formatRootFolderSummary(library.rootFolders)}
 												</span>

--- a/src/lib/components/libraries/StorageMaintenanceSection.svelte
+++ b/src/lib/components/libraries/StorageMaintenanceSection.svelte
@@ -360,7 +360,69 @@
 	</div>
 {/if}
 
-<div class="space-y-4">
+{#if rootFolderCount === 0}
+	<div class="mt-4 alert alert-warning">
+		<AlertCircle class="h-5 w-5" />
+		<span>{m.settings_general_addFolderFirst()}</span>
+	</div>
+{/if}
+
+{#if scanError}
+	<div class="mt-4 alert alert-error">
+		<AlertCircle class="h-5 w-5" />
+		<span>{scanError}</span>
+	</div>
+{/if}
+
+{#if scanSuccess}
+	<div class="mt-4 alert alert-success">
+		<CheckCircle class="h-5 w-5" />
+		<div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+			<span>{scanSuccess.message}</span>
+			{#if scanSuccess.unmatchedCount > 0}
+				<a href="/library/unmatched" class="btn gap-1 btn-ghost btn-sm">
+					{m.settings_general_viewUnmatchedFiles({ count: scanSuccess.unmatchedCount })}
+					<ExternalLink class="h-3 w-3" />
+				</a>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+{#if scanning && scanProgress}
+	<div class="card mt-4 bg-base-200 p-3 sm:p-4">
+		<div class="mb-2 flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:justify-between">
+			<span class="max-w-md truncate">
+				{scanProgress.phase === 'scanning' ? m.settings_general_discoveringFiles() : ''}
+				{scanProgress.phase === 'processing' ? m.settings_general_processing() : ''}
+				{scanProgress.phase === 'matching' ? m.settings_general_matchingFiles() : ''}
+				{scanProgress.rootFolderPath ?? ''}
+			</span>
+			<span class="text-base-content/60">
+				{scanProgress.filesProcessed} / {scanProgress.filesFound}
+				{m.common_files()}
+			</span>
+		</div>
+		<progress
+			class="progress w-full progress-primary"
+			value={scanProgress.filesProcessed}
+			max={scanProgress.filesFound || 1}
+		></progress>
+		<div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/60">
+			<span>{m.settings_general_scanAdded()}: {scanProgress.filesAdded}</span>
+			<span>{m.settings_general_scanUpdated()}: {scanProgress.filesUpdated}</span>
+			<span>{m.settings_general_scanRemoved()}: {scanProgress.filesRemoved}</span>
+			<span>{m.settings_general_scanUnmatched()}: {scanProgress.unmatchedCount}</span>
+		</div>
+		{#if scanProgress.currentFile}
+			<div class="mt-2 truncate text-xs text-base-content/50">
+				{scanProgress.currentFile}
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<div class="mt-6 space-y-4">
 	<div class="rounded-lg border border-base-300 bg-base-100 p-4">
 		<div class="mb-3 flex items-center gap-2">
 			<RefreshCw class="h-4 w-4" />
@@ -608,68 +670,6 @@
 		</div>
 	</div>
 </div>
-
-{#if rootFolderCount === 0}
-	<div class="mt-4 alert alert-warning">
-		<AlertCircle class="h-5 w-5" />
-		<span>{m.settings_general_addFolderFirst()}</span>
-	</div>
-{/if}
-
-{#if scanError}
-	<div class="mt-4 alert alert-error">
-		<AlertCircle class="h-5 w-5" />
-		<span>{scanError}</span>
-	</div>
-{/if}
-
-{#if scanSuccess}
-	<div class="mt-4 alert alert-success">
-		<CheckCircle class="h-5 w-5" />
-		<div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-			<span>{scanSuccess.message}</span>
-			{#if scanSuccess.unmatchedCount > 0}
-				<a href="/library/unmatched" class="btn gap-1 btn-ghost btn-sm">
-					{m.settings_general_viewUnmatchedFiles({ count: scanSuccess.unmatchedCount })}
-					<ExternalLink class="h-3 w-3" />
-				</a>
-			{/if}
-		</div>
-	</div>
-{/if}
-
-{#if scanning && scanProgress}
-	<div class="card mt-4 bg-base-200 p-3 sm:p-4">
-		<div class="mb-2 flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:justify-between">
-			<span class="max-w-md truncate">
-				{scanProgress.phase === 'scanning' ? m.settings_general_discoveringFiles() : ''}
-				{scanProgress.phase === 'processing' ? m.settings_general_processing() : ''}
-				{scanProgress.phase === 'matching' ? m.settings_general_matchingFiles() : ''}
-				{scanProgress.rootFolderPath ?? ''}
-			</span>
-			<span class="text-base-content/60">
-				{scanProgress.filesProcessed} / {scanProgress.filesFound}
-				{m.common_files()}
-			</span>
-		</div>
-		<progress
-			class="progress w-full progress-primary"
-			value={scanProgress.filesProcessed}
-			max={scanProgress.filesFound || 1}
-		></progress>
-		<div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/60">
-			<span>{m.settings_general_scanAdded()}: {scanProgress.filesAdded}</span>
-			<span>{m.settings_general_scanUpdated()}: {scanProgress.filesUpdated}</span>
-			<span>{m.settings_general_scanRemoved()}: {scanProgress.filesRemoved}</span>
-			<span>{m.settings_general_scanUnmatched()}: {scanProgress.unmatchedCount}</span>
-		</div>
-		{#if scanProgress.currentFile}
-			<div class="mt-2 truncate text-xs text-base-content/50">
-				{scanProgress.currentFile}
-			</div>
-		{/if}
-	</div>
-{/if}
 
 <div class="mt-6 grid gap-6 xl:grid-cols-2">
 	<div id="libraries-usage">

--- a/src/lib/components/rootFolders/RootFolderModal.svelte
+++ b/src/lib/components/rootFolders/RootFolderModal.svelte
@@ -19,7 +19,6 @@
 		error?: string | null;
 		onClose: () => void;
 		onSave: (data: RootFolderFormData) => void;
-		onDelete?: () => void;
 		onValidatePath: (
 			path: string,
 			readOnly?: boolean,

--- a/src/lib/components/rootFolders/RootFolderModal.svelte
+++ b/src/lib/components/rootFolders/RootFolderModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { X, Loader2, CheckCircle2, XCircle, FolderOpen, Info } from 'lucide-svelte';
+	import { Loader2, CheckCircle2, XCircle, FolderOpen, Info } from 'lucide-svelte';
 	import type {
 		RootFolder,
 		RootFolderFormData,
@@ -8,6 +8,8 @@
 	} from '$lib/types/downloadClient';
 	import { FolderBrowser } from '$lib/components/library';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
+	import ModalHeader from '$lib/components/ui/modal/ModalHeader.svelte';
+	import ModalFooter from '$lib/components/ui/modal/ModalFooter.svelte';
 
 	interface Props {
 		open: boolean;
@@ -33,7 +35,6 @@
 		error = null,
 		onClose,
 		onSave,
-		onDelete,
 		onValidatePath
 	}: Props = $props();
 
@@ -116,13 +117,7 @@
 </script>
 
 <ModalWrapper {open} {onClose} maxWidth="2xl" labelledBy="root-folder-modal-title">
-	<!-- Header -->
-	<div class="mb-6 flex items-center justify-between">
-		<h3 id="root-folder-modal-title" class="text-xl font-bold">{modalTitle}</h3>
-		<button class="btn btn-circle btn-ghost btn-sm" onclick={onClose}>
-			<X class="h-4 w-4" />
-		</button>
-	</div>
+	<ModalHeader title={modalTitle} {onClose} />
 
 	<!-- Folder Browser -->
 	{#if showFolderBrowser}
@@ -341,20 +336,12 @@
 			{/if}
 		</div>
 
-		<!-- Actions -->
-		<div class="modal-action">
-			{#if mode === 'edit' && onDelete}
-				<button class="btn mr-auto btn-outline btn-error" onclick={onDelete}>Delete</button>
-			{/if}
-
-			<button class="btn btn-ghost" onclick={onClose}>Cancel</button>
-
-			<button class="btn btn-primary" onclick={handleSave} disabled={saving || !path || !name}>
-				{#if saving}
-					<Loader2 class="h-4 w-4 animate-spin" />
-				{/if}
-				Save
-			</button>
-		</div>
+		<ModalFooter
+			onCancel={onClose}
+			onSave={handleSave}
+			{saving}
+			saveLabel={m.action_save()}
+			saveDisabled={saving || !path || !name}
+		/>
 	{/if}
 </ModalWrapper>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -218,7 +218,12 @@
 				label: m.nav_settings,
 				icon: Settings,
 				children: [
-					{ href: '/settings/general', label: m.nav_libraryStorage, icon: FolderCog },
+					{
+						href: '/settings/general?tab=libraries',
+						label: m.nav_libraryStorage,
+						icon: FolderCog,
+						match: (url: URL) => url.pathname === '/settings/general'
+					},
 					{ href: '/settings/system', label: m.nav_system, icon: Server },
 					{ href: '/settings/logs', label: m.nav_logs, icon: ScrollText },
 					{ href: '/settings/naming', label: m.nav_naming, icon: FileSignature },

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -211,13 +211,13 @@
 
 	$effect(() => {
 		if (activeTab === 'maintenance' || !$page.url.hash) return;
-		const url = new URL($page.url);
+		const url = new SvelteURL($page.url);
 		url.hash = '';
 		goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
 	});
 
 	function setTab(tab: TabId) {
-		const url = new URL($page.url);
+		const url = new SvelteURL($page.url);
 		url.searchParams.set('tab', tab);
 		if (tab !== 'maintenance') {
 			url.hash = '';

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { SvelteURL } from 'svelte/reactivity';
 	import {
 		Plus,
 		HardDrive,
@@ -796,7 +797,6 @@
 	error={folderSaveError}
 	onClose={closeFolderModal}
 	onSave={handleFolderSave}
-	onDelete={() => {}}
 	onValidatePath={handleValidatePath}
 />
 

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -209,9 +209,19 @@
 		enforceAnimeSubtype = data.enforceAnimeSubtype ?? false;
 	});
 
+	$effect(() => {
+		if (activeTab === 'maintenance' || !$page.url.hash) return;
+		const url = new URL($page.url);
+		url.hash = '';
+		goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
+	});
+
 	function setTab(tab: TabId) {
 		const url = new URL($page.url);
 		url.searchParams.set('tab', tab);
+		if (tab !== 'maintenance') {
+			url.hash = '';
+		}
 		goto(url.toString(), { replaceState: true });
 	}
 


### PR DESCRIPTION
## Summary

N/A

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

Enhances:  PR: #263 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Move manual scan banner to visible location.
- Applied the shared save/footer helper to `RootFolderModal.svelte`
- Minor UI tweaks

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [ ] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
