### PR TITLE
feat: add configuration backup and restore with encrypted secrets

### DIFF
--- a/src/lib/server/crypto/backupCrypto.test.ts
+++ b/src/lib/server/crypto/backupCrypto.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { decryptBackupPayload, encryptBackupPayload } from './backupCrypto.js';
+
+describe('backupCrypto', () => {
+	it('round-trips encrypted backup payloads', () => {
+		const payload = {
+			indexers: {
+				a: {
+					settings: {
+						username: 'demo',
+						password: 'secret'
+					}
+				}
+			}
+		};
+
+		const encrypted = encryptBackupPayload(payload, 'correct horse battery staple');
+		const decrypted = decryptBackupPayload(encrypted, 'correct horse battery staple');
+
+		expect(decrypted).toEqual(payload);
+	});
+
+	it('fails to decrypt with wrong passphrase', () => {
+		const encrypted = encryptBackupPayload({ value: 'secret' }, 'right-passphrase');
+
+		expect(() => decryptBackupPayload(encrypted, 'wrong-passphrase')).toThrow();
+	});
+});

--- a/src/lib/server/crypto/backupCrypto.ts
+++ b/src/lib/server/crypto/backupCrypto.ts
@@ -1,0 +1,56 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+const SALT_LENGTH = 16;
+
+export interface EncryptedBackupPayload {
+	algorithm: 'aes-256-gcm';
+	salt: string;
+	iv: string;
+	authTag: string;
+	ciphertext: string;
+}
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+	return scryptSync(passphrase, salt, KEY_LENGTH);
+}
+
+export function encryptBackupPayload(
+	payload: Record<string, unknown>,
+	passphrase: string
+): EncryptedBackupPayload {
+	const salt = randomBytes(SALT_LENGTH);
+	const iv = randomBytes(IV_LENGTH);
+	const key = deriveKey(passphrase, salt);
+	const cipher = createCipheriv(ALGORITHM, key, iv);
+	const serialized = JSON.stringify(payload);
+
+	const ciphertext = Buffer.concat([cipher.update(serialized, 'utf8'), cipher.final()]);
+	const authTag = cipher.getAuthTag();
+
+	return {
+		algorithm: 'aes-256-gcm',
+		salt: salt.toString('base64'),
+		iv: iv.toString('base64'),
+		authTag: authTag.toString('base64'),
+		ciphertext: ciphertext.toString('base64')
+	};
+}
+
+export function decryptBackupPayload(
+	encrypted: EncryptedBackupPayload,
+	passphrase: string
+): Record<string, unknown> {
+	const salt = Buffer.from(encrypted.salt, 'base64');
+	const iv = Buffer.from(encrypted.iv, 'base64');
+	const authTag = Buffer.from(encrypted.authTag, 'base64');
+	const ciphertext = Buffer.from(encrypted.ciphertext, 'base64');
+	const key = deriveKey(passphrase, salt);
+	const decipher = createDecipheriv(ALGORITHM, key, iv);
+	decipher.setAuthTag(authTag);
+
+	const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+	return JSON.parse(decrypted) as Record<string, unknown>;
+}

