### PR TITLE
chore: rename main container channel from edge to main and decouple release provenance

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,8 @@
 #
 # Triggers:
 # - Pull requests to main: Build only (validates Dockerfile)
-# - Push to main: Build and push with edge channel tags
+# - Push to main: Build and push with main channel tags
+# - Push to dev/experimental branches: Build and push branch-scoped prerelease tags
 # - Runs only when Docker-relevant files change (paths filter)
 #
 # Images are pushed to ghcr.io/<owner>/cinephage
@@ -13,7 +14,7 @@ name: Docker Build
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, experimental, 'experimental/**']
     paths:
       - '.github/workflows/docker-build.yml'
       - 'Dockerfile'
@@ -75,6 +76,19 @@ jobs:
       - name: Compute version and arch tags
         id: meta
         run: |
+          branch_channel() {
+            local ref="$1"
+            if [ "$ref" = 'dev' ]; then
+              echo 'dev'
+            elif [[ "$ref" =~ ^experimental([/-].*)?$ ]]; then
+              printf '%s' "$ref" \
+                | tr '[:upper:]' '[:lower:]' \
+                | sed -E 's|[^a-z0-9]+|-|g; s|^-+||; s|-+$||; s|-+|-|g'
+            else
+              return 1
+            fi
+          }
+
           RUN_DATE="$(date +%Y%m%d)"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.tag }}" ]; then
@@ -82,7 +96,9 @@ jobs:
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
             APP_VERSION="dev-${RUN_DATE}-${{ github.run_number }}"
           elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            APP_VERSION="edge-${RUN_DATE}-${{ github.run_number }}"
+            APP_VERSION="main-${RUN_DATE}-${{ github.run_number }}"
+          elif CHANNEL="$(branch_channel "${{ github.ref_name }}")"; then
+            APP_VERSION="${CHANNEL}-${RUN_DATE}-${{ github.run_number }}"
           else
             APP_VERSION="sha-${GITHUB_SHA::7}"
           fi
