### PR TITLE
fix: harden library add flows and improve auth/activity error handling

### DIFF
--- a/src/lib/components/activity/ActivityTable.svelte
+++ b/src/lib/components/activity/ActivityTable.svelte
@@ -28,6 +28,7 @@
 	import { createProgressiveRenderer } from '$lib/utils/progressive-render.svelte.js';
 	import {
 		statusConfig,
+		getCompactProgressLabel,
 		getStatusLabel,
 		formatRelativeTime,
 		formatTimestamp,
@@ -735,12 +736,12 @@
 										max="100"
 									></progress>
 								</div>
-							{:else if activity.statusReason}
+							{:else if getCompactProgressLabel(activity)}
 								<span
 									class="max-w-32 truncate text-xs text-base-content/60"
 									title={activity.statusReason}
 								>
-									{activity.statusReason}
+									{getCompactProgressLabel(activity)}
 								</span>
 							{:else}
 								<span class="text-sm">{getStatusLabel(activity, config.label)}</span>

--- a/src/lib/components/activity/activity-display-utils.ts
+++ b/src/lib/components/activity/activity-display-utils.ts
@@ -82,6 +82,29 @@ export function getStatusLabel(activity: UnifiedActivity, fallbackLabel?: string
 }
 
 /**
+ * Compact progress-cell text for table layouts.
+ *
+ * Failed queue items may carry very long client error messages which do not fit
+ * well in summary tables. In those cases we surface a short status label and
+ * leave the full reason for the expanded detail view / tooltip.
+ */
+export function getCompactProgressLabel(activity: UnifiedActivity): string | null {
+	if (!activity.statusReason) {
+		return null;
+	}
+
+	if (activity.status === 'failed') {
+		return m.status_error();
+	}
+
+	if (activity.status === 'search_error') {
+		return m.status_searchError();
+	}
+
+	return activity.statusReason;
+}
+
+/**
  * Human-readable relative timestamp ("3m ago", "2d ago", etc.).
  *
  * Returns `'-'` when `dateStr` is null/undefined so callers don't need to

--- a/src/lib/components/library/AddToLibraryModal.svelte
+++ b/src/lib/components/library/AddToLibraryModal.svelte
@@ -3,6 +3,7 @@
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
+	import { getResponseErrorMessage, readResponsePayload } from '$lib/utils/http';
 	import CommonOptions from './add/CommonOptions.svelte';
 	import { sortRootFoldersForMediaType } from '$lib/utils/root-folders.js';
 	import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
@@ -523,8 +524,8 @@
 			});
 
 			if (!response.ok) {
-				const data = await response.json();
-				throw new Error(data.error || `Failed to add ${mediaType}`);
+				const payload = await readResponsePayload(response);
+				throw new Error(getResponseErrorMessage(payload, `Failed to add ${mediaType}`));
 			}
 
 			const result = await response.json();
@@ -574,8 +575,8 @@
 			});
 
 			if (!response.ok) {
-				const data = await response.json();
-				throw new Error(data.error || 'Failed to add collection');
+				const payload = await readResponsePayload(response);
+				throw new Error(getResponseErrorMessage(payload, 'Failed to add collection'));
 			}
 
 			const result = await response.json();

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -224,6 +224,11 @@ export const auth = betterAuth({
 			origins.push(process.env.BETTER_AUTH_URL);
 		}
 
+		// Add ORIGIN if set (common Docker/manual deployment configuration)
+		if (process.env.ORIGIN) {
+			origins.push(process.env.ORIGIN);
+		}
+
 		// Add additional trusted origins from comma-separated env var
 		if (process.env.BETTER_AUTH_TRUSTED_ORIGINS) {
 			const additional = process.env.BETTER_AUTH_TRUSTED_ORIGINS.split(',').map((o) => o.trim());

--- a/src/lib/server/auth/secret.test.ts
+++ b/src/lib/server/auth/secret.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const KEYS = ['BETTER_AUTH_SECRET', 'VITE_SSR_BUILD', 'VITEST', 'NODE_ENV'] as const;
+const KEYS = [
+	'BETTER_AUTH_SECRET',
+	'BETTER_AUTH_URL',
+	'ORIGIN',
+	'VITE_SSR_BUILD',
+	'VITEST',
+	'NODE_ENV'
+] as const;
 
 let originalEnv: Record<(typeof KEYS)[number], string | undefined>;
 
@@ -19,6 +26,8 @@ describe('getAuthSecret', () => {
 	beforeEach(() => {
 		originalEnv = {
 			BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+			BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+			ORIGIN: process.env.ORIGIN,
 			VITE_SSR_BUILD: process.env.VITE_SSR_BUILD,
 			VITEST: process.env.VITEST,
 			NODE_ENV: process.env.NODE_ENV
@@ -58,5 +67,42 @@ describe('getAuthSecret', () => {
 		process.env.NODE_ENV = 'production';
 		const mod = await loadSecretModule();
 		expect(() => mod.getAuthSecret()).toThrowError(/BETTER_AUTH_SECRET is not set/);
+	});
+});
+
+describe('getBaseURL', () => {
+	beforeEach(() => {
+		originalEnv = {
+			BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+			BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+			ORIGIN: process.env.ORIGIN,
+			VITE_SSR_BUILD: process.env.VITE_SSR_BUILD,
+			VITEST: process.env.VITEST,
+			NODE_ENV: process.env.NODE_ENV
+		};
+		resetAuthEnv();
+	});
+
+	afterEach(() => {
+		resetAuthEnv();
+		for (const key of KEYS) {
+			const value = originalEnv[key];
+			if (value !== undefined) {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	it('prefers BETTER_AUTH_URL over ORIGIN', async () => {
+		process.env.BETTER_AUTH_URL = 'http://auth.example.com/';
+		process.env.ORIGIN = 'http://origin.example.com/';
+		const mod = await loadSecretModule();
+		expect(mod.getBaseURL()).toBe('http://auth.example.com');
+	});
+
+	it('falls back to ORIGIN when BETTER_AUTH_URL is unset', async () => {
+		process.env.ORIGIN = 'http://192.168.1.6:3000/';
+		const mod = await loadSecretModule();
+		expect(mod.getBaseURL()).toBe('http://192.168.1.6:3000');
 	});
 });

--- a/src/lib/server/auth/secret.ts
+++ b/src/lib/server/auth/secret.ts
@@ -98,12 +98,17 @@ export function getAuthSecret(): string {
  * Get the base URL for Better Auth
  * Priority:
  * 1. BETTER_AUTH_URL environment variable
- * 2. Saved external URL from system settings
- * 3. Local development fallback
+ * 2. ORIGIN environment variable
+ * 3. Saved external URL from system settings
+ * 4. Local development fallback
  */
 export function getBaseURL(): string {
 	if (process.env.BETTER_AUTH_URL?.trim()) {
 		return normalizeUrl(process.env.BETTER_AUTH_URL);
+	}
+
+	if (process.env.ORIGIN?.trim()) {
+		return normalizeUrl(process.env.ORIGIN);
 	}
 
 	const externalUrl = getConfiguredExternalUrl();

--- a/src/lib/server/library/LibraryAddService.ts
+++ b/src/lib/server/library/LibraryAddService.ts
@@ -10,7 +10,7 @@
  */
 
 import { db } from '$lib/server/db/index.js';
-import { rootFolders, languageProfiles } from '$lib/server/db/schema.js';
+import { rootFolders, languageProfiles, scoringProfiles } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import { qualityFilter } from '$lib/server/quality/index.js';
@@ -108,7 +108,23 @@ export async function getAnimeSubtypeEnforcement(): Promise<boolean> {
  * Get the effective scoring profile ID (provided or default)
  */
 export async function getEffectiveScoringProfileId(providedProfileId?: string): Promise<string> {
+	// Ensure built-in profiles exist as valid FK targets before resolving the final profile ID.
+	await qualityFilter.seedDefaultScoringProfiles();
+
 	if (providedProfileId) {
+		const existingProfile = await db
+			.select({ id: scoringProfiles.id })
+			.from(scoringProfiles)
+			.where(eq(scoringProfiles.id, providedProfileId))
+			.limit(1)
+			.get();
+
+		if (!existingProfile) {
+			throw new ValidationError('Selected quality profile is no longer valid. Refresh and try again.', {
+				scoringProfileId: providedProfileId
+			});
+		}
+
 		return providedProfileId;
 	}
 

--- a/src/lib/server/library/LibraryAddService.ts
+++ b/src/lib/server/library/LibraryAddService.ts
@@ -120,9 +120,12 @@ export async function getEffectiveScoringProfileId(providedProfileId?: string): 
 			.get();
 
 		if (!existingProfile) {
-			throw new ValidationError('Selected quality profile is no longer valid. Refresh and try again.', {
-				scoringProfileId: providedProfileId
-			});
+			throw new ValidationError(
+				'Selected quality profile is no longer valid. Refresh and try again.',
+				{
+					scoringProfileId: providedProfileId
+				}
+			);
 		}
 
 		return providedProfileId;

--- a/src/lib/utils/http.ts
+++ b/src/lib/utils/http.ts
@@ -18,8 +18,23 @@ export function getResponseErrorMessage(payload: unknown, fallback: string): str
 	}
 
 	if (typeof payload === 'string') {
+		if (
+			(/authentication required/i.test(payload) || /unauthorized/i.test(payload)) &&
+			!/api key required/i.test(payload)
+		) {
+			return 'Request blocked because your session could not be validated. Refresh and sign in again. If you are using Docker, a LAN IP, or a reverse proxy, verify ORIGIN and BETTER_AUTH_URL.';
+		}
+
 		if (/cross-site/i.test(payload) && /forbidden/i.test(payload)) {
 			return 'Request blocked by origin/CSRF protection. Check ORIGIN and reverse proxy configuration.';
+		}
+
+		if (/csrf/i.test(payload) || /origin/i.test(payload)) {
+			return 'Request blocked by origin/CSRF protection. Check ORIGIN and reverse proxy configuration.';
+		}
+
+		if (/FOREIGN KEY constraint failed/i.test(payload)) {
+			return 'The selected root folder or one of its linked library settings is no longer valid. Refresh the page and try again.';
 		}
 
 		return payload;
@@ -46,6 +61,25 @@ export function getResponseErrorMessage(payload: unknown, fallback: string): str
 
 	for (const candidate of candidates) {
 		if (typeof candidate === 'string' && candidate.trim().length > 0) {
+			if (
+				(/authentication required/i.test(candidate) || /unauthorized/i.test(candidate)) &&
+				!/api key required/i.test(candidate)
+			) {
+				return 'Request blocked because your session could not be validated. Refresh and sign in again. If you are using Docker, a LAN IP, or a reverse proxy, verify ORIGIN and BETTER_AUTH_URL.';
+			}
+
+			if (
+				/csrf/i.test(candidate) ||
+				/cross-site/i.test(candidate) ||
+				(/origin/i.test(candidate) && /forbidden/i.test(candidate))
+			) {
+				return 'Request blocked by origin/CSRF protection. Check ORIGIN and reverse proxy configuration.';
+			}
+
+			if (/FOREIGN KEY constraint failed/i.test(candidate)) {
+				return 'The selected root folder or one of its linked library settings is no longer valid. Refresh the page and try again.';
+			}
+
 			return candidate;
 		}
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -225,6 +225,22 @@
 		return Boolean(activity.seriesId || activity.mediaId);
 	}
 
+	function getCompactProgressLabel(activity: UnifiedActivity): string | null {
+		if (!activity.statusReason) {
+			return null;
+		}
+
+		if (activity.status === 'failed') {
+			return m.status_error();
+		}
+
+		if (activity.status === 'search_error') {
+			return m.status_searchError();
+		}
+
+		return activity.statusReason;
+	}
+
 	function formatBytes(bytes: number): string {
 		if (bytes === 0) return '0 B';
 		const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
@@ -892,12 +908,12 @@
 													value={activity.downloadProgress}
 													max="100"
 												></progress>
-											{:else if activity.statusReason}
+											{:else if getCompactProgressLabel(activity)}
 												<span
 													class="max-w-16 truncate text-xs text-base-content/50"
 													title={activity.statusReason}
 												>
-													{activity.statusReason}
+													{getCompactProgressLabel(activity)}
 												</span>
 											{:else}
 												<span class="text-xs text-base-content/50">{config.label}</span>

--- a/src/routes/api/library/movies/+server.ts
+++ b/src/routes/api/library/movies/+server.ts
@@ -18,7 +18,7 @@ import {
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { fetchAndStoreMovieAlternateTitles } from '$lib/server/services/AlternateTitleService.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
-import { ValidationError } from '$lib/errors';
+import { ValidationError, isAppError } from '$lib/errors';
 import { logger } from '$lib/logging';
 import { requireAuth } from '$lib/server/auth/authorization.js';
 
@@ -288,6 +288,29 @@ export const POST: RequestHandler = async (event) => {
 		});
 	} catch (error) {
 		logger.error('[API] Error adding movie', error instanceof Error ? error : undefined);
+
+		if (isAppError(error)) {
+			return json(
+				{
+					success: false,
+					...error.toJSON()
+				},
+				{ status: error.statusCode }
+			);
+		}
+
+		if (error instanceof Error && /FOREIGN KEY constraint failed/i.test(error.message)) {
+			return json(
+				{
+					success: false,
+					error:
+						'The selected root folder or one of its linked library settings is no longer valid. Refresh the page and try again.',
+					code: 'LIBRARY_CONFIGURATION_STALE'
+				},
+				{ status: 409 }
+			);
+		}
+
 		return json(
 			{
 				success: false,

--- a/src/routes/api/library/series/+server.ts
+++ b/src/routes/api/library/series/+server.ts
@@ -16,7 +16,7 @@ import {
 } from '$lib/server/library/LibraryAddService.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { fetchAndStoreSeriesAlternateTitles } from '$lib/server/services/AlternateTitleService.js';
-import { ValidationError } from '$lib/errors';
+import { ValidationError, isAppError } from '$lib/errors';
 import { logger } from '$lib/logging';
 import { requireAuth } from '$lib/server/auth/authorization.js';
 import { NamingService, type MediaNamingInfo } from '$lib/server/library/naming/NamingService.js';
@@ -437,6 +437,29 @@ export const POST: RequestHandler = async (event) => {
 		});
 	} catch (error) {
 		logger.error('[API] Error adding series', error instanceof Error ? error : undefined);
+
+		if (isAppError(error)) {
+			return json(
+				{
+					success: false,
+					...error.toJSON()
+				},
+				{ status: error.statusCode }
+			);
+		}
+
+		if (error instanceof Error && /FOREIGN KEY constraint failed/i.test(error.message)) {
+			return json(
+				{
+					success: false,
+					error:
+						'The selected root folder or one of its linked library settings is no longer valid. Refresh the page and try again.',
+					code: 'LIBRARY_CONFIGURATION_STALE'
+				},
+				{ status: 409 }
+			);
+		}
+
 		return json(
 			{
 				success: false,


### PR DESCRIPTION
## Summary

Fixes a set of user-facing regressions around library add flows, Better Auth deployment behavior, and activity/history rendering. This PR improves Docker/LAN auth compatibility, prevents missing scoring-profile foreign key failures during media add, surfaces clearer API/auth errors in the add-to-library UI, and keeps failed download messages from breaking dashboard/activity table layouts.

## Related Issues

- Relates to Docker/LAN Better Auth deployment issues
- Relates to media add failures caused by stale or missing library/profile references

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Dependency update
- [x] Other: UX/error-surface hardening

## Changes Made

- Updated Better Auth base URL resolution to fall back to `ORIGIN` when `BETTER_AUTH_URL` is not set, and added `ORIGIN` to trusted origins.
- Added focused auth tests covering Better Auth URL precedence and `ORIGIN` fallback behavior.
- Hardened library add flows by seeding built-in scoring profiles before resolving default profile IDs, preventing foreign key failures on installs with unseeded profile rows.
- Improved movie/series add API error handling so stale library/profile/root-folder issues return friendly structured responses instead of leaking raw SQLite errors.
- Updated the add-to-library modal to use the shared HTTP error parser so Better Auth/session/origin failures surface as actionable messages.
- Normalized failed activity/download progress text in desktop summary tables so long client error messages do not overflow or push other columns around.

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [x] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [ ] All tests pass (npm run test)
- [x] Type checking passes (npm run check)

## Checklist

- [x] Code follows project conventions
- [ ] Ran npm run format
- [x] Commit messages follow conventional commits (feat:, fix:, etc.)
- [x] Svelte 5 runes used correctly ($state, $derived, $effect, $props)
- [x] No new warnings in console or build output
- [x] Documentation updated (if applicable)

## Maintainer Notes

- The Better Auth warning:
  - `Rate limiting skipped: could not determine client IP address`
  - is not the same as the movie add failure.
- In the current Docker/LAN reports, that warning appears to be non-blocking and related to Better Auth rate-limit IP detection rather than request rejection.
- The actual add-media failure was more consistent with a missing valid FK target, specifically unseeded built-in scoring profiles such as `balanced`.
- `ORIGIN` fallback support was still added because Docker/manual users were reasonably expecting it to behave as the auth base URL when `BETTER_AUTH_URL` was omitted.
- If this warning comes up again later, we need to investigate proxy/IP forwarding separately from media-add failures; they are easy to conflate but are not necessarily causally related.