--- a/src/lib/server/settings/ConfigurationBackupService.ts
+++ b/src/lib/server/settings/ConfigurationBackupService.ts
@@ -1,0 +1,771 @@
+import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+
+import { ValidationError } from '$lib/errors';
+import { logger } from '$lib/logging';
+import {
+	decryptBackupPayload,
+	encryptBackupPayload,
+	type EncryptedBackupPayload
+} from '$lib/server/crypto/backupCrypto.js';
+import { db } from '$lib/server/db';
+import { getCookieStore } from '$lib/server/indexers/auth/CookieStore.js';
+import {
+	builtInProfileScoreOverrides,
+	captchaSolverSettings,
+	channelCategories,
+	channelLineupBackups,
+	channelLineupItems,
+	customFormats,
+	delayProfiles,
+	downloadClients,
+	indexers,
+	languageProfiles,
+	libraries,
+	libraryRootFolders,
+	librarySettings,
+	livetvAccounts,
+	mediaBrowserServers,
+	monitoringSettings,
+	namingPresets,
+	namingSettings,
+	nntpServers,
+	profileSizeLimits,
+	rootFolders,
+	scoringProfiles,
+	settings,
+	smartLists,
+	stalkerPortals,
+	subtitleProviders,
+	subtitleSettings,
+	taskSettings,
+	indexerStatus
+} from '$lib/server/db/schema';
+
+export interface ConfigurationBackupFile {
+	format: 'cinephage-config-backup';
+	version: 1;
+	createdAt: string;
+	manifest?: ConfigurationBackupManifest;
+	options?: {
+		includeIndexerCookies?: boolean;
+	};
+	data: Record<string, unknown[]>;
+	secrets: EncryptedBackupPayload;
+}
+
+type TableName =
+	| 'settings'
+	| 'monitoringSettings'
+	| 'captchaSolverSettings'
+	| 'taskSettings'
+	| 'scoringProfiles'
+	| 'profileSizeLimits'
+	| 'builtInProfileScoreOverrides'
+	| 'customFormats'
+	| 'downloadClients'
+	| 'rootFolders'
+	| 'libraries'
+	| 'libraryRootFolders'
+	| 'librarySettings'
+	| 'namingSettings'
+	| 'namingPresets'
+	| 'delayProfiles'
+	| 'languageProfiles'
+	| 'subtitleProviders'
+	| 'subtitleSettings'
+	| 'indexers'
+	| 'nntpServers'
+	| 'mediaBrowserServers'
+	| 'stalkerPortals'
+	| 'livetvAccounts'
+	| 'channelCategories'
+	| 'channelLineupItems'
+	| 'channelLineupBackups'
+	| 'smartLists';
+
+export type BackupSectionName =
+	| 'system'
+	| 'profiles'
+	| 'downloads'
+	| 'indexers'
+	| 'subtitles'
+	| 'integrations'
+	| 'liveTv';
+
+export interface ConfigurationBackupSectionManifest {
+	id: BackupSectionName;
+	label: string;
+	tableNames: string[];
+	totalRows: number;
+}
+
+export interface ConfigurationBackupManifest {
+	sectionOrder: BackupSectionName[];
+	sections: ConfigurationBackupSectionManifest[];
+	totalTables: number;
+	totalRows: number;
+	supportsRestoreModes: Array<'apply'>;
+}
+
+export interface RestoreConfigOptions {
+	passphrase: string;
+	sections?: BackupSectionName[];
+	mode?: 'apply' | 'replace';
+}
+
+export interface RestoreConfigResult {
+	restoredSections: BackupSectionName[];
+	restoredTables: TableName[];
+	secretsRestored: boolean;
+	warnings: string[];
+}
+
+interface BackupSecretPayload {
+	tables: Record<string, Record<string, unknown>>;
+	indexerCookies?: Record<
+		string,
+		{
+			cookies: Record<string, string>;
+			expiry: string;
+		}
+	>;
+}
+
+interface ExportConfigOptions {
+	includeIndexerCookies?: boolean;
+}
+
+interface PreparedRestoreTable {
+	config: TableBackupConfig;
+	rows: Record<string, unknown>[];
+}
+
+interface TableBackupConfig {
+	name: TableName;
+	table: AnySQLiteTable;
+	getRecordKey: (row: Record<string, unknown>) => string;
+	conflictTarget: AnySQLiteColumn | AnySQLiteColumn[];
+}
+
+const BACKUP_VERSION = 1 as const;
+const BACKUP_FORMAT = 'cinephage-config-backup' as const;
+
+const SECRET_KEY_NAMES = new Set([
+	'api_key',
+	'apikey',
+	'password',
+	'username',
+	'token',
+	'auth_token',
+	'authtoken',
+	'secret',
+	'cookie',
+	'cookies',
+	'proxy_username',
+	'proxy_password',
+	'headers'
+]);
+
+const TABLES: TableBackupConfig[] = [
+	{
+		name: 'settings',
+		table: settings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: settings.key
+	},
+	{
+		name: 'monitoringSettings',
+		table: monitoringSettings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: monitoringSettings.key
+	},
+	{
+		name: 'captchaSolverSettings',
+		table: captchaSolverSettings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: captchaSolverSettings.key
+	},
+	{
+		name: 'taskSettings',
+		table: taskSettings,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: taskSettings.id
+	},
+	{
+		name: 'scoringProfiles',
+		table: scoringProfiles,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: scoringProfiles.id
+	},
+	{
+		name: 'profileSizeLimits',
+		table: profileSizeLimits,
+		getRecordKey: (row) => String(row.profileId),
+		conflictTarget: profileSizeLimits.profileId
+	},
+	{
+		name: 'builtInProfileScoreOverrides',
+		table: builtInProfileScoreOverrides,
+		getRecordKey: (row) => String(row.profileId),
+		conflictTarget: builtInProfileScoreOverrides.profileId
+	},
+	{
+		name: 'customFormats',
+		table: customFormats,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: customFormats.id
+	},
+	{
+		name: 'downloadClients',
+		table: downloadClients,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: downloadClients.id
+	},
+	{
+		name: 'rootFolders',
+		table: rootFolders,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: rootFolders.id
+	},
+	{
+		name: 'libraries',
+		table: libraries,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: libraries.id
+	},
+	{
+		name: 'libraryRootFolders',
+		table: libraryRootFolders,
+		getRecordKey: (row) => `${String(row.libraryId)}:${String(row.rootFolderId)}`,
+		conflictTarget: [libraryRootFolders.libraryId, libraryRootFolders.rootFolderId]
+	},
+	{
+		name: 'librarySettings',
+		table: librarySettings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: librarySettings.key
+	},
+	{
+		name: 'namingSettings',
+		table: namingSettings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: namingSettings.key
+	},
+	{
+		name: 'namingPresets',
+		table: namingPresets,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: namingPresets.id
+	},
+	{
+		name: 'delayProfiles',
+		table: delayProfiles,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: delayProfiles.id
+	},
+	{
+		name: 'languageProfiles',
+		table: languageProfiles,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: languageProfiles.id
+	},
+	{
+		name: 'subtitleProviders',
+		table: subtitleProviders,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: subtitleProviders.id
+	},
+	{
+		name: 'subtitleSettings',
+		table: subtitleSettings,
+		getRecordKey: (row) => String(row.key),
+		conflictTarget: subtitleSettings.key
+	},
+	{
+		name: 'indexers',
+		table: indexers,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: indexers.id
+	},
+	{
+		name: 'nntpServers',
+		table: nntpServers,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: nntpServers.id
+	},
+	{
+		name: 'mediaBrowserServers',
+		table: mediaBrowserServers,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: mediaBrowserServers.id
+	},
+	{
+		name: 'stalkerPortals',
+		table: stalkerPortals,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: stalkerPortals.id
+	},
+	{
+		name: 'livetvAccounts',
+		table: livetvAccounts,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: livetvAccounts.id
+	},
+	{
+		name: 'channelCategories',
+		table: channelCategories,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: channelCategories.id
+	},
+	{
+		name: 'channelLineupItems',
+		table: channelLineupItems,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: channelLineupItems.id
+	},
+	{
+		name: 'channelLineupBackups',
+		table: channelLineupBackups,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: channelLineupBackups.id
+	},
+	{
+		name: 'smartLists',
+		table: smartLists,
+		getRecordKey: (row) => String(row.id),
+		conflictTarget: smartLists.id
+	}
+];
+const IMPORT_ORDER: TableBackupConfig[] = TABLES;
+
+const SECTION_ORDER: BackupSectionName[] = [
+	'system',
+	'profiles',
+	'downloads',
+	'indexers',
+	'subtitles',
+	'integrations',
+	'liveTv'
+];
+
+const SECTIONS: Array<{
+	id: BackupSectionName;
+	label: string;
+	tableNames: TableName[];
+}> = [
+	{
+		id: 'system',
+		label: 'System & Libraries',
+		tableNames: [
+			'settings',
+			'monitoringSettings',
+			'captchaSolverSettings',
+			'taskSettings',
+			'rootFolders',
+			'libraries',
+			'libraryRootFolders',
+			'librarySettings',
+			'namingSettings',
+			'namingPresets'
+		]
+	},
+	{
+		id: 'profiles',
+		label: 'Profiles & Formats',
+		tableNames: [
+			'scoringProfiles',
+			'profileSizeLimits',
+			'builtInProfileScoreOverrides',
+			'customFormats',
+			'delayProfiles',
+			'languageProfiles'
+		]
+	},
+	{
+		id: 'downloads',
+		label: 'Download Clients',
+		tableNames: ['downloadClients', 'nntpServers']
+	},
+	{
+		id: 'indexers',
+		label: 'Indexers',
+		tableNames: ['indexers']
+	},
+	{
+		id: 'subtitles',
+		label: 'Subtitles',
+		tableNames: ['subtitleProviders', 'subtitleSettings']
+	},
+	{
+		id: 'integrations',
+		label: 'External Integrations',
+		tableNames: ['mediaBrowserServers', 'smartLists']
+	},
+	{
+		id: 'liveTv',
+		label: 'Live TV',
+		tableNames: [
+			'stalkerPortals',
+			'livetvAccounts',
+			'channelCategories',
+			'channelLineupItems',
+			'channelLineupBackups'
+		]
+	}
+];
+
+function normalizeSecretKey(value: string): string {
+	return value.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+}
+
+function isKeyValueSecretEntry(tableName: TableName, row: Record<string, unknown>): boolean {
+	if (!('key' in row) || typeof row.key !== 'string') {
+		return false;
+	}
+
+	if (tableName === 'settings') {
+		return ['tmdb_api_key'].includes(row.key);
+	}
+
+	if (tableName === 'captchaSolverSettings') {
+		return ['proxy_username', 'proxy_password'].includes(row.key);
+	}
+
+	return false;
+}
+
+function isSensitiveField(fieldName: string): boolean {
+	return SECRET_KEY_NAMES.has(normalizeSecretKey(fieldName));
+}
+
+function extractSecrets(
+	value: unknown,
+	fieldName?: string
+): { sanitized: unknown; secret?: unknown } {
+	if (fieldName && isSensitiveField(fieldName)) {
+		return { sanitized: null, secret: value };
+	}
+
+	if (Array.isArray(value)) {
+		const sanitizedArray: unknown[] = [];
+		const secretArray: unknown[] = [];
+		let hasSecret = false;
+
+		for (const item of value) {
+			const extracted = extractSecrets(item);
+			sanitizedArray.push(extracted.sanitized);
+			if (extracted.secret !== undefined) {
+				secretArray.push(extracted.secret);
+				hasSecret = true;
+			} else {
+				secretArray.push(null);
+			}
+		}
+
+		return {
+			sanitized: sanitizedArray,
+			secret: hasSecret ? secretArray : undefined
+		};
+	}
+
+	if (value && typeof value === 'object') {
+		const sanitizedObject: Record<string, unknown> = {};
+		const secretObject: Record<string, unknown> = {};
+		let hasSecret = false;
+
+		for (const [key, nestedValue] of Object.entries(value)) {
+			const extracted = extractSecrets(nestedValue, key);
+			sanitizedObject[key] = extracted.sanitized;
+			if (extracted.secret !== undefined) {
+				secretObject[key] = extracted.secret;
+				hasSecret = true;
+			}
+		}
+
+		return {
+			sanitized: sanitizedObject,
+			secret: hasSecret ? secretObject : undefined
+		};
+	}
+
+	return { sanitized: value };
+}
+
+function deepMergeRecord<T>(base: T, secret: unknown): T {
+	if (secret === undefined || secret === null) {
+		return base;
+	}
+
+	if (Array.isArray(base) && Array.isArray(secret)) {
+		return base.map((item, index) => deepMergeRecord(item, secret[index])) as T;
+	}
+
+	if (base && typeof base === 'object' && !Array.isArray(base) && typeof secret === 'object') {
+		const merged = { ...(base as Record<string, unknown>) };
+		for (const [key, secretValue] of Object.entries(secret as Record<string, unknown>)) {
+			merged[key] = key in merged ? deepMergeRecord(merged[key], secretValue) : secretValue;
+		}
+		return merged as T;
+	}
+
+	return secret as T;
+}
+
+function restoreExistingSensitiveValues<T>(incoming: T, existing: unknown, fieldName?: string): T {
+	if (fieldName && isSensitiveField(fieldName) && incoming === null) {
+		return existing as T;
+	}
+
+	if (Array.isArray(incoming) && Array.isArray(existing)) {
+		return incoming.map((item, index) =>
+			restoreExistingSensitiveValues(item, existing[index])
+		) as T;
+	}
+
+	if (
+		incoming &&
+		typeof incoming === 'object' &&
+		!Array.isArray(incoming) &&
+		existing &&
+		typeof existing === 'object' &&
+		!Array.isArray(existing)
+	) {
+		const merged = { ...(incoming as Record<string, unknown>) };
+
+		for (const [key, value] of Object.entries(merged)) {
+			merged[key] = restoreExistingSensitiveValues(
+				value,
+				(existing as Record<string, unknown>)[key],
+				key
+			);
+		}
+
+		return merged as T;
+	}
+
+	return incoming;
+}
+
+function buildManifest(data: Record<string, unknown[]>): ConfigurationBackupManifest {
+	const sections = SECTIONS.map((section) => ({
+		id: section.id,
+		label: section.label,
+		tableNames: section.tableNames,
+		totalRows: section.tableNames.reduce(
+			(sum, tableName) => sum + (data[tableName]?.length ?? 0),
+			0
+		)
+	}));
+
+	return {
+		sectionOrder: SECTION_ORDER,
+		sections,
+		totalTables: TABLES.length,
+		totalRows: Object.values(data).reduce((sum, rows) => sum + rows.length, 0),
+		supportsRestoreModes: ['apply']
+	};
+}
+
+export class ConfigurationBackupService {
+	async exportConfig(
+		passphrase: string,
+		options: ExportConfigOptions = {}
+	): Promise<ConfigurationBackupFile> {
+		const data: Record<string, unknown[]> = {};
+		const secretPayload: BackupSecretPayload = {
+			tables: {}
+		};
+
+		for (const config of TABLES) {
+			const rows = (await db.select().from(config.table)) as Record<string, unknown>[];
+			const sanitizedRows: Record<string, unknown>[] = [];
+			const tableSecrets: Record<string, unknown> = {};
+
+			for (const row of rows) {
+				const recordKey = config.getRecordKey(row);
+
+				if (isKeyValueSecretEntry(config.name, row)) {
+					sanitizedRows.push({ ...row, value: null });
+					tableSecrets[recordKey] = { value: row.value };
+					continue;
+				}
+
+				const extracted = extractSecrets(row);
+				sanitizedRows.push(extracted.sanitized as Record<string, unknown>);
+				if (extracted.secret !== undefined) {
+					tableSecrets[recordKey] = extracted.secret;
+				}
+			}
+
+			data[config.name] = sanitizedRows;
+			if (Object.keys(tableSecrets).length > 0) {
+				secretPayload.tables[config.name] = tableSecrets;
+			}
+		}
+
+		if (options.includeIndexerCookies) {
+			const cookieRows = await db
+				.select({
+					indexerId: indexerStatus.indexerId,
+					cookies: indexerStatus.cookies,
+					cookiesExpirationDate: indexerStatus.cookiesExpirationDate
+				})
+				.from(indexerStatus);
+
+			const activeCookieRows = cookieRows.filter(
+				(row) =>
+					!!row.cookies &&
+					!!row.cookiesExpirationDate &&
+					new Date(row.cookiesExpirationDate).getTime() > Date.now()
+			);
+
+			if (activeCookieRows.length > 0) {
+				secretPayload.indexerCookies = Object.fromEntries(
+					activeCookieRows.map((row) => [
+						row.indexerId,
+						{
+							cookies: row.cookies as Record<string, string>,
+							expiry: row.cookiesExpirationDate as string
+						}
+					])
+				);
+			}
+		}
+
+		return {
+			format: BACKUP_FORMAT,
+			version: BACKUP_VERSION,
+			createdAt: new Date().toISOString(),
+			manifest: buildManifest(data),
+			options: {
+				includeIndexerCookies: !!options.includeIndexerCookies
+			},
+			data,
+			secrets: encryptBackupPayload(secretPayload as unknown as Record<string, unknown>, passphrase)
+		};
+	}
+
+	async restoreConfig(
+		backup: ConfigurationBackupFile,
+		options: RestoreConfigOptions
+	): Promise<RestoreConfigResult> {
+		this.validateBackupFile(backup);
+
+		const mode = options.mode ?? 'apply';
+		if (mode !== 'apply') {
+			throw new ValidationError(
+				'Replace-all restore mode is not implemented yet. Use apply mode to avoid breaking existing references.'
+			);
+		}
+
+		const selectedSections =
+			options.sections && options.sections.length > 0
+				? new Set(options.sections)
+				: new Set<BackupSectionName>(SECTION_ORDER);
+		const selectedTableNames = new Set<TableName>(
+			SECTIONS.filter((section) => selectedSections.has(section.id)).flatMap(
+				(section) => section.tableNames
+			)
+		);
+		const warnings: string[] = [];
+		let decryptedSecrets: BackupSecretPayload;
+		try {
+			decryptedSecrets = decryptBackupPayload(
+				backup.secrets,
+				options.passphrase
+			) as unknown as BackupSecretPayload;
+		} catch (error) {
+			logger.error(
+				{ err: error, component: 'ConfigurationBackupService', logDomain: 'settings' },
+				'Failed to decrypt configuration backup'
+			);
+			throw new ValidationError('Invalid backup passphrase or corrupted secret payload');
+		}
+
+		const preparedTables: PreparedRestoreTable[] = [];
+		const restoredTables: TableName[] = [];
+
+		for (const config of IMPORT_ORDER) {
+			if (!selectedTableNames.has(config.name)) {
+				continue;
+			}
+
+			const rawRows = backup.data[config.name] ?? [];
+			if (!Array.isArray(rawRows) || rawRows.length === 0) {
+				continue;
+			}
+
+			const tableSecrets =
+				(decryptedSecrets.tables?.[config.name] as Record<string, unknown> | undefined) ?? {};
+			const existingRows = (await db.select().from(config.table)) as Record<string, unknown>[];
+			const existingRowMap = new Map(
+				existingRows.map((row) => [config.getRecordKey(row), row] as const)
+			);
+
+			const restoredRows = rawRows.map((rawRow) => {
+				const row = rawRow as Record<string, unknown>;
+				const recordKey = config.getRecordKey(row);
+				const restoredWithSecrets = deepMergeRecord(row, tableSecrets[recordKey]);
+				return restoreExistingSensitiveValues(restoredWithSecrets, existingRowMap.get(recordKey));
+			});
+
+			preparedTables.push({
+				config,
+				rows: restoredRows
+			});
+			restoredTables.push(config.name);
+		}
+
+		db.transaction((tx) => {
+			for (const preparedTable of preparedTables) {
+				for (const restoredRow of preparedTable.rows) {
+					tx.insert(preparedTable.config.table)
+						.values(restoredRow as never)
+						.onConflictDoUpdate({
+							target: preparedTable.config.conflictTarget,
+							set: restoredRow as never
+						})
+						.run();
+				}
+			}
+		});
+
+		if (selectedSections.has('indexers') && decryptedSecrets.indexerCookies) {
+			const cookieStore = getCookieStore();
+			for (const [indexerId, stored] of Object.entries(decryptedSecrets.indexerCookies)) {
+				await cookieStore.clear(indexerId);
+				await cookieStore.save(indexerId, stored.cookies, new Date(stored.expiry));
+			}
+		}
+
+		return {
+			restoredSections: SECTION_ORDER.filter((section) => selectedSections.has(section)),
+			restoredTables,
+			secretsRestored: true,
+			warnings: [...new Set(warnings)]
+		};
+	}
+
+	private validateBackupFile(backup: ConfigurationBackupFile): void {
+		if (backup.format !== BACKUP_FORMAT) {
+			throw new ValidationError('Unsupported backup format');
+		}
+
+		if (backup.version !== BACKUP_VERSION) {
+			throw new ValidationError(`Unsupported backup version: ${backup.version}`);
+		}
+
+		if (!backup.data || typeof backup.data !== 'object') {
+			throw new ValidationError('Backup file is missing configuration data');
+		}
+	}
+}
+
+let _instance: ConfigurationBackupService | null = null;
+
+export function getConfigurationBackupService(): ConfigurationBackupService {
+	if (!_instance) {
+		_instance = new ConfigurationBackupService();
+	}
+	return _instance;
+}

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -185,6 +185,68 @@ export const enrichmentOptionsSchema = z.object({
 });
 
 /**
+ * Schema for configuration export (Backup & Restore).
+ */
+export const backupExportSchema = z.object({
+	passphrase: z.string().min(16, 'Passphrase must be at least 16 characters'),
+	includeIndexerCookies: z.boolean().default(false)
+});
+
+export const encryptedBackupPayloadSchema = z.object({
+	algorithm: z.literal('aes-256-gcm'),
+	salt: z.string().min(1),
+	iv: z.string().min(1),
+	authTag: z.string().min(1),
+	ciphertext: z.string().min(1)
+});
+
+const backupSectionNameSchema = z.enum([
+	'system',
+	'profiles',
+	'downloads',
+	'indexers',
+	'subtitles',
+	'integrations',
+	'liveTv'
+]);
+
+export const configurationBackupManifestSchema = z.object({
+	sectionOrder: z.array(backupSectionNameSchema),
+	sections: z.array(
+		z.object({
+			id: backupSectionNameSchema,
+			label: z.string().min(1),
+			tableNames: z.array(z.string().min(1)),
+			totalRows: z.number().int().min(0)
+		})
+	),
+	totalTables: z.number().int().min(0),
+	totalRows: z.number().int().min(0),
+	supportsRestoreModes: z.array(z.literal('apply'))
+});
+
+export const configurationBackupFileSchema = z.object({
+	format: z.literal('cinephage-config-backup'),
+	version: z.literal(1),
+	createdAt: z.string().min(1),
+	manifest: configurationBackupManifestSchema.optional(),
+	options: z
+		.object({
+			includeIndexerCookies: z.boolean().optional()
+		})
+		.optional(),
+	data: z.record(z.string(), z.array(z.record(z.string(), z.unknown()))),
+	secrets: encryptedBackupPayloadSchema
+});
+
+export const backupImportSchema = z.object({
+	passphrase: z.string().trim().min(1, 'Backup passphrase is required'),
+	sections: z.array(backupSectionNameSchema).optional(),
+	mode: z.enum(['apply', 'replace']).default('apply'),
+	backup: configurationBackupFileSchema
+});
+
+/**
  * Schema for search query parameters (GET request).
  */
 export const searchQuerySchema = z.object({

--- a/src/routes/api/settings/system/backup/+server.ts
+++ b/src/routes/api/settings/system/backup/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { parseBody } from '$lib/server/api/validate.js';
+import { getConfigurationBackupService } from '$lib/server/settings/ConfigurationBackupService.js';
+import { backupExportSchema, backupImportSchema } from '$lib/validation/schemas.js';
+
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const { passphrase, includeIndexerCookies } = await parseBody(event.request, backupExportSchema);
+	const service = getConfigurationBackupService();
+	const backup = await service.exportConfig(passphrase, { includeIndexerCookies });
+	const timestamp = backup.createdAt.replace(/[:.]/g, '-');
+
+	return json({
+		success: true,
+		fileName: `cinephage-config-backup-${timestamp}.json`,
+		backup
+	});
+};
+
+export const PUT: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const { passphrase, sections, mode, backup } = await parseBody(event.request, backupImportSchema);
+	const service = getConfigurationBackupService();
+	const result = await service.restoreConfig(backup, { passphrase, sections, mode });
+
+	return json({
+		success: true,
+		message: 'Configuration restored successfully',
+		result
+	});
+};

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -650,12 +650,12 @@
 </svelte:head>
 
 <SettingsPage title={m.settings_general_heading()} subtitle={m.settings_general_subtitle()}>
