### PR TITLE
fix: preserve native tracker search titles and extend alternate-title usage across search flows

### DIFF
--- a/src/lib/server/downloads/CascadingSearchStrategy.ts
+++ b/src/lib/server/downloads/CascadingSearchStrategy.ts
@@ -25,6 +25,7 @@ import { episodes } from '$lib/server/db/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import type { SearchCriteria } from '$lib/server/indexers/types';
 import type { ScoringProfile } from '$lib/server/scoring/types.js';
+import { getSeriesSearchTitles } from '$lib/server/services/AlternateTitleService.js';
 
 const logger = createChildLogger({ module: 'CascadingSearchStrategy' });
 
@@ -408,6 +409,7 @@ class CascadingSearchStrategy {
 
 		try {
 			const indexerManager = await getIndexerManager();
+			const searchTitles = await getSeriesSearchTitles(seriesData.id);
 
 			// Build search criteria - season only (no episode number) to get packs
 			const criteria: SearchCriteria = {
@@ -416,7 +418,8 @@ class CascadingSearchStrategy {
 				tmdbId: seriesData.tmdbId,
 				tvdbId: seriesData.tvdbId ?? undefined,
 				imdbId: seriesData.imdbId ?? undefined,
-				season: seasonNumber
+				season: seasonNumber,
+				searchTitles
 				// Note: No episode number - this will return season packs
 			};
 
@@ -557,6 +560,7 @@ class CascadingSearchStrategy {
 
 		try {
 			const indexerManager = await getIndexerManager();
+			const searchTitles = await getSeriesSearchTitles(seriesData.id);
 
 			// Build search criteria with season and episode
 			const criteria: SearchCriteria = {
@@ -566,7 +570,8 @@ class CascadingSearchStrategy {
 				tvdbId: seriesData.tvdbId ?? undefined,
 				imdbId: seriesData.imdbId ?? undefined,
 				season: episode.seasonNumber,
-				episode: episode.episodeNumber
+				episode: episode.episodeNumber,
+				searchTitles
 			};
 
 			// Get episode count for potential pack size validation

--- a/src/lib/server/downloads/MultiSeasonSearchStrategy.ts
+++ b/src/lib/server/downloads/MultiSeasonSearchStrategy.ts
@@ -24,6 +24,7 @@ import { episodes } from '$lib/server/db/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import type { SearchCriteria } from '$lib/server/indexers/types';
 import { isSeasonPack } from '$lib/server/indexers/types/release.js';
+import { getSeriesSearchTitles } from '$lib/server/services/AlternateTitleService.js';
 
 // Re-export types from CascadingSearchStrategy for consistency
 export interface EpisodeToSearch {
@@ -574,6 +575,7 @@ export class MultiSeasonSearchStrategy {
 
 		try {
 			const indexerManager = await getIndexerManager();
+			const searchTitles = await getSeriesSearchTitles(seriesData.id);
 
 			// Search without season filter to get complete series packs
 			const criteria: SearchCriteria = {
@@ -581,7 +583,8 @@ export class MultiSeasonSearchStrategy {
 				query: seriesData.title,
 				tmdbId: seriesData.tmdbId,
 				tvdbId: seriesData.tvdbId ?? undefined,
-				imdbId: seriesData.imdbId ?? undefined
+				imdbId: seriesData.imdbId ?? undefined,
+				searchTitles
 				// Note: No season filter - this returns complete series packs
 			};
 
@@ -731,6 +734,7 @@ export class MultiSeasonSearchStrategy {
 
 		try {
 			const indexerManager = await getIndexerManager();
+			const searchTitles = await getSeriesSearchTitles(seriesData.id);
 
 			// Search with season filter to get packs
 			const criteria: SearchCriteria = {
@@ -739,7 +743,8 @@ export class MultiSeasonSearchStrategy {
 				tmdbId: seriesData.tmdbId,
 				tvdbId: seriesData.tvdbId ?? undefined,
 				imdbId: seriesData.imdbId ?? undefined,
-				season: startSeason
+				season: startSeason,
+				searchTitles
 				// Note: We search for start season and filter for multi-season packs
 			};
 
@@ -858,6 +863,7 @@ export class MultiSeasonSearchStrategy {
 
 		try {
 			const indexerManager = await getIndexerManager();
+			const searchTitles = await getSeriesSearchTitles(seriesData.id);
 
 			const criteria: SearchCriteria = {
 				searchType: 'tv',
@@ -865,7 +871,8 @@ export class MultiSeasonSearchStrategy {
 				tmdbId: seriesData.tmdbId,
 				tvdbId: seriesData.tvdbId ?? undefined,
 				imdbId: seriesData.imdbId ?? undefined,
-				season: seasonNumber
+				season: seasonNumber,
+				searchTitles
 			};
 
 			const searchResult = await indexerManager.searchEnhanced(criteria, {

--- a/src/lib/server/indexers/runtime/ResponseParser.ts
+++ b/src/lib/server/indexers/runtime/ResponseParser.ts
@@ -51,6 +51,11 @@ export class ResponseParser {
 		this.selectorEngine = selectorEngine;
 	}
 
+	private shouldTraceTracker(context: ParseContext): boolean {
+		const name = context.indexerName.toLowerCase();
+		return name.includes('rutracker') || name.includes('kinozal');
+	}
+
 	/**
 	 * Parse response content into release results.
 	 */
@@ -363,11 +368,24 @@ export class ResponseParser {
 			});
 		}
 
+		if (this.shouldTraceTracker(context)) {
+			logger.info(
+				{
+					indexer: context.indexerName,
+					rowSelector,
+					rowCount: rows.length,
+					filteredRowCount: filteredRows.length,
+					sampleRowHtml: filteredRows[0]?.html()?.slice(0, 500) ?? null
+				},
+				'[ResponseParser] HTML row selection'
+			);
+		}
+
 		// Handle date headers (sticky dates)
 		let currentDate: string | null = null;
 		const dateHeadersSelector = search.rows.dateheaders;
 
-		for (const row of filteredRows) {
+		for (const [rowIndex, row] of filteredRows.entries()) {
 			try {
 				// Check for date header
 				if (dateHeadersSelector?.selector) {
@@ -378,7 +396,7 @@ export class ResponseParser {
 					}
 				}
 
-				const release = this.extractReleaseFromHtml($, row, context, currentDate);
+				const release = this.extractReleaseFromHtml($, row, context, currentDate, rowIndex);
 				if (release) releases.push(release);
 			} catch (error) {
 				logger.warn(
@@ -400,7 +418,8 @@ export class ResponseParser {
 		$: CheerioAPI,
 		row: Cheerio<Element>,
 		context: ParseContext,
-		stickyDate: string | null
+		stickyDate: string | null,
+		rowIndex?: number
 	): ReleaseResult | null {
 		const search = this.definition.search;
 		const fields = search.fields;
@@ -434,12 +453,52 @@ export class ResponseParser {
 			}
 		}
 
+		if (this.shouldTraceTracker(context) && (rowIndex ?? 99) < 3) {
+			logger.info(
+				{
+					indexer: context.indexerName,
+					rowIndex,
+					values: {
+						title: values['title'],
+						details: values['details'],
+						download: values['download'],
+						size: values['size'],
+						seeders: values['seeders'],
+						leechers: values['leechers'],
+						category: values['category'],
+						date: values['date']
+					}
+				},
+				'[ResponseParser] HTML row field extraction'
+			);
+		}
+
 		// Apply sticky date if no date was extracted
 		if (stickyDate && !values['date'] && !values['publishdate']) {
 			values['date'] = stickyDate;
 		}
 
-		return this.buildReleaseResult(values, context);
+		const release = this.buildReleaseResult(values, context);
+
+		if (this.shouldTraceTracker(context) && (rowIndex ?? 99) < 3 && !release) {
+			logger.info(
+				{
+					indexer: context.indexerName,
+					rowIndex,
+					values: {
+						title: values['title'],
+						details: values['details'],
+						download: values['download'],
+						infohash: values['infohash'] || values['hash'],
+						magnet: values['magnet'] || values['magneturl'] || values['magneturi'],
+						size: values['size']
+					}
+				},
+				'[ResponseParser] HTML row dropped before release build'
+			);
+		}
+
+		return release;
 	}
 
 	/**

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -1155,6 +1155,11 @@ export class SearchOrchestrator {
 		let titlesToSearch = [...new Set(rawTitles.map((title) => title.trim()).filter(Boolean))];
 
 		if (prefersNativeCyrillicTitles(indexer)) {
+			const nativeCyrillicTitles = titlesToSearch.filter((title) => containsCyrillic(title));
+			if (nativeCyrillicTitles.length > 0) {
+				titlesToSearch = nativeCyrillicTitles;
+			}
+
 			titlesToSearch = [...titlesToSearch].sort((a, b) => {
 				const aCyrillic = containsCyrillic(a) ? 1 : 0;
 				const bCyrillic = containsCyrillic(b) ? 1 : 0;

--- a/src/lib/server/indexers/search/searchorchestrator.spec.ts
+++ b/src/lib/server/indexers/search/searchorchestrator.spec.ts
@@ -181,7 +181,7 @@ describe('SearchOrchestrator.executeMultiTitleTextSearch', () => {
 		).toBe(true);
 	});
 
-	it('prioritizes Cyrillic title variants for RuTracker and expands the title budget', async () => {
+	it('uses only Cyrillic title variants for RuTracker when native titles are available', async () => {
 		const orchestrator = new SearchOrchestrator();
 		const captured: any[] = [];
 
@@ -213,7 +213,8 @@ describe('SearchOrchestrator.executeMultiTitleTextSearch', () => {
 		expect(captured.length).toBeGreaterThan(0);
 		expect(captured[0].query).toBe('Как Деревянко Чехова играл');
 		expect(captured.some((c: any) => c.query === 'Как Деревянко играл')).toBe(true);
-		expect(captured.some((c: any) => c.query === 'How Derevyanko Chekhov Played')).toBe(true);
+		expect(captured.some((c: any) => c.query === 'How Derevyanko Chekhov Played')).toBe(false);
+		expect(captured.some((c: any) => c.query === 'Kak Derevyanko Chekhova igral')).toBe(false);
 	});
 
 	it('reuses cached RuTracker season search results across automatic episode variants', async () => {
@@ -247,8 +248,8 @@ describe('SearchOrchestrator.executeMultiTitleTextSearch', () => {
 			episode: 2
 		});
 
-		// First call: two title variants (budgeted). Second call: served from cache.
-		expect(captured).toHaveLength(2);
+		// Only the native-script title should be queried, and the second call should be served from cache.
+		expect(captured).toHaveLength(1);
 		expect(captured.every((c: any) => c.preferredEpisodeFormat === 'standard')).toBe(true);
 		expect(captured.every((c: any) => c.episode === undefined)).toBe(true);
 		expect(captured.every((c: any) => c.season === 1)).toBe(true);
@@ -288,8 +289,8 @@ describe('SearchOrchestrator.executeMultiTitleTextSearch', () => {
 			})
 		]);
 
-		// Budget is 2 titles; with in-flight dedupe concurrent calls should still issue only 2 variants total.
-		expect(captured).toHaveLength(2);
+		// Only the native-script title should be queried, and concurrent calls should dedupe to one request.
+		expect(captured).toHaveLength(1);
 		expect(captured.every((c: any) => c.preferredEpisodeFormat === 'standard')).toBe(true);
 		expect(captured.every((c: any) => c.episode === undefined)).toBe(true);
 	});

--- a/src/lib/server/services/AlternateTitleService.ts
+++ b/src/lib/server/services/AlternateTitleService.ts
@@ -48,9 +48,27 @@ export function cleanTitle(title: string): string {
 	return clean;
 }
 
+function pushUniqueSearchTitle(
+	titles: string[],
+	seen: Set<string>,
+	title: string | null | undefined
+): void {
+	if (!title) return;
+
+	const trimmed = title.trim();
+	if (!trimmed) return;
+
+	const normalized = cleanTitle(trimmed);
+	if (!normalized || seen.has(normalized)) return;
+
+	seen.add(normalized);
+	titles.push(trimmed);
+}
+
 /**
  * Get all search titles for a movie (primary + original + alternates)
- * Returns deduplicated list with primary title first, all normalized for matching
+ * Returns deduplicated list with primary/original title text preserved for searching.
+ * Deduplication is still done using normalized titles for stable matching.
  */
 export async function getMovieSearchTitles(movieId: string): Promise<string[]> {
 	// Get the movie's primary and original titles
@@ -61,23 +79,23 @@ export async function getMovieSearchTitles(movieId: string): Promise<string[]> {
 
 	if (!movie) return [];
 
-	const titles: string[] = [cleanTitle(movie.title)];
+	const titles: string[] = [];
+	const seen = new Set<string>();
 
-	// Add original title if different (cleaned)
+	// Prefer original/native title first for tracker search ordering.
 	if (movie.originalTitle && movie.originalTitle !== movie.title) {
-		titles.push(cleanTitle(movie.originalTitle));
+		pushUniqueSearchTitle(titles, seen, movie.originalTitle);
 	}
+	pushUniqueSearchTitle(titles, seen, movie.title);
 
-	// Get alternate titles from database (use pre-computed cleanTitle)
+	// Get alternate titles from database, preserving their original text for searching.
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'movie'), eq(alternateTitles.mediaId, movieId)),
-		columns: { cleanTitle: true }
+		columns: { title: true }
 	});
 
 	for (const alt of alternates) {
-		if (!titles.includes(alt.cleanTitle)) {
-			titles.push(alt.cleanTitle);
-		}
+		pushUniqueSearchTitle(titles, seen, alt.title);
 	}
 
 	// Limit to prevent excessive searches
@@ -86,7 +104,8 @@ export async function getMovieSearchTitles(movieId: string): Promise<string[]> {
 
 /**
  * Get all search titles for a series (primary + original + alternates)
- * Returns deduplicated list with primary title first, all normalized for matching
+ * Returns deduplicated list with primary/original title text preserved for searching.
+ * Deduplication is still done using normalized titles for stable matching.
  */
 export async function getSeriesSearchTitles(seriesId: string): Promise<string[]> {
 	// Get the series' primary and original titles
@@ -97,23 +116,23 @@ export async function getSeriesSearchTitles(seriesId: string): Promise<string[]>
 
 	if (!show) return [];
 
-	const titles: string[] = [cleanTitle(show.title)];
+	const titles: string[] = [];
+	const seen = new Set<string>();
 
-	// Add original title if different (cleaned)
+	// Prefer original/native title first for tracker search ordering.
 	if (show.originalTitle && show.originalTitle !== show.title) {
-		titles.push(cleanTitle(show.originalTitle));
+		pushUniqueSearchTitle(titles, seen, show.originalTitle);
 	}
+	pushUniqueSearchTitle(titles, seen, show.title);
 
-	// Get alternate titles from database (use pre-computed cleanTitle)
+	// Get alternate titles from database, preserving their original text for searching.
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'series'), eq(alternateTitles.mediaId, seriesId)),
-		columns: { cleanTitle: true }
+		columns: { title: true }
 	});
 
 	for (const alt of alternates) {
-		if (!titles.includes(alt.cleanTitle)) {
-			titles.push(alt.cleanTitle);
-		}
+		pushUniqueSearchTitle(titles, seen, alt.title);
 	}
 
 	// Limit to prevent excessive searches


### PR DESCRIPTION
## Summary

Ensures tracker searches use the exact native/original title text instead of normalized fallback variants, which is especially important for RuTracker and Kinozal. This PR preserves original-title spelling and diacritics in outbound search requests, keeps normalized titles only for deduplication/matching, and extends alternate-title search coverage across interactive, monitoring, and TV download strategy flows.

## Related Issues

- Relates to RuTracker and Kinozal failing to return releases for titles that only match when searched using the exact native/original title (#228)
- Relates to outbound tracker queries using normalized variants such as `особенности национальнои охоты` instead of `Особенности национальной охоты`
- Relates to inconsistent alternate-title usage between manual search and automated TV search strategies

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [x] Other: Search reliability and diagnostics improvement

## Changes Made

- Preserve exact original and alternate title text for outbound search requests instead of feeding trackers normalized `cleanTitle()` values.
- Continue using normalized titles internally only for deduplication and matching stability.
- Prefer original/native titles before localized or transliterated variants when building movie and series search title lists.
- Extend alternate-title powered `searchTitles` usage to TV download search strategies so they do not rely only on `query: seriesData.title`.
- Update `MultiSeasonSearchStrategy` to include native/alternate search titles in complete-series, multi-season, and single-season searches.
- Update `CascadingSearchStrategy` to include native/alternate search titles in season-pack and individual-episode searches.
- Add focused parser diagnostics for RuTracker and Kinozal row selection and row field extraction to make zero-result HTML parse failures easier to debug.

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)
