### PR TITLE
fix: improve tracker search resilience and restore source format metadata

### DIFF
--- a/src/lib/server/downloadClients/monitoring/DownloadMonitorService.ts
+++ b/src/lib/server/downloadClients/monitoring/DownloadMonitorService.ts
@@ -36,6 +36,7 @@ import {
 	type QueueStats,
 	type QueueEvent
 } from '$lib/types/queue';
+import { parseEpisodePointerFromTitle } from '$lib/server/downloads/episode-pointer.js';
 
 // Import service is loaded lazily to avoid circular dependencies
 let importServiceInstance: import('../import').ImportService | null = null;
@@ -201,6 +202,20 @@ function mapDownloadStatusToQueueStatus(
 			);
 			return 'queued';
 	}
+}
+
+function shouldPreservePointerSize(
+	queueItem: typeof downloadQueue.$inferSelect,
+	download: DownloadInfo
+): boolean {
+	const pointerTarget = parseEpisodePointerFromTitle(queueItem.title);
+	if (!pointerTarget) {
+		return false;
+	}
+
+	const existingSize = queueItem.size ?? 0;
+	const clientSize = download.size ?? 0;
+	return existingSize > 0 && clientSize > existingSize;
 }
 
 /**
@@ -1226,7 +1241,7 @@ export class DownloadMonitorService extends EventEmitter implements BackgroundSe
 		// Build update object
 		const updates: Partial<typeof downloadQueue.$inferInsert> = {
 			progress: download.progress.toString(),
-			size: download.size,
+			size: shouldPreservePointerSize(queueItem, download) ? queueItem.size : download.size,
 			downloadSpeed: download.downloadSpeed,
 			uploadSpeed: download.uploadSpeed,
 			eta: download.eta,

--- a/src/lib/server/indexers/runtime/UnifiedIndexer.ts
+++ b/src/lib/server/indexers/runtime/UnifiedIndexer.ts
@@ -588,7 +588,7 @@ export class UnifiedIndexer implements IIndexer {
 		if (this.authManager.checkLoginNeeded(mockResponse, response.body)) {
 			this.log.info('Login needed, re-authenticating');
 			this.isLoggedIn = false;
-			await this.ensureLoggedIn();
+			await this.ensureLoggedIn(true);
 
 			this.http.setCookies(this.cookies);
 
@@ -691,12 +691,12 @@ export class UnifiedIndexer implements IIndexer {
 	/**
 	 * Ensure we're logged in (if required)
 	 */