-	<div class="overflow-x-auto">
-		<div role="tablist" class="tabs-boxed tabs inline-flex min-w-max flex-nowrap">
+	<div>
+		<div role="tablist" class="tabs-boxed tabs flex flex-wrap gap-2">
 			<button
 				type="button"
 				role="tab"
-				class="tab gap-2 whitespace-nowrap"
+				class="tab h-auto min-h-0 flex-1 gap-2 px-3 py-2 sm:flex-none"
 				class:tab-active={activeTab === 'libraries'}
 				onclick={() => void setTab('libraries')}
 			>
@@ -665,7 +665,7 @@
 			<button
 				type="button"
 				role="tab"
-				class="tab gap-2 whitespace-nowrap"
+				class="tab h-auto min-h-0 flex-1 gap-2 px-3 py-2 sm:flex-none"
 				class:tab-active={activeTab === 'rootFolders'}
 				onclick={() => void setTab('rootFolders')}
 			>
@@ -675,7 +675,7 @@
 			<button
 				type="button"
 				role="tab"
-				class="tab gap-2 whitespace-nowrap"
+				class="tab h-auto min-h-0 flex-1 gap-2 px-3 py-2 sm:flex-none"
 				class:tab-active={activeTab === 'maintenance'}
 				onclick={() => void setTab('maintenance')}
 			>