@@ -240,10 +256,11 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
-            type=raw,value=edge-${{ needs.prepare.outputs.run_date }}-${{ github.run_number }},enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main-${{ needs.prepare.outputs.run_date }}-${{ github.run_number }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev-${{ needs.prepare.outputs.run_date }}-${{ github.run_number }},enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=raw,value=${{ needs.prepare.outputs.app_version }},enable=${{ startsWith(github.ref, 'refs/heads/experimental') }}
           labels: |
             org.opencontainers.image.title=Cinephage
             org.opencontainers.image.description=Self-hosted media management application

--- a/.github/workflows/ghcr-prune-non-release.yml
+++ b/.github/workflows/ghcr-prune-non-release.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
         default: true
       keep_channel_builds:
-        description: 'Keep this many recent builds for each channel (edge/dev)'
+        description: 'Keep this many recent builds for each channel (main/dev plus legacy edge)'
         required: true
         type: string
         default: '5'
@@ -165,7 +165,7 @@ jobs:
               return 0
             fi
 
-            if [ "$tag" = 'edge' ] || [ "$tag" = 'dev' ]; then
+            if [ "$tag" = 'main' ] || [ "$tag" = 'dev' ]; then
               return 0
             fi
 
@@ -214,13 +214,14 @@ jobs:
           candidates=0
           deleted=0
           failed=0
-          edge_kept=0
+          legacy_edge_kept=0
+          main_kept=0
           dev_kept=0
 
           declare -A KEEP_RECENT_TAGS=()
 
           if [ "$KEEP_CHANNEL_BUILDS" -gt 0 ]; then
-            for channel in edge dev; do
+            for channel in edge main dev; do
               mapfile -t recent_base_tags < <(echo "$versions_json" | jq -r \
                 --arg channel "$channel" \
                 --argjson limit "$KEEP_CHANNEL_BUILDS" '
@@ -239,7 +240,9 @@ jobs:
                 ')
 
               if [ "$channel" = 'edge' ]; then
-                edge_kept=${#recent_base_tags[@]}
+                legacy_edge_kept=${#recent_base_tags[@]}
+              elif [ "$channel" = 'main' ]; then
+                main_kept=${#recent_base_tags[@]}
               else
                 dev_kept=${#recent_base_tags[@]}
               fi
@@ -270,7 +273,7 @@ jobs:
               tag_csv=$(IFS=, ; echo "${tags[*]}")
               [ -z "$tag_csv" ] && tag_csv='<untagged>'
               kept=$((kept + 1))
-              echo "Keep id=${id} created=${created_at} tags=${tag_csv} (recent edge/dev build)"
+              echo "Keep id=${id} created=${created_at} tags=${tag_csv} (recent channel build)"
               continue
             fi
 
@@ -341,7 +344,8 @@ jobs:
           echo "Package: ${PACKAGE_NAME}"
           echo "Dry run: ${DRY_RUN}"
           echo "Keep recent channel builds (each): ${KEEP_CHANNEL_BUILDS}"
-          echo "Recent edge builds protected: ${edge_kept}"
+          echo "Recent legacy edge builds protected: ${legacy_edge_kept}"
+          echo "Recent main builds protected: ${main_kept}"
           echo "Recent dev builds protected: ${dev_kept}"
           echo "Total versions: ${total_versions}"
           echo "Kept: ${kept}"
@@ -355,7 +359,8 @@ jobs:
             echo "- Package: \`${PACKAGE_NAME}\`"
             echo "- Dry run: \`${DRY_RUN}\`"
             echo "- Keep recent channel builds (each): \`${KEEP_CHANNEL_BUILDS}\`"
-            echo "- Protected recent edge builds: \`${edge_kept}\`"
+            echo "- Protected recent legacy edge builds: \`${legacy_edge_kept}\`"
+            echo "- Protected recent main builds: \`${main_kept}\`"
             echo "- Protected recent dev builds: \`${dev_kept}\`"
             echo "- Total versions: \`${total_versions}\`"
             echo "- Kept: \`${kept}\`"
@@ -368,9 +373,10 @@ jobs:
             if [ "$KEEP_LATEST" = 'true' ]; then
               echo "- \`latest\`"
             fi
-            echo "- \`edge\` and \`dev\`"
+            echo "- \`main\` and \`dev\`"
             if [ "$KEEP_CHANNEL_BUILDS" -gt 0 ]; then
-              echo "- Last \`${KEEP_CHANNEL_BUILDS}\` \`edge-YYYYMMDD-run\` builds"
+              echo "- Last \`${KEEP_CHANNEL_BUILDS}\` legacy \`edge-YYYYMMDD-run\` builds"
+              echo "- Last \`${KEEP_CHANNEL_BUILDS}\` \`main-YYYYMMDD-run\` builds"
               echo "- Last \`${KEEP_CHANNEL_BUILDS}\` \`dev-YYYYMMDD-run\` builds"
             fi
             if [ "$KEEP_ARCH_TAGS" = 'true' ]; then

--- a/.github/workflows/ghcr-retag-latest.yml
+++ b/.github/workflows/ghcr-retag-latest.yml
@@ -13,8 +13,8 @@ on:
         required: true
         type: boolean
         default: true
-      allow_edge_rollback:
-        description: 'Allow edge-YYYYMMDD-RUN tags for emergency rollback'
+      allow_channel_rollback:
+        description: 'Allow main-YYYYMMDD-RUN or legacy edge-YYYYMMDD-RUN tags for emergency rollback'
         required: true
         type: boolean
         default: false
@@ -23,8 +23,8 @@ on:
         required: true
         type: string
         default: 'NO'
-      edge_confirm:
-        description: 'Type EDGE_ROLLBACK to allow edge rollback when allow_edge_rollback=true'
+      channel_confirm:
+        description: 'Type CHANNEL_ROLLBACK to allow channel rollback when allow_channel_rollback=true'
         required: true
         type: string
         default: 'NO'
@@ -55,8 +55,8 @@ jobs:
         id: refs
         env:
           SOURCE_TAG_INPUT: ${{ github.event.inputs.source_tag }}
-          ALLOW_EDGE_ROLLBACK: ${{ github.event.inputs.allow_edge_rollback }}
-          EDGE_CONFIRM: ${{ github.event.inputs.edge_confirm }}
+          ALLOW_CHANNEL_ROLLBACK: ${{ github.event.inputs.allow_channel_rollback }}
+          CHANNEL_CONFIRM: ${{ github.event.inputs.channel_confirm }}
         run: |
           set -euo pipefail
 
@@ -74,27 +74,27 @@ jobs:
           fi
 
           IS_STABLE_TAG='false'
-          IS_EDGE_TAG='false'
+          IS_CHANNEL_BUILD_TAG='false'
           if [[ "$SOURCE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             IS_STABLE_TAG='true'
           fi
-          if [[ "$SOURCE_TAG" =~ ^edge-[0-9]{8}-[0-9]+$ ]]; then
-            IS_EDGE_TAG='true'
+          if [[ "$SOURCE_TAG" =~ ^(main|edge)-[0-9]{8}-[0-9]+$ ]]; then
+            IS_CHANNEL_BUILD_TAG='true'
           fi
 
-          if [ "$IS_STABLE_TAG" != 'true' ] && [ "$IS_EDGE_TAG" != 'true' ]; then
-            echo "source_tag must be stable semver (vX.Y.Z) or edge-YYYYMMDD-RUN."
+          if [ "$IS_STABLE_TAG" != 'true' ] && [ "$IS_CHANNEL_BUILD_TAG" != 'true' ]; then
+            echo "source_tag must be stable semver (vX.Y.Z), main-YYYYMMDD-RUN, or legacy edge-YYYYMMDD-RUN."
             echo "Got: ${SOURCE_TAG}"
             exit 1
           fi
 
-          if [ "$IS_EDGE_TAG" = 'true' ]; then
-            if [ "$ALLOW_EDGE_ROLLBACK" != 'true' ]; then
-              echo "Refusing edge rollback: set allow_edge_rollback=true for edge tags."
+          if [ "$IS_CHANNEL_BUILD_TAG" = 'true' ]; then
+            if [ "$ALLOW_CHANNEL_ROLLBACK" != 'true' ]; then
+              echo "Refusing channel rollback: set allow_channel_rollback=true for main/edge tags."
               exit 1
             fi
-            if [ "$EDGE_CONFIRM" != 'EDGE_ROLLBACK' ]; then
-              echo "Refusing edge rollback: set edge_confirm=EDGE_ROLLBACK."
+            if [ "$CHANNEL_CONFIRM" != 'CHANNEL_ROLLBACK' ]; then
+              echo "Refusing channel rollback: set channel_confirm=CHANNEL_ROLLBACK."
               exit 1
             fi
           fi
@@ -150,7 +150,7 @@ jobs:
         env:
           SOURCE_IMAGE: ${{ steps.refs.outputs.source_image }}
           SOURCE_TAG: ${{ steps.refs.outputs.source_tag }}
-          ALLOW_EDGE_ROLLBACK: ${{ github.event.inputs.allow_edge_rollback }}
+          ALLOW_CHANNEL_ROLLBACK: ${{ github.event.inputs.allow_channel_rollback }}
         run: |
           set -euo pipefail
 
@@ -172,17 +172,17 @@ jobs:
             [[ "$value" =~ (^dev-|-dev($|[.-])|-rc($|[.-])|-beta($|[.-])|-alpha($|[.-])|-pre($|[.-])|-preview($|[.-])) ]]
           }
 
-          is_edge_channel() {
+          is_channel_build() {
             local value="$1"
             if [ -z "$value" ]; then
               return 1
             fi
-            [[ "$value" =~ (^edge-|-edge($|[.-])) ]]
+            [[ "$value" =~ (^main-|-main($|[.-])|^edge-|-edge($|[.-])) ]]
           }
 
-          IS_EDGE_ROLLBACK='false'
-          if [ "$ALLOW_EDGE_ROLLBACK" = 'true' ] && [[ "$SOURCE_TAG" =~ ^edge-[0-9]{8}-[0-9]+$ ]]; then
-            IS_EDGE_ROLLBACK='true'
+          IS_CHANNEL_ROLLBACK='false'
+          if [ "$ALLOW_CHANNEL_ROLLBACK" = 'true' ] && [[ "$SOURCE_TAG" =~ ^(main|edge)-[0-9]{8}-[0-9]+$ ]]; then
+            IS_CHANNEL_ROLLBACK='true'
           fi
 
           if is_dev_or_prerelease "$SOURCE_TAG"; then
@@ -190,8 +190,8 @@ jobs:
             exit 1
           fi
 
-          if [ "$IS_EDGE_ROLLBACK" != 'true' ] && is_edge_channel "$SOURCE_TAG"; then
-            echo "Refusing retag: source tag appears to be edge, but edge rollback is not enabled."
+          if [ "$IS_CHANNEL_ROLLBACK" != 'true' ] && is_channel_build "$SOURCE_TAG"; then
+            echo "Refusing retag: source tag appears to be a main/edge channel build, but channel rollback is not enabled."
             exit 1
           fi
 
@@ -200,8 +200,8 @@ jobs:
               echo "Refusing retag: source image metadata appears to be dev/prerelease."
               exit 1
             fi
-            if [ "$IS_EDGE_ROLLBACK" != 'true' ] && is_edge_channel "$value"; then
-              echo "Refusing retag: source image metadata appears to be edge, but edge rollback is not enabled."
+            if [ "$IS_CHANNEL_ROLLBACK" != 'true' ] && is_channel_build "$value"; then
+              echo "Refusing retag: source image metadata appears to be a main/edge channel build, but channel rollback is not enabled."
               exit 1
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Create versioned releases by promoting existing CI Docker images
 #
 # Triggers:
-# - Manual workflow_dispatch from main or dev branches
+# - Manual workflow_dispatch from main, dev, or experimental branches
 #
 # This workflow:
 # 1. Promotes existing CI architecture tags into release tags
@@ -12,9 +12,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    branches:
-      - main
-      - dev
     inputs:
       release_type:
         description: 'Version bump type (dev branch remaps major to minor)'
@@ -32,7 +29,7 @@ on:
         type: string
         default: ''
       source_tag:
-        description: 'CI candidate tag to promote (without -amd64/-arm64), e.g. edge-20260306-123'
+        description: 'CI candidate tag to promote (without -amd64/-arm64), e.g. main-20260306-123'
         required: true
         type: string
       release_notes:
@@ -150,20 +147,40 @@ jobs:
               ;;
           esac
 
-          # Dev-branch releases are always tagged as dev variants.
+          branch_channel() {
+            local ref="$1"
+            if [ "$ref" = 'main' ]; then
+              echo 'main'
+            elif [ "$ref" = 'dev' ]; then
+              echo 'dev'
+            elif [[ "$ref" =~ ^experimental([/-].*)?$ ]]; then
+              printf '%s' "$ref" \
+                | tr '[:upper:]' '[:lower:]' \
+                | sed -E 's|[^a-z0-9]+|-|g; s|^-+||; s|-+$||; s|-+|-|g'
+            else
+              return 1
+            fi
+          }
+
+          CHANNEL="$(branch_channel "$REF_NAME")" || {
+            echo "❌ Releases are only allowed from main, dev, or experimental branches. Got: ${REF_NAME}"
+            exit 1
+          }
+
+          # Non-main releases are always prerelease variants tied to the branch channel.
           # For auto-bumps, skip existing tags while preserving the selected bump semantics.
-          if [ "$REF_NAME" = 'dev' ]; then
+          if [ "$CHANNEL" != 'main' ]; then
             if [ "$RELEASE_TYPE" = 'custom' ]; then
-              if [[ ! "$VERSION" =~ -dev([.-][0-9A-Za-z]+)?$ ]]; then
-                VERSION="${VERSION}-dev"
+              if [[ ! "$VERSION" =~ -${CHANNEL}([.-][0-9A-Za-z]+)?$ ]]; then
+                VERSION="${VERSION}-${CHANNEL}"
               fi
             else
               if ! read -r DEV_MAJOR DEV_MINOR DEV_PATCH < <(parse_core_semver "$VERSION"); then
-                echo "❌ Could not parse dev version base: ${VERSION}"
+                echo "❌ Could not parse prerelease version base: ${VERSION}"
                 exit 1
               fi
 
-              while git rev-parse "v${DEV_MAJOR}.${DEV_MINOR}.${DEV_PATCH}-dev" >/dev/null 2>&1; do
+              while git rev-parse "v${DEV_MAJOR}.${DEV_MINOR}.${DEV_PATCH}-${CHANNEL}" >/dev/null 2>&1; do
                 case "$BUMP_TYPE" in
                   patch)
                     DEV_PATCH=$((DEV_PATCH + 1))
@@ -171,11 +188,11 @@ jobs:
                   *)
                     DEV_MINOR=$((DEV_MINOR + 1))
                     DEV_PATCH=0
-                    ;;
+                  ;;
                 esac
               done
 
-              VERSION="v${DEV_MAJOR}.${DEV_MINOR}.${DEV_PATCH}-dev"
+              VERSION="v${DEV_MAJOR}.${DEV_MINOR}.${DEV_PATCH}-${CHANNEL}"
             fi
           fi
 
@@ -199,18 +216,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$REF_NAME" != 'main' ] && [ "$REF_NAME" != 'dev' ]; then
-            echo "❌ Releases are only allowed from main or dev. Got: ${REF_NAME}"
+          branch_channel() {
+            local ref="$1"
+            if [ "$ref" = 'main' ]; then
+              echo 'main'
+            elif [ "$ref" = 'dev' ]; then
+              echo 'dev'
+            elif [[ "$ref" =~ ^experimental([/-].*)?$ ]]; then
+              printf '%s' "$ref" \
+                | tr '[:upper:]' '[:lower:]' \
+                | sed -E 's|[^a-z0-9]+|-|g; s|^-+||; s|-+$||; s|-+|-|g'
+            else
+              return 1
+            fi
+          }
+
+          CHANNEL="$(branch_channel "$REF_NAME")" || {
+            echo "❌ Releases are only allowed from main, dev, or experimental branches. Got: ${REF_NAME}"
             exit 1
-          fi
+          }
 
           IS_PRERELEASE='false'
           REASON='stable-main'
 
-          # All dev-branch releases are prereleases.
-          if [ "$REF_NAME" = 'dev' ]; then
+          # All non-main branch releases are prereleases.
+          if [ "$CHANNEL" != 'main' ]; then
             IS_PRERELEASE='true'
-            REASON='dev-branch'
+            REASON="branch-${CHANNEL}"
           # Main-branch prerelease tags (rc/beta/alpha/pre/preview) are also prereleases.
           elif [[ "$VERSION" =~ -([Rr][Cc]|[Bb]eta|[Aa]lpha|[Pp]re|[Pp]review)([.-]?[0-9A-Za-z]*)?$ ]]; then
             IS_PRERELEASE='true'
@@ -250,14 +282,34 @@ jobs:
             exit 1
           fi
 
-          if [ "$REF_NAME" = 'main' ] && [[ ! "$SOURCE_TAG" =~ ^edge-[0-9]{8}-[0-9]+$ ]]; then
-            echo "❌ main releases must promote an immutable edge tag (edge-YYYYMMDD-RUN)."
+          branch_channel() {
+            local ref="$1"
+            if [ "$ref" = 'main' ]; then
+              echo 'main'
+            elif [ "$ref" = 'dev' ]; then
+              echo 'dev'
+            elif [[ "$ref" =~ ^experimental([/-].*)?$ ]]; then
+              printf '%s' "$ref" \
+                | tr '[:upper:]' '[:lower:]' \
+                | sed -E 's|[^a-z0-9]+|-|g; s|^-+||; s|-+$||; s|-+|-|g'
+            else
+              return 1
+            fi
+          }
+
+          CHANNEL="$(branch_channel "$REF_NAME")" || {
+            echo "❌ Releases are only allowed from main, dev, or experimental branches. Got: ${REF_NAME}"
+            exit 1
+          }
+
+          if [ "$CHANNEL" = 'main' ] && [[ ! "$SOURCE_TAG" =~ ^main-[0-9]{8}-[0-9]+$ ]]; then
+            echo "❌ main releases must promote an immutable main tag (main-YYYYMMDD-RUN)."
             echo "Got: ${SOURCE_TAG}"
             exit 1
           fi
 
-          if [ "$REF_NAME" = 'dev' ] && [[ ! "$SOURCE_TAG" =~ ^dev-[0-9]{8}-[0-9]+$ ]]; then
-            echo "❌ dev releases must promote an immutable dev tag (dev-YYYYMMDD-RUN)."
+          if [ "$CHANNEL" != 'main' ] && [[ ! "$SOURCE_TAG" =~ ^${CHANNEL}-[0-9]{8}-[0-9]+$ ]]; then
+            echo "❌ ${CHANNEL} releases must promote an immutable ${CHANNEL} tag (${CHANNEL}-YYYYMMDD-RUN)."
             echo "Got: ${SOURCE_TAG}"
             exit 1
           fi
@@ -269,11 +321,11 @@ jobs:
     name: Create Multi-Arch Manifest
     runs-on: ubuntu-latest
     needs: [validate]
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
     permissions:
       contents: write
       packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -392,11 +444,26 @@ jobs:
           digest=$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest.Digest}}' | xargs)
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
+  attest-manifest:
+    name: Attest Release Manifest
+    runs-on: ubuntu-latest
+    needs: [manifest]
+    if: needs.manifest.result == 'success'
+    continue-on-error: true
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecc0c4c32 # v4
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
-          subject-digest: ${{ steps.digest.outputs.digest }}
+          subject-digest: ${{ needs.manifest.outputs.digest }}
           push-to-registry: true
 
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      digest: ${{ steps.promote.outputs.digest }}
     permissions:
       contents: write
       packages: write
@@ -372,6 +372,7 @@ jobs:
           echo "✅ Found ${SOURCE_AMD64_IMAGE} and ${SOURCE_ARM64_IMAGE}"
 
       - name: Promote source images to release tags with release metadata
+        id: promote
         env:
           REF_NAME: ${{ github.ref_name }}
           SOURCE_TAG: ${{ needs.validate.outputs.source_tag }}
@@ -384,6 +385,26 @@ jobs:
           RELEASE_MULTIARCH_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
+
+          resolve_digest() {
+            local image="$1"
+            local attempts="${2:-10}"
+            local sleep_seconds="${3:-3}"
+            local digest=''
+
+            for attempt in $(seq 1 "$attempts"); do
+              digest="$(crane digest "$image" 2>/dev/null || true)"
+              if [ -n "$digest" ]; then
+                echo "$digest"
+                return 0
+              fi
+              echo "Digest not yet available for ${image} (attempt ${attempt}/${attempts}), retrying..."
+              sleep "$sleep_seconds"
+            done
+
+            echo "❌ Failed to resolve digest for ${image} after ${attempts} attempts" >&2
+            return 1
+          }
 
           # Mutate immutable source architecture images into release tags without rebuild.
           # This writes release version metadata directly into the image config.
@@ -412,17 +433,13 @@ jobs:
 
           # Build release manifest from the release architecture tags.
           docker buildx imagetools create -t "$RELEASE_MULTIARCH_IMAGE" "$RELEASE_AMD64_IMAGE" "$RELEASE_ARM64_IMAGE"
-          RELEASE_DIGEST="$(docker buildx imagetools inspect "$RELEASE_MULTIARCH_IMAGE" | awk '/^Digest:/ {print $2; exit}')"
-
-          if [ -z "$RELEASE_DIGEST" ]; then
-            echo "❌ Failed to resolve digest for ${RELEASE_MULTIARCH_IMAGE}"
-            exit 1
-          fi
+          RELEASE_DIGEST="$(resolve_digest "$RELEASE_MULTIARCH_IMAGE")"
+          echo "digest=${RELEASE_DIGEST}" >> "$GITHUB_OUTPUT"
 
           # Tag as latest only for stable main releases.
           if [ "$REF_NAME" = 'main' ] && [ "$IS_PRERELEASE" != 'true' ]; then
             crane tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}@${RELEASE_DIGEST}" latest
-            LATEST_DIGEST="$(docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest" | awk '/^Digest:/ {print $2; exit}')"
+            LATEST_DIGEST="$(resolve_digest "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest")"
 
             if [ "$LATEST_DIGEST" != "$RELEASE_DIGEST" ]; then
               echo "❌ latest digest does not match release digest"
@@ -435,14 +452,6 @@ jobs:
           else
             echo "✅ Promoted ${SOURCE_TAG} to ${VERSION} (latest skipped for prerelease/non-main)"
           fi
-
-      - name: Get manifest digest
-        id: digest
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ needs.validate.outputs.version }}
-        run: |
-          digest=$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest.Digest}}' | xargs)
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
   attest-manifest:
     name: Attest Release Manifest
