### PR TITLE
chore: improve GitHub release note categorization

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,19 +8,48 @@ changelog:
       labels:
         - breaking-change
         - major
+        - breaking
     - title: 'Features'
       labels:
         - feature
         - enhancement
+        - feat
     - title: 'Bug Fixes'
       labels:
         - bug
         - bugfix
         - fix
+        - regression
+    - title: 'Indexers & Search'
+      labels:
+        - indexer
+        - search
+        - metadata
+        - tmdb
+    - title: 'Downloads & Imports'
+      labels:
+        - downloads
+        - import
+        - sabnzbd
+        - torrent
+        - usenet
+    - title: 'Subtitles'
+      labels:
+        - subtitles
+        - subtitle
     - title: 'Documentation'
       labels:
         - documentation
         - docs
+    - title: 'Testing'
+      labels:
+        - test
+        - tests
+        - testing
+    - title: 'Performance'
+      labels:
+        - performance
+        - perf
     - title: 'Dependencies'
       labels:
         - dependencies
@@ -29,8 +58,18 @@ changelog:
         - npm
         - docker
         - security
-    - title: 'Maintenance'
+    - title: 'Workflow & Release'
+      labels:
+        - ci
+        - cd
+        - workflow
+        - github-actions
+        - release
+    - title: 'Maintenance & Refactoring'
       labels:
         - chore
-        - ci
         - refactor
+        - cleanup
+    - title: 'Other Changes'
+      labels:
+        - other


### PR DESCRIPTION
## Summary

Improves GitHub-generated release notes by expanding `.github/release.yml` with more specific changelog categories. This makes release notes easier to scan, reduces how much important work falls into generic maintenance buckets, and gives workflow/release changes their own visible section.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [x] Documentation
- [ ] Dependency update
- [x] Other: Release note quality improvement

## Changes Made

- Add new changelog categories for:
  - `Indexers & Search`
  - `Downloads & Imports`
  - `Subtitles`
  - `Testing`
  - `Performance`
  - `Workflow & Release`
- Split generic maintenance into a narrower `Maintenance & Refactoring` category.
- Move `ci`-style workflow changes out of generic maintenance and into `Workflow & Release`.
- Broaden label coverage for common variations such as `breaking`, `feat`, `regression`, and `cleanup`.
- Add a lightweight `Other Changes` category for intentionally generic labels.

## Areas Affected

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [x] Documentation
- [x] CI/CD / Release Workflows

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)
- [x] Targeted validation passes

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)