@@ -692,7 +692,10 @@
 			variant="flat"
 		>
 			{#snippet actions()}
-				<button class="btn ml-auto gap-2 btn-sm btn-primary" onclick={handleActiveTabAction}>
+				<button
+					class="btn ml-auto w-full gap-2 btn-sm btn-primary sm:w-auto"
+					onclick={handleActiveTabAction}
+				>
 					<Plus class="h-4 w-4" />
 					{activeTabActionLabel}
 				</button>
@@ -713,7 +716,10 @@
 			variant="flat"
 		>
 			{#snippet actions()}
-				<button class="btn ml-auto gap-2 btn-sm btn-primary" onclick={handleActiveTabAction}>
+				<button
+					class="btn ml-auto w-full gap-2 btn-sm btn-primary sm:w-auto"
+					onclick={handleActiveTabAction}
+				>
 					<Plus class="h-4 w-4" />
 					{activeTabActionLabel}
 				</button>
@@ -757,7 +763,7 @@
 		>
 			{#snippet actions()}
 				<button
-					class="btn ml-auto gap-2 btn-sm btn-primary"
+					class="btn ml-auto w-full gap-2 btn-sm btn-primary sm:w-auto"
 					onclick={handleActiveTabAction}
 					disabled={scanning || data.rootFolders.length === 0}
 				>

--- a/src/routes/settings/system/+page.svelte
+++ b/src/routes/settings/system/+page.svelte
@@ -20,7 +20,9 @@
 		Activity,
 		Clock,
 		Trash2,
-		Play
+		Play,
+		Download,
+		Upload
 	} from 'lucide-svelte';
 	import type { PageData } from './$types';
 	import { copyToClipboard as copyTextToClipboard } from '$lib/utils/clipboard.js';
@@ -216,6 +218,452 @@
 		} catch {
 			return false;
 		}
+	}
+
+	// =====================
+	// Backup & Restore State
+	// =====================
+	type BackupSectionId =
+		| 'system'
+		| 'profiles'
+		| 'downloads'
+		| 'indexers'
+		| 'subtitles'
+		| 'integrations'
+		| 'liveTv';
+
+	interface BackupSectionPreview {
+		id: BackupSectionId;
+		label: string;
+		tableNames: string[];
+		totalRows: number;
+		summary: string;
+	}
+
+	interface BackupPreview {
+		version: number;
+		createdAt: string;
+		totalSections: number;
+		includeIndexerCookies: boolean;
+		supportsRestoreModes: string[];
+		sections: BackupSectionPreview[];
+	}
+
+	const BACKUP_SECTION_GROUPS: BackupSectionPreview[] = [
+		{
+			id: 'system',
+			label: 'System & Libraries',
+			tableNames: [
+				'settings',
+				'monitoringSettings',
+				'captchaSolverSettings',
+				'taskSettings',
+				'rootFolders',
+				'libraries',
+				'libraryRootFolders',
+				'librarySettings',
+				'namingSettings',
+				'namingPresets'
+			],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'profiles',
+			label: 'Profiles & Formats',
+			tableNames: [
+				'scoringProfiles',
+				'profileSizeLimits',
+				'builtInProfileScoreOverrides',
+				'customFormats',
+				'delayProfiles',
+				'languageProfiles'
+			],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'downloads',
+			label: 'Download Clients',
+			tableNames: ['downloadClients', 'nntpServers'],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'indexers',
+			label: 'Indexers',
+			tableNames: ['indexers'],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'subtitles',
+			label: 'Subtitles',
+			tableNames: ['subtitleProviders', 'subtitleSettings'],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'integrations',
+			label: 'External Integrations',
+			tableNames: ['mediaBrowserServers', 'smartLists'],
+			totalRows: 0,
+			summary: ''
+		},
+		{
+			id: 'liveTv',
+			label: 'Live TV',
+			tableNames: [
+				'stalkerPortals',
+				'livetvAccounts',
+				'channelCategories',
+				'channelLineupItems',
+				'channelLineupBackups'
+			],
+			totalRows: 0,
+			summary: ''
+		}
+	];
+
+	function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+		return `${count} ${count === 1 ? singular : plural}`;
+	}
+
+	function summarizeBackupSection(
+		sectionId: BackupSectionId,
+		totalRows: number,
+		countsByTable: Record<string, number>
+	): string {
+		const joinNonZero = (parts: string[]) => parts.filter(Boolean).join(', ');
+
+		switch (sectionId) {
+			case 'system':
+				return pluralize(totalRows, 'system and library setting');
+			case 'profiles':
+				return joinNonZero([
+					countsByTable.scoringProfiles
+						? pluralize(countsByTable.scoringProfiles, 'scoring profile')
+						: '',
+					countsByTable.customFormats
+						? pluralize(countsByTable.customFormats, 'custom format')
+						: '',
+					countsByTable.languageProfiles
+						? pluralize(countsByTable.languageProfiles, 'language profile')
+						: '',
+					countsByTable.delayProfiles ? pluralize(countsByTable.delayProfiles, 'delay profile') : ''
+				]);
+			case 'downloads':
+				return joinNonZero([
+					countsByTable.downloadClients ? pluralize(countsByTable.downloadClients, 'client') : '',
+					countsByTable.nntpServers ? pluralize(countsByTable.nntpServers, 'NNTP server') : ''
+				]);
+			case 'indexers':
+				return `${pluralize(totalRows, 'indexer')} configured`;
+			case 'subtitles':
+				return joinNonZero([
+					countsByTable.subtitleProviders
+						? pluralize(countsByTable.subtitleProviders, 'provider')
+						: '',
+					countsByTable.subtitleSettings ? pluralize(countsByTable.subtitleSettings, 'setting') : ''
+				]);
+			case 'integrations':
+				return joinNonZero([
+					countsByTable.mediaBrowserServers
+						? pluralize(countsByTable.mediaBrowserServers, 'media server')
+						: '',
+					countsByTable.smartLists ? pluralize(countsByTable.smartLists, 'smart list') : ''
+				]);
+			case 'liveTv':
+				return joinNonZero([
+					countsByTable.stalkerPortals ? pluralize(countsByTable.stalkerPortals, 'portal') : '',
+					countsByTable.livetvAccounts ? pluralize(countsByTable.livetvAccounts, 'account') : '',
+					countsByTable.channelCategories
+						? pluralize(countsByTable.channelCategories, 'category')
+						: '',
+					countsByTable.channelLineupItems
+						? pluralize(countsByTable.channelLineupItems, 'lineup item')
+						: '',
+					countsByTable.channelLineupBackups
+						? pluralize(countsByTable.channelLineupBackups, 'lineup backup')
+						: ''
+				]);
+		}
+	}
+
+	let backupExportPassphrase = $state('');
+	let backupIncludeIndexerCookies = $state(false);
+	let backupImportPassphrase = $state('');
+	let backupExporting = $state(false);
+	let backupImporting = $state(false);
+	let confirmRestoreOpen = $state(false);
+	let selectedBackupFile = $state<File | null>(null);
+	let backupPreview = $state<BackupPreview | null>(null);
+	let backupMessage = $state<string | null>(null);
+	let backupError = $state<string | null>(null);
+	let backupWarnings = $state<string[]>([]);
+	let selectedRestoreSections = $state<BackupSectionId[]>([]);
+
+	function buildBackupPreview(backup: unknown): BackupPreview {
+		if (!backup || typeof backup !== 'object' || Array.isArray(backup)) {
+			throw new Error('Invalid backup file');
+		}
+
+		const candidate = backup as Record<string, unknown>;
+		const data = candidate.data;
+		if (!data || typeof data !== 'object' || Array.isArray(data)) {
+			throw new Error('Backup file is missing configuration data');
+		}
+
+		const manifest = candidate.manifest;
+		if (manifest && typeof manifest === 'object' && !Array.isArray(manifest)) {
+			const typedManifest = manifest as Record<string, unknown>;
+			const sections = Array.isArray(typedManifest.sections)
+				? typedManifest.sections
+						.filter(
+							(section): section is Record<string, unknown> =>
+								!!section && typeof section === 'object'
+						)
+						.map((section) => {
+							const tableNames = Array.isArray(section.tableNames)
+								? section.tableNames.map((name) => String(name))
+								: [];
+							const sectionId = String(section.id) as BackupSectionId;
+							const countsByTable = Object.fromEntries(
+								tableNames.map((tableName) => [
+									tableName,
+									Array.isArray((data as Record<string, unknown>)[tableName])
+										? ((data as Record<string, unknown>)[tableName] as unknown[]).length
+										: 0
+								])
+							);
+
+							return {
+								id: sectionId,
+								label: String(section.label),
+								tableNames,
+								totalRows: typeof section.totalRows === 'number' ? section.totalRows : 0,
+								summary: summarizeBackupSection(
+									sectionId,
+									typeof section.totalRows === 'number' ? section.totalRows : 0,
+									countsByTable
+								)
+							};
+						})
+				: [];
+
+			return {
+				version: typeof candidate.version === 'number' ? candidate.version : 1,
+				createdAt: typeof candidate.createdAt === 'string' ? candidate.createdAt : '',
+				totalSections: sections.filter((section) => section.totalRows > 0).length,
+				includeIndexerCookies:
+					!!candidate.options &&
+					typeof candidate.options === 'object' &&
+					!Array.isArray(candidate.options) &&
+					!!(candidate.options as Record<string, unknown>).includeIndexerCookies,
+				supportsRestoreModes: Array.isArray(typedManifest.supportsRestoreModes)
+					? typedManifest.supportsRestoreModes.map((mode) => String(mode))
+					: ['apply'],
+				sections
+			};
+		}
+
+		const dataRecord = data as Record<string, unknown>;
+		const sections = BACKUP_SECTION_GROUPS.map((section) => {
+			const countsByTable = Object.fromEntries(
+				section.tableNames.map((tableName) => [
+					tableName,
+					Array.isArray(dataRecord[tableName]) ? (dataRecord[tableName] as unknown[]).length : 0
+				])
+			);
+			const totalRows = Object.values(countsByTable).reduce<number>((sum, count) => sum + count, 0);
+
+			return {
+				...section,
+				totalRows,
+				summary: summarizeBackupSection(section.id, totalRows, countsByTable)
+			};
+		});
+
+		return {
+			version: typeof candidate.version === 'number' ? candidate.version : 1,
+			createdAt: typeof candidate.createdAt === 'string' ? candidate.createdAt : '',
+			totalSections: sections.filter((section) => section.totalRows > 0).length,
+			includeIndexerCookies: false,
+			supportsRestoreModes: ['apply'],
+			sections
+		};
+	}
+
+	async function handleBackupFileChange(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		selectedBackupFile = input.files?.[0] ?? null;
+		backupError = null;
+		backupMessage = null;
+		backupWarnings = [];
+		backupPreview = null;
+
+		if (!selectedBackupFile) {
+			selectedRestoreSections = [];
+			return;
+		}
+
+		try {
+			const backup = JSON.parse(await selectedBackupFile.text());
+			backupPreview = buildBackupPreview(backup);
+			selectedRestoreSections = backupPreview.sections
+				.filter((section) => section.totalRows > 0)
+				.map((section) => section.id);
+		} catch (error) {
+			selectedBackupFile = null;
+			selectedRestoreSections = [];
+			backupError = error instanceof Error ? error.message : 'Failed to read backup file';
+		}
+	}
+
+	function toggleRestoreSection(sectionId: BackupSectionId, checked: boolean) {
+		if (checked) {
+			if (!selectedRestoreSections.includes(sectionId)) {
+				selectedRestoreSections = [...selectedRestoreSections, sectionId];
+			}
+			return;
+		}
+
+		selectedRestoreSections = selectedRestoreSections.filter((section) => section !== sectionId);
+	}
+
+	async function exportConfigurationBackup() {
+		backupExporting = true;
+		backupError = null;
+		backupMessage = null;
+		backupWarnings = [];
+
+		try {
+			const response = await fetch('/api/settings/system/backup', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					passphrase: backupExportPassphrase,
+					includeIndexerCookies: backupIncludeIndexerCookies
+				})
+			});
+			const payload = await readResponsePayload<Record<string, unknown>>(response);
+
+			if (!response.ok) {
+				throw new Error(getResponseErrorMessage(payload, 'Failed to export configuration backup'));
+			}
+
+			if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+				throw new Error('Invalid backup export response');
+			}
+
+			const backup = payload.backup;
+			const fileName =
+				typeof payload.fileName === 'string' ? payload.fileName : 'cinephage-config-backup.json';
+			const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const anchor = document.createElement('a');
+			anchor.href = url;
+			anchor.download = fileName;
+			anchor.click();
+			URL.revokeObjectURL(url);
+
+			backupMessage = 'Configuration backup exported successfully.';
+		} catch (error) {
+			backupError =
+				error instanceof Error ? error.message : 'Failed to export configuration backup';
+		} finally {
+			backupExporting = false;
+		}
+	}
+
+	async function importConfigurationBackup() {
+		if (!selectedBackupFile) {
+			backupError = 'Select a backup file first.';
+			return;
+		}
+
+		if (selectedRestoreSections.length === 0) {
+			backupError = 'Select at least one backup section to restore.';
+			return;
+		}
+
+		if (!backupImportPassphrase.trim()) {
+			backupError = 'Backup passphrase is required for restore.';
+			return;
+		}
+
+		confirmRestoreOpen = false;
+		backupImporting = true;
+		backupError = null;
+		backupMessage = null;
+		backupWarnings = [];
+
+		try {
+			const backup = JSON.parse(await selectedBackupFile.text());
+			const response = await fetch('/api/settings/system/backup', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					passphrase: backupImportPassphrase.trim(),
+					sections: selectedRestoreSections,
+					mode: 'apply',
+					backup
+				})
+			});
+			const payload = await readResponsePayload<Record<string, unknown>>(response);
+
+			if (!response.ok) {
+				throw new Error(getResponseErrorMessage(payload, 'Failed to restore configuration backup'));
+			}
+
+			const result =
+				payload && typeof payload === 'object' && !Array.isArray(payload)
+					? payload.result
+					: undefined;
+			const resultRecord =
+				result && typeof result === 'object' && !Array.isArray(result)
+					? (result as Record<string, unknown>)
+					: null;
+			const warningCandidates = resultRecord?.warnings;
+			backupWarnings = Array.isArray(warningCandidates)
+				? warningCandidates.filter(
+						(warning: unknown): warning is string => typeof warning === 'string'
+					)
+				: [];
+			backupMessage =
+				backupWarnings.length > 0
+					? 'Configuration restored with warnings.'
+					: 'Configuration restored successfully.';
+			selectedBackupFile = null;
+			backupPreview = null;
+			selectedRestoreSections = [];
+			await invalidateAll();
+		} catch (error) {
+			backupError =
+				error instanceof Error ? error.message : 'Failed to restore configuration backup';
+		} finally {
+			backupImporting = false;
+		}
+	}
+
+	function promptRestoreConfiguration() {
+		if (!selectedBackupFile) {
+			backupError = 'Select a backup file first.';
+			return;
+		}
+
+		if (selectedRestoreSections.length === 0) {
+			backupError = 'Select at least one backup section to restore.';
+			return;
+		}
+
+		if (!backupImportPassphrase.trim()) {
+			backupError = 'Backup passphrase is required for restore.';
+			return;
+		}
+
+		backupError = null;
+		confirmRestoreOpen = true;
 	}
 
 	// =====================
@@ -514,33 +962,42 @@
 
 <SettingsPage title={m.settings_system_heading()} subtitle={m.settings_system_subtitle()}>
 	<!-- Tab navigation -->
-	<div role="tablist" class="tabs-boxed tabs">
+	<div role="tablist" class="tabs-boxed tabs flex flex-wrap gap-2">
 		<button
 			role="tab"
-			class="tab gap-2"
+			class="tab h-auto min-h-0 flex-1 items-center justify-center gap-2 px-3 py-2 sm:flex-none sm:justify-start"
 			class:tab-active={activeTab === 'general'}
 			onclick={() => setTab('general')}
 		>
-			<Server class="h-4 w-4" />
+			<Server class="h-4 w-4 shrink-0" />
 			{m.nav_general()}
 		</button>
 		<button
 			role="tab"
-			class="tab gap-2"
+			class="tab h-auto min-h-0 flex-1 items-center justify-center gap-2 px-3 py-2 sm:flex-none sm:justify-start"
 			class:tab-active={activeTab === 'tmdb'}
 			onclick={() => setTab('tmdb')}
 		>
-			<Film class="h-4 w-4" />
+			<Film class="h-4 w-4 shrink-0" />
 			TMDB
 		</button>
 		<button
 			role="tab"
-			class="tab gap-2"
+			class="tab h-auto min-h-0 flex-1 items-center justify-center gap-2 px-3 py-2 sm:flex-none sm:justify-start"
 			class:tab-active={activeTab === 'captcha'}
 			onclick={() => setTab('captcha')}
 		>
 			<Shield class="h-4 w-4" />
 			{m.nav_captchaSolver()}
+		</button>
+		<button
+			role="tab"
+			class="tab h-auto min-h-0 flex-1 gap-2 px-3 py-2 sm:flex-none"
+			class:tab-active={activeTab === 'backup'}
+			onclick={() => setTab('backup')}
+		>
+			<Download class="h-4 w-4" />
+			Backup & Restore
 		</button>
 	</div>
 
@@ -575,7 +1032,7 @@
 
 			<!-- Main API Key -->
 			<div class="rounded-lg bg-base-100 p-4">
-				<div class="flex items-center justify-between">
+				<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 					<div class="flex items-center gap-2">
 						<Key class="h-5 w-5" />
 						<h3 class="text-base font-semibold">{m.settings_system_mainApiKey()}</h3>
@@ -621,7 +1078,9 @@
 					</div>
 				</div>
 
-				<div class="mt-3 flex items-center justify-between text-sm text-base-content/70">
+				<div
+					class="mt-3 flex flex-col gap-3 text-sm text-base-content/70 sm:flex-row sm:items-center sm:justify-between"
+				>
 					<span
 						>{m.settings_system_created()}: {data.mainApiKey?.createdAt
 							? new Date(data.mainApiKey.createdAt).toLocaleDateString()
@@ -645,7 +1104,7 @@
 
 			<!-- Media Streaming API Key -->
 			<div class="rounded-lg bg-base-100 p-4">
-				<div class="flex items-center justify-between">
+				<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 					<div class="flex items-center gap-2">
 						<Server class="h-5 w-5" />
 						<h3 class="text-base font-semibold">{m.settings_system_mediaStreamingApiKey()}</h3>
@@ -710,7 +1169,9 @@
 					</ul>
 				</div>
 
-				<div class="mt-3 flex items-center justify-between text-sm text-base-content/70">
+				<div
+					class="mt-3 flex flex-col gap-3 text-sm text-base-content/70 sm:flex-row sm:items-center sm:justify-between"
+				>
 					<span
 						>{m.settings_system_created()}: {data.streamingApiKey?.createdAt
 							? new Date(data.streamingApiKey.createdAt).toLocaleDateString()
@@ -779,7 +1240,7 @@
 
 				<div class="mt-4 flex justify-end">
 					<button
-						class="btn gap-2 btn-sm btn-primary"
+						class="btn w-full gap-2 btn-sm btn-primary sm:w-auto"
 						onclick={saveExternalUrl}
 						disabled={isSavingUrl}
 					>
@@ -833,6 +1294,228 @@
 							themoviedb.org
 						</a>.
 					</p>
+				</div>
+			</div>
+		</SettingsSection>
+	{/if}
+
+	{#if activeTab === 'backup'}
+		<SettingsSection
+			title="Backup & Restore"
+			description="Export your Cinephage configuration for disaster recovery and restore it later with the same passphrase."
+		>
+			<div class="alert overflow-hidden alert-info">
+				<AlertCircle class="h-5 w-5" />
+				<div class="min-w-0">
+					<p class="font-medium">Configuration backup only</p>
+					<p class="text-sm wrap-break-word">
+						Backups include user-managed settings and encrypted user-supplied credentials. Runtime
+						caches, queues, task history, and generated system API keys are excluded. Indexer
+						session cookies can be included explicitly as an advanced option.
+					</p>
+				</div>
+			</div>
+
+			{#if backupError}
+				<div class="alert alert-error">
+					<AlertCircle class="h-4 w-4" />
+					<span>{backupError}</span>
+				</div>
+			{/if}
+
+			{#if backupWarnings.length > 0}
+				<div class="alert alert-warning">
+					<AlertCircle class="h-4 w-4" />
+					<div class="space-y-1">
+						<div class="font-medium">Restore warnings</div>
+						<ul class="list-inside list-disc text-sm">
+							{#each backupWarnings as warning (warning)}
+								<li>{warning}</li>
+							{/each}
+						</ul>
+					</div>
+				</div>
+			{/if}
+
+			{#if backupMessage}
+				<div class="alert alert-success">
+					<CheckCircle class="h-4 w-4" />
+					<span>{backupMessage}</span>
+				</div>
+			{/if}
+
+			<div class="grid gap-4 lg:grid-cols-2">
+				<div class="min-w-0 overflow-hidden rounded-lg bg-base-100 p-4">
+					<div class="mb-3 flex items-center gap-2">
+						<Download class="h-5 w-5" />
+						<h3 class="text-base font-semibold">Export configuration</h3>
+					</div>
+
+					<p class="mb-4 text-sm wrap-break-word text-base-content/70">
+						Exports configuration for settings, integrations, indexers, download clients, profiles,
+						and other user-managed setup required to rebuild the instance.
+					</p>
+
+					<label
+						class="label flex-wrap items-start gap-2 whitespace-normal"
+						for="backup-export-passphrase"
+					>
+						<span class="label-text">Encryption passphrase</span>
+					</label>
+					<input
+						id="backup-export-passphrase"
+						type="password"
+						class="input-bordered input w-full"
+						placeholder="At least 16 characters to encrypt exported secrets"
+						bind:value={backupExportPassphrase}
+					/>
+
+					<label class="label mt-4 cursor-pointer justify-start gap-3 whitespace-normal">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={backupIncludeIndexerCookies}
+						/>
+						<div class="min-w-0">
+							<span class="label-text font-medium">Include indexer session cookies</span>
+							<p class="text-sm wrap-break-word text-base-content/70">
+								Back up active 2FA/session cookies for indexers that rely on them. These are
+								encrypted, short-lived, and more sensitive than saved credentials.
+							</p>
+						</div>
+					</label>
+
+					<div class="mt-4 flex justify-end">
+						<button
+							class="btn w-full gap-2 btn-primary sm:w-auto"
+							onclick={exportConfigurationBackup}
+							disabled={backupExporting || backupExportPassphrase.trim().length < 16}
+						>
+							{#if backupExporting}
+								<RefreshCw class="h-4 w-4 animate-spin" />
+								Exporting...
+							{:else}
+								<Download class="h-4 w-4" />
+								Export backup
+							{/if}
+						</button>
+					</div>
+				</div>
+
+				<div class="min-w-0 overflow-hidden rounded-lg bg-base-100 p-4">
+					<div class="mb-3 flex items-center gap-2">
+						<Upload class="h-5 w-5" />
+						<h3 class="text-base font-semibold">Restore configuration</h3>
+					</div>
+
+					<p class="mb-4 text-sm wrap-break-word text-base-content/70">
+						Restoring applies the saved configuration from the backup file to this instance. Use the
+						same passphrase that was used during export.
+					</p>
+
+					<label
+						class="label flex-wrap items-start gap-2 whitespace-normal"
+						for="backup-restore-file"
+					>
+						<span class="label-text">Backup file</span>
+					</label>
+					<input
+						id="backup-restore-file"
+						type="file"
+						class="file-input-bordered file-input w-full max-w-full min-w-0"
+						accept="application/json,.json"
+						onchange={handleBackupFileChange}
+					/>
+
+					{#if backupPreview}
+						<div class="mt-4 min-w-0 overflow-hidden rounded-lg border border-base-300 p-4">
+							<div
+								class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+							>
+								<div class="min-w-0">
+									<div class="font-medium">Backup preview</div>
+									<div class="text-sm wrap-break-word text-base-content/70">
+										Version {backupPreview.version}
+										{#if backupPreview.createdAt}
+											• {new Date(backupPreview.createdAt).toLocaleString()}
+										{/if}
+									</div>
+								</div>
+								<div class="text-right text-sm text-base-content/70">
+									<div>{pluralize(backupPreview.totalSections, 'section')}</div>
+								</div>
+							</div>
+
+							<div class="space-y-2">
+								<div class="text-sm font-medium">Restore sections</div>
+								{#each backupPreview.sections.filter((section) => section.totalRows > 0) as section (section.id)}
+									<label
+										class="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 p-3"
+									>
+										<input
+											type="checkbox"
+											class="checkbox mt-0.5 checkbox-sm"
+											checked={selectedRestoreSections.includes(section.id)}
+											onchange={(event) =>
+												toggleRestoreSection(
+													section.id,
+													(event.currentTarget as HTMLInputElement).checked
+												)}
+										/>
+										<div class="min-w-0">
+											<div class="font-medium">{section.label}</div>
+											<div class="text-sm text-base-content/70">
+												{section.summary}
+											</div>
+										</div>
+									</label>
+								{/each}
+							</div>
+
+							{#if backupPreview.includeIndexerCookies}
+								<div class="mt-4 alert overflow-hidden alert-warning">
+									<AlertCircle class="h-4 w-4" />
+									<span class="wrap-break-word">
+										This backup includes encrypted indexer session cookies. Restoring it will try to
+										reuse active indexer sessions where they are still valid.
+									</span>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<label
+						class="label mt-3 flex-wrap items-start gap-2 whitespace-normal"
+						for="backup-import-passphrase"
+					>
+						<span class="label-text">Backup passphrase</span>
+					</label>
+					<input
+						id="backup-import-passphrase"
+						type="password"
+						class="input-bordered input w-full"
+						placeholder="Required to decrypt exported secrets"
+						bind:value={backupImportPassphrase}
+					/>
+
+					<div class="mt-4 flex justify-end">
+						<button
+							class="btn w-full gap-2 btn-warning sm:w-auto"
+							onclick={promptRestoreConfiguration}
+							disabled={backupImporting ||
+								!selectedBackupFile ||
+								selectedRestoreSections.length === 0 ||
+								!backupImportPassphrase.trim()}
+						>
+							{#if backupImporting}
+								<RefreshCw class="h-4 w-4 animate-spin" />
+								Restoring...
+							{:else}
+								<Upload class="h-4 w-4" />
+								Restore backup
+							{/if}
+						</button>
+					</div>
 				</div>
 			</div>
 		</SettingsSection>
@@ -956,14 +1639,14 @@
 
 					<div class="grid gap-4 sm:grid-cols-2">
 						<!-- Timeout -->
-						<div class="form-control w-full">
-							<label class="label" for="timeout">
+						<div class="form-control w-full min-w-0">
+							<label class="label flex-wrap items-start gap-2 whitespace-normal" for="timeout">
 								<span class="label-text">{m.settings_integrations_captcha_solveTimeout()}</span>
 							</label>
 							<select
 								id="timeout"
 								bind:value={captchaSettings.timeoutSeconds}
-								class="select-bordered select select-sm"
+								class="select-bordered select w-full max-w-full min-w-0 select-sm"
 								disabled={!captchaSettings.enabled}
 							>
 								<option value={30}>{m.settings_integrations_captcha_seconds30()}</option>
@@ -972,22 +1655,22 @@
 								<option value={120}>{m.settings_integrations_captcha_minutes2()}</option>
 								<option value={180}>{m.settings_integrations_captcha_minutes3()}</option>
 							</select>
-							<div class="label">
-								<span class="label-text-alt text-base-content/50">
+							<div class="label whitespace-normal">
+								<span class="label-text-alt wrap-break-word text-base-content/50">
 									{m.settings_integrations_captcha_solveTimeoutHelp()}
 								</span>
 							</div>
 						</div>
 
 						<!-- Cache TTL -->
-						<div class="form-control w-full">
-							<label class="label" for="cacheTtl">
+						<div class="form-control w-full min-w-0">
+							<label class="label flex-wrap items-start gap-2 whitespace-normal" for="cacheTtl">
 								<span class="label-text">{m.settings_integrations_captcha_cacheDuration()}</span>
 							</label>
 							<select
 								id="cacheTtl"
 								bind:value={captchaSettings.cacheTtlSeconds}
-								class="select-bordered select select-sm"
+								class="select-bordered select w-full max-w-full min-w-0 select-sm"
 								disabled={!captchaSettings.enabled}
 							>
 								<option value={1800}>{m.settings_integrations_captcha_minutes30()}</option>
@@ -997,8 +1680,8 @@
 								<option value={28800}>{m.settings_integrations_captcha_hours8()}</option>
 								<option value={86400}>{m.settings_integrations_captcha_hours24()}</option>
 							</select>
-							<div class="label">
-								<span class="label-text-alt text-base-content/50">
+							<div class="label whitespace-normal">
+								<span class="label-text-alt wrap-break-word text-base-content/50">
 									{m.settings_integrations_captcha_cacheDurationHelp()}
 								</span>
 							</div>
@@ -1011,8 +1694,8 @@
 					</div>
 
 					<!-- Proxy URL -->
-					<div class="form-control w-full">
-						<label class="label" for="proxyUrl">
+					<div class="form-control w-full min-w-0">
+						<label class="label flex-wrap items-start gap-2 whitespace-normal" for="proxyUrl">
 							<span class="label-text">{m.settings_integrations_captcha_proxyUrl()}</span>
 						</label>
 						<input
@@ -1020,11 +1703,11 @@
 							type="text"
 							bind:value={captchaSettings.proxyUrl}
 							placeholder="http://proxy.example.com:8080"
-							class="input-bordered input input-sm"
+							class="input-bordered input input-sm w-full min-w-0"
 							disabled={!captchaSettings.enabled}
 						/>
-						<div class="label">
-							<span class="label-text-alt text-base-content/50">
+						<div class="label whitespace-normal">
+							<span class="label-text-alt wrap-break-word text-base-content/50">
 								{m.settings_integrations_captcha_proxyUrlHelp()}
 							</span>
 						</div>
@@ -1033,8 +1716,11 @@
 					<!-- Proxy Auth -->
 					{#if captchaSettings.proxyUrl}
 						<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-							<div class="form-control">
-								<label class="label" for="proxyUsername">
+							<div class="form-control min-w-0">
+								<label
+									class="label flex-wrap items-start gap-2 whitespace-normal"
+									for="proxyUsername"
+								>
 									<span class="label-text">{m.settings_integrations_captcha_proxyUsername()}</span>
 								</label>
 								<input
@@ -1042,12 +1728,15 @@
 									type="text"
 									bind:value={captchaSettings.proxyUsername}
 									placeholder={m.settings_integrations_captcha_optional()}
-									class="input-bordered input input-sm"
+									class="input-bordered input input-sm w-full min-w-0"
 									disabled={!captchaSettings.enabled}
 								/>
 							</div>
-							<div class="form-control">
-								<label class="label" for="proxyPassword">
+							<div class="form-control min-w-0">
+								<label
+									class="label flex-wrap items-start gap-2 whitespace-normal"
+									for="proxyPassword"
+								>
 									<span class="label-text">{m.settings_integrations_captcha_proxyPassword()}</span>
 								</label>
 								<input
@@ -1055,7 +1744,7 @@
 									type="password"
 									bind:value={captchaSettings.proxyPassword}
 									placeholder={m.settings_integrations_captcha_optional()}
-									class="input-bordered input input-sm"
+									class="input-bordered input input-sm w-full min-w-0"
 									disabled={!captchaSettings.enabled}
 								/>
 							</div>
@@ -1065,7 +1754,7 @@
 
 				<div class="flex justify-end">
 					<button
-						class="btn gap-2 btn-sm btn-primary"
+						class="btn w-full gap-2 btn-sm btn-primary sm:w-auto"
 						onclick={saveCaptchaSettings}
 						disabled={captchaSaving}
 					>
@@ -1090,11 +1779,11 @@
 						type="url"
 						bind:value={testUrl}
 						placeholder="https://example.com"
-						class="input-bordered input input-sm w-full sm:flex-1"
+						class="input-bordered input input-sm w-full min-w-0 sm:flex-1"
 						disabled={captchaTesting || !captchaSettings.enabled}
 					/>
 					<button
-						class="btn gap-2 btn-sm btn-primary"
+						class="btn w-full gap-2 btn-sm btn-primary sm:w-auto"
 						onclick={testSolver}
 						disabled={captchaTesting || !testUrl || !captchaSettings.enabled}
 					>
@@ -1221,6 +1910,17 @@
 	loading={regeneratingMain || regeneratingStreaming}
 	onConfirm={() => regenerateKey(regenerateTarget)}
 	onCancel={() => (confirmRegenerateOpen = false)}
+/>
+
+<ConfirmationModal
+	open={confirmRestoreOpen}
+	title="Restore configuration backup?"
+	message={`This will apply ${selectedRestoreSections.length} selected backup section(s) to the current instance. This action cannot be undone.`}
+	confirmLabel="Restore backup"
+	confirmVariant="warning"
+	loading={backupImporting}
+	onConfirm={importConfigurationBackup}
+	onCancel={() => (confirmRestoreOpen = false)}
 />
 
 <!-- TMDB API Key Modal -->


### PR DESCRIPTION
## Summary

Adds a complete configuration backup and restore system that allows admins to export their Cinephage instance settings for disaster recovery and selectively restore them later. Secrets (API keys, passwords, tokens, cookies) are extracted from the exported data and encrypted separately using AES-256-GCM with a user-provided passphrase. The restore process supports selective section-level granularity and preserves existing credentials to prevent accidental data loss.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- **New crypto module** (`backupCrypto.ts`): AES-256-GCM encryption/decryption with scrypt key derivation (16-byte salt, 16-byte IV) for securing backup secret payloads
- **ConfigurationBackupService**: Orchestrates export and restore across 29 database tables grouped into 7 logical sections (system, profiles, downloads, indexers, subtitles, integrations, liveTv); separates secrets from non-secret config data and encrypts them independently
- **Backup/Restore API** (`/api/settings/system/backup`): Admin-only `POST` (export) and `PUT` (restore) endpoints with Zod-validated request bodies
- **Settings UI**: New "Backup & Restore" tab with two-column layout (export left, restore right), section-level checkboxes with row-count summaries, backup preview parsing, confirmation modal, and error/warning/success alert banners
- **Validation schemas**: `backupExportSchema`, `encryptedBackupPayloadSchema`, `configurationBackupManifestSchema`, `configurationBackupFileSchema`, and `backupImportSchema` added to `schemas.ts`
- **Unit tests**: `backupCrypto.test.ts` covering payload round-trips and wrong-passphrase failure
- **Responsive layout improvements**: Flex-wrap tabs, full-width buttons on mobile, and label wrapping on the General and System settings pages

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`): previously failing test CI still failing on GA, but passes locally.
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

<img width="2230" height="999" alt="image" src="https://github.com/user-attachments/assets/6f722c57-6efb-44d6-aa0f-618ad0d82323" /><br>

<img width="2177" height="1262" alt="image" src="https://github.com/user-attachments/assets/2c346ab3-cfea-4e9f-8f3a-6df130658c9d" />