@@ -458,6 +467,13 @@ jobs:
     steps:
       - name: Set lowercase image name
         run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
@@ -478,6 +494,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Create Git tag
         env:


### PR DESCRIPTION
## Summary

Renamed the main branch container channel from `edge-*` to `main-*` for clearer release semantics, updated the release and cleanup workflows to support the new naming while safely aging out legacy `edge-*` builds, and separated provenance attestation from the critical release path so a provenance issue cannot block image promotion or GitHub release publication.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [x] Other: CI/CD workflow and release channel migration

## Changes Made

- Rename main branch CI image tags from `edge-*` to `main-*` in the Docker build workflow.
- Publish mutable `main` for the `main` branch instead of mutable `edge`.
- Update the release workflow to require `main-YYYYMMDD-RUN` as the source candidate tag for stable main releases.
- Replace the broken `actions/attest-build-provenance` pin with a valid `@v4` action reference.
- Move provenance attestation out of the manifest promotion job into a separate attestation job.
- Make provenance attestation non-blocking so release promotion and GitHub release creation can still complete if attestation fails.
- Pass the promoted manifest digest between jobs so attestation targets the final published release manifest.
- Update GHCR cleanup to retain and prune both legacy `edge-*` builds and new `main-*` builds during the migration period.
- Stop explicitly preserving the legacy mutable `edge` tag so old edge artifacts can age out naturally.
- Update the GHCR latest retag workflow to allow emergency rollback from `main-*` and legacy `edge-*` tags during transition.
- Remove the ineffective `workflow_dispatch.branches` restriction from the release workflow.

## Areas Affected

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation
- [x] CI/CD / Release Workflows

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)
- [x] Targeted validation passes

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)