-	private async ensureLoggedIn(): Promise<void> {
+	private async ensureLoggedIn(forceFreshLogin = false): Promise<void> {
 		if (!this.authManager.requiresAuth()) {
 			return;
 		}
 
-		if (this.isLoggedIn && Object.keys(this.cookies).length > 0) {
+		if (!forceFreshLogin && this.isLoggedIn && Object.keys(this.cookies).length > 0) {
 			return;
 		}
 
@@ -707,7 +707,12 @@ export class UnifiedIndexer implements IIndexer {
 			encoding: this.definition.encoding
 		};
 
-		const hasStoredCookies = await this.authManager.loadCookies(context);
+		if (forceFreshLogin) {
+			await this.authManager.clearCookies(context);
+			this.cookies = {};
+		}
+
+		const hasStoredCookies = !forceFreshLogin && (await this.authManager.loadCookies(context));
 		if (hasStoredCookies) {
 			this.cookies = this.authManager.getCookies();
 			this.isLoggedIn = true;
@@ -1187,7 +1192,7 @@ export class UnifiedIndexer implements IIndexer {
 
 			const headers: Record<string, string> = {
 				Accept: 'application/x-bittorrent, application/x-nzb, */*',
-				Referer: this.requestBuilder.getBaseUrl()
+				Referer: options?.releaseDetailsUrl ?? url
 			};
 
 			if (Object.keys(this.cookies).length > 0) {

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -119,6 +119,17 @@ const DEFAULT_OPTIONS: Required<
 	useCache: true
 };
 
+const CYRILLIC_REGEX = /\p{Script=Cyrillic}/u;
+
+function containsCyrillic(value: string): boolean {
+	return CYRILLIC_REGEX.test(value);
+}
+
+function prefersNativeCyrillicTitles(indexer: IIndexer): boolean {
+	const name = indexer.name.toLowerCase();
+	return name.includes('rutracker') || name.includes('kinozal');
+}
+
 const NON_VIDEO_ARTIFACT_TITLE_PATTERNS: RegExp[] = [
 	/\boriginal\s+soundtrack\b/i,
 	/\bsoundtrack\b/i,
@@ -1141,7 +1152,15 @@ export class SearchOrchestrator {
 					? [criteria.query]
 					: [];
 
-		const titlesToSearch = [...new Set(rawTitles.map((title) => title.trim()).filter(Boolean))];
+		let titlesToSearch = [...new Set(rawTitles.map((title) => title.trim()).filter(Boolean))];
+
+		if (prefersNativeCyrillicTitles(indexer)) {
+			titlesToSearch = [...titlesToSearch].sort((a, b) => {
+				const aCyrillic = containsCyrillic(a) ? 1 : 0;
+				const bCyrillic = containsCyrillic(b) ? 1 : 0;
+				return bCyrillic - aCyrillic;
+			});
+		}
 
 		if (titlesToSearch.length === 0) {
 			return [];
@@ -1174,8 +1193,10 @@ export class SearchOrchestrator {
 		let successfulVariants = 0;
 		const variantErrors: string[] = [];
 
-		// Search with each title variant (limit to 3 titles to avoid excessive queries)
-		for (const title of titlesToSearch.slice(0, 3)) {
+		// Search with each title variant. Russian trackers benefit from a slightly
+		// larger budget because native-script titles may appear after English variants.
+		const titleBudget = prefersNativeCyrillicTitles(indexer) ? 5 : 3;
+		for (const title of titlesToSearch.slice(0, titleBudget)) {
 			if (episodeFormats.length > 0) {
 				const shouldTryInteractiveTvTitleOnlyFallback =
 					isTvSearch(criteria) &&
@@ -2305,6 +2326,10 @@ export class SearchOrchestrator {
 		}
 
 		const beforeCount = releases.length;
+		const isInteractiveSearch = criteria.searchSource === 'interactive';
+		const allowInteractiveFallback =
+			isInteractiveSearch &&
+			(isMovieSearch(criteria) || (isTvSearch(criteria) && !criteria.season && !criteria.episode));
 
 		const filtered = releases.filter((release) => {
 			let parsed: ReturnType<typeof parseRelease> | undefined;
@@ -2399,7 +2424,6 @@ export class SearchOrchestrator {
 
 			// PRIORITY 2: Title + Year Fallback (if no ID match possible)
 			if (hasSearchTitles && hasSearchYear) {
-				const isInteractiveSearch = criteria.searchSource === 'interactive';
 				const isEpisodeTarget = isTvSearch(criteria) && criteria.episode !== undefined;
 				const isSeasonTarget = isTvSearch(criteria) && criteria.season !== undefined;
 				const releaseHasAnyId = !!(release.tmdbId || release.imdbId || release.tvdbId);
@@ -2522,6 +2546,43 @@ export class SearchOrchestrator {
 				},
 				'[SearchOrchestrator] ID/Title filter removed mismatched releases'
 			);
+		}
+
+		// Interactive localized searches should not hard-fail here when the
+		// tracker returns relevant releases in a different script/transliteration
+		// and none of them expose authoritative IDs. Keep explicit ID mismatches
+		// strict, but fall back to the pre-filtered set when everything else
+		// would be removed.
+		if (allowInteractiveFallback && beforeCount > 0 && filtered.length === 0) {
+			const releasesWithoutIdConflicts = releases.filter((release) => {
+				if (searchTmdbId && release.tmdbId && release.tmdbId !== searchTmdbId) {
+					return false;
+				}
+				if (searchImdbId && release.imdbId && release.imdbId !== searchImdbId) {
+					return false;
+				}
+				if (searchTvdbId && release.tvdbId && release.tvdbId !== searchTvdbId) {
+					return false;
+				}
+				return true;
+			});
+
+			if (releasesWithoutIdConflicts.length > 0) {
+				logger.info(
+					{
+						before: beforeCount,
+						kept: releasesWithoutIdConflicts.length,
+						searchType: criteria.searchType,
+						searchSource: criteria.searchSource,
+						criteriaTmdbId: searchTmdbId,
+						criteriaImdbId: searchImdbId,
+						criteriaTvdbId: searchTvdbId,
+						criteriaYear: searchYear
+					},
+					'[SearchOrchestrator] ID/title fallback applied for interactive search'
+				);
+				return releasesWithoutIdConflicts;
+			}
 		}
 
 		return filtered;

--- a/src/lib/server/indexers/search/searchorchestrator.spec.ts
+++ b/src/lib/server/indexers/search/searchorchestrator.spec.ts
@@ -181,6 +181,41 @@ describe('SearchOrchestrator.executeMultiTitleTextSearch', () => {
 		).toBe(true);
 	});
 
+	it('prioritizes Cyrillic title variants for RuTracker and expands the title budget', async () => {
+		const orchestrator = new SearchOrchestrator();
+		const captured: any[] = [];
+
+		const fakeIndexer = {
+			name: 'RuTracker.org',
+			capabilities: mockCapabilities,
+			search: async (criteria: any) => {
+				captured.push(criteria);
+				return [];
+			}
+		} as any;
+
+		const criteria = {
+			searchType: 'tv',
+			searchSource: 'interactive',
+			query: 'How Derevyanko Chekhov Played',
+			searchTitles: [
+				'How Derevyanko Chekhov Played',
+				'How Derevyanko Played',
+				'Как Деревянко Чехова играл',
+				'Как Деревянко играл',
+				'Kak Derevyanko Chekhova igral'
+			],
+			season: 1
+		} as any;
+
+		await (orchestrator as any).executeMultiTitleTextSearch(fakeIndexer, criteria);
+
+		expect(captured.length).toBeGreaterThan(0);
+		expect(captured[0].query).toBe('Как Деревянко Чехова играл');
+		expect(captured.some((c: any) => c.query === 'Как Деревянко играл')).toBe(true);
+		expect(captured.some((c: any) => c.query === 'How Derevyanko Chekhov Played')).toBe(true);
+	});
+
 	it('reuses cached RuTracker season search results across automatic episode variants', async () => {
 		const orchestrator = new SearchOrchestrator();
 		const captured: any[] = [];
@@ -1056,5 +1091,44 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 
 		const filtered = (orchestrator as any).filterByTitleRelevance(releases, criteria);
 		expect(filtered).toHaveLength(0);
+	});
+
+	it('falls back to pre-filtered releases for interactive movie ID/title checks when localized titles remove all', () => {
+		const releases = [
+			{ title: 'Сталкер / Stalker [1979, BDRip 1080p]' },
+			{ title: 'Пикник на обочине [1979, WEB-DL 1080p]' }
+		] as any[];
+
+		const criteria = {
+			searchType: 'movie',
+			searchSource: 'interactive',
+			query: 'Stalker',
+			searchTitles: ['Stalker'],
+			year: 1979
+		} as any;
+
+		const filtered = (orchestrator as any).filterByIdOrTitleMatch(releases, criteria);
+		expect(filtered).toHaveLength(2);
+		expect(filtered).toEqual(releases);
+	});
+
+	it('keeps explicit ID mismatches strict during interactive ID/title fallback', () => {
+		const releases = [
+			{ title: 'Сталкер / Stalker [1979, BDRip 1080p]', tmdbId: 999999 },
+			{ title: 'Пикник на обочине [1979, WEB-DL 1080p]' }
+		] as any[];
+
+		const criteria = {
+			searchType: 'movie',
+			searchSource: 'interactive',
+			query: 'Stalker',
+			searchTitles: ['Stalker'],
+			year: 1979,
+			tmdbId: 1398
+		} as any;
+
+		const filtered = (orchestrator as any).filterByIdOrTitleMatch(releases, criteria);
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].title).toContain('Пикник');
 	});
 });

--- a/src/lib/server/services/AlternateTitleService.test.ts
+++ b/src/lib/server/services/AlternateTitleService.test.ts
@@ -39,6 +39,18 @@ describe('cleanTitle', () => {
 		});
 	});
 
+	describe('non-Latin scripts', () => {
+		it('should preserve Cyrillic titles for regional tracker searching', () => {
+			expect(cleanTitle('Как Деревянко Чехова играл')).toBe('как деревянко чехова играл');
+		});
+
+		it('should preserve mixed Latin and Cyrillic titles', () => {
+			expect(cleanTitle('How Derevyanko Played / Как Деревянко играл')).toBe(
+				'how derevyanko played как деревянко играл'
+			);
+		});
+	});
+
 	describe('basic normalization', () => {
 		it('should convert to lowercase', () => {
 			expect(cleanTitle('DUNE')).toBe('dune');

--- a/src/lib/server/services/AlternateTitleService.ts
+++ b/src/lib/server/services/AlternateTitleService.ts
@@ -39,8 +39,8 @@ export function cleanTitle(title: string): string {
 	// This ensures Unicode letters like ű are properly handled
 	clean = clean.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
-	// Replace non-alphanumeric with space (now that diacritics are stripped)
-	clean = clean.replace(/[^\w\s]/g, ' ');
+	// Replace non-letter/number with space while preserving non-Latin scripts
+	clean = clean.replace(/[^\p{L}\p{N}\s]/gu, ' ');
 
 	// Collapse multiple spaces and trim
 	clean = clean.replace(/\s+/g, ' ').trim();

--- a/src/lib/types/format.ts
+++ b/src/lib/types/format.ts
@@ -33,6 +33,7 @@ export type {
  */
 export const FORMAT_CATEGORY_LABELS: Record<FormatCategory, string> = {
 	resolution: 'Resolution & Source',
+	source: 'Source Only',
 	release_group_tier: 'Release Groups',
 	audio: 'Audio',
 	hdr: 'HDR',
@@ -50,6 +51,7 @@ export const FORMAT_CATEGORY_LABELS: Record<FormatCategory, string> = {
  */
 export const FORMAT_CATEGORY_DESCRIPTIONS: Record<FormatCategory, string> = {
 	resolution: 'Resolution and source quality combinations (e.g., 2160p Remux, 1080p WEB-DL)',
+	source: 'Source-only fallback formats when resolution cannot be detected',
 	release_group_tier: 'Quality tiers for known release groups',
 	audio: 'Audio codec formats (TrueHD, DTS-HD MA, Atmos, etc.)',
 	hdr: 'HDR formats (Dolby Vision, HDR10+, HDR10, HLG)',
@@ -67,6 +69,7 @@ export const FORMAT_CATEGORY_DESCRIPTIONS: Record<FormatCategory, string> = {
  */
 export const FORMAT_CATEGORY_ORDER: FormatCategory[] = [
 	'resolution',
+	'source',
 	'audio',
 	'hdr',
 	'release_group_tier',
@@ -84,6 +87,7 @@ export const FORMAT_CATEGORY_ORDER: FormatCategory[] = [
  */
 export const FORMAT_CATEGORY_ICONS: Record<FormatCategory, string> = {
 	resolution: 'Monitor',
+	source: 'Film',
 	release_group_tier: 'Users',
 	audio: 'Volume2',
 	hdr: 'Sun',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -566,9 +566,9 @@
 	</div>
 
 	<!-- Main Content Grid -->
-	<div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-		<!-- Recently Added Section (2/3 width on lg, full width on md) -->
-		<div class="space-y-6 md:col-span-2 lg:col-span-2">
+	<div class="grid gap-6 lg:grid-cols-3">
+		<!-- Recently Added Section (2/3 width) -->
+		<div class="space-y-6 lg:col-span-2">
 			<!-- Recently Added Movies -->
 			{#if isRecentlyAddedLoading}
 				<div class="card bg-base-200">
@@ -581,7 +581,7 @@
 							<Skeleton variant="text" class="h-8 w-20" />
 						</div>
 						<div
-							class="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
+							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
 							{#each Array.from({ length: 6 }, (_, index) => index) as index (index)}
 								<div class="aspect-2/3 overflow-hidden rounded-lg">
@@ -604,7 +604,7 @@
 							>
 						</div>
 						<div
-							class="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
+							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
 							{#each recentlyAdded.movies as movie (movie.id)}
 								{@const typedMovie = movie as RecentlyAddedMovie}
@@ -656,7 +656,7 @@
 							<Skeleton variant="text" class="h-8 w-20" />
 						</div>
 						<div
-							class="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
+							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
 							{#each Array.from({ length: 6 }, (_, index) => index) as index (index)}
 								<div class="aspect-2/3 overflow-hidden rounded-lg">
@@ -679,7 +679,7 @@
 							>
 						</div>
 						<div
-							class="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
+							class="grid grid-cols-3 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-6"
 						>
 							{#each recentlyAdded.series as show (show.id)}
 								{@const typedShow = show as RecentlyAddedSeries}
@@ -859,7 +859,7 @@
 									{@const StatusIcon = config.icon}
 									<tr class="hover">
 										<td>
-											<span class="badge gap-1 {config.variant} badge-xs whitespace-nowrap">
+											<span class="badge gap-1 {config.variant} badge-xs">
 												<StatusIcon
 													class="h-3 w-3 {activity.status === 'downloading' ||
 													activity.status === 'searching'

--- a/src/routes/api/download/grab/+server.ts
+++ b/src/routes/api/download/grab/+server.ts
@@ -796,6 +796,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			episodeIds: data.episodeIds,
 			seasonNumber: data.seasonNumber,
 			quality,
+			size: data.size,
 			isAutomatic: data.isAutomatic ?? false,
 			isUpgrade: isUpgrade
 		});


### PR DESCRIPTION
## Summary

Improves private tracker behavior for Russian-language content and fixes a frontend type regression introduced by the new source-only scoring formats. This PR hardens stale-cookie reauthentication, preserves Cyrillic title variants for tracker search, prioritizes native-script queries for RuTracker/Kinozal, keeps virtual episode sizes consistent after grab, and restores the missing UI metadata for the new `source` format category.

## Related Issues

- Relates to RuTracker/Kinozal search and grab reliability for localized/native-script titles (#228)
- Relates to virtual episode queue rows showing full season-pack size after grab
- Relates to typecheck failures introduced after adding source-only scoring formats

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [x] Other: Search-quality and queue-display hardening

## Changes Made

- Preserve Cyrillic and other non-Latin titles in alternate-title normalization so regional tracker titles remain searchable.
- Prioritize Cyrillic title variants for RuTracker and Kinozal and expand the title-variant budget for those trackers.
- Force a fresh relogin when private indexers return login-required responses instead of reusing stale stored cookies.
- Keep interactive localized/transliterated tracker results from being dropped too aggressively during ID/title filtering.
- Preserve per-episode virtual pointer sizes in queue/activity views by seeding queue items with pointer size and not overwriting them with full pack size during polling.
- Restore missing UI metadata for the new `source` scoring format category in `src/lib/types/format.ts`, fixing the `npm run check` regression.

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)