### PR TITLE
fix: Fix Transmission seed ratio and time settings not set correctly

### DIFF
--- a/src/lib/server/downloadClients/transmission/TransmissionClient.ts
+++ b/src/lib/server/downloadClients/transmission/TransmissionClient.ts
@@ -64,6 +64,24 @@ interface TransmissionTorrentAddResponse {
 type TransmissionTorrentStatus = DownloadInfo['status'];
 type TransmissionId = number | string;
 
+enum TransmissionRatioMode {
+	/* follow the global settings */
+	GLOBAL = 0,
+	/* override the global settings, seeding until a certain ratio */
+	SINGLE = 1,
+	/* override the global settings, seeding regardless of ratio */
+	UNLIMITED = 2
+}
+
+enum TransmissionIdleMode {
+	/* follow the global settings */
+	GLOBAL = 0,
+	/* override the global settings, seeding until a idle time */
+	SINGLE = 1,
+	/* override the global settings, seeding regardless of activity */
+	UNLIMITED = 2
+}
+
 const TORRENT_FIELDS = [
 	'id',
 	'name',
@@ -348,24 +366,6 @@ export class TransmissionClient implements IDownloadClient {
 			args.bandwidthPriority = 1;
 		}
 
-		if (typeof options.seedRatioLimit === 'number') {
-			if (options.seedRatioLimit < 0) {
-				args.seedRatioMode = 2;
-			} else {
-				args.seedRatioMode = 1;
-				args.seedRatioLimit = options.seedRatioLimit;
-			}
-		}
-
-		if (typeof options.seedTimeLimit === 'number') {
-			if (options.seedTimeLimit < 0) {
-				args.seedIdleMode = 2;
-			} else {
-				args.seedIdleMode = 1;
-				args.seedIdleLimit = Math.max(0, Math.round(options.seedTimeLimit));
-			}
-		}
-
 		if (selectedFileIndices.length > 0) {
 			args['files-wanted'] = selectedFileIndices;
 			const keepSet = new Set(selectedFileIndices);
@@ -395,7 +395,13 @@ export class TransmissionClient implements IDownloadClient {
 			throw new Error('Transmission did not return torrent add result');
 		}
 
-		return added.hashString || String(added.id);
+		const torrentId = added.hashString || String(added.id);
+		await this.setSeedingConfig(torrentId, {
+			ratioLimit: options.seedRatioLimit,
+			seedingTimeLimit: options.seedTimeLimit
+		});
+
+		return torrentId;
 	}
 
 	async getDownloads(category?: string): Promise<DownloadInfo[]> {
@@ -490,18 +496,18 @@ export class TransmissionClient implements IDownloadClient {
 
 		if (typeof config.ratioLimit === 'number') {
 			if (config.ratioLimit < 0) {
-				args.seedRatioMode = 2;
+				args.seedRatioMode = TransmissionRatioMode.UNLIMITED;
 			} else {
-				args.seedRatioMode = 1;
+				args.seedRatioMode = TransmissionRatioMode.SINGLE;
 				args.seedRatioLimit = config.ratioLimit;
 			}
 		}
 
 		if (typeof config.seedingTimeLimit === 'number') {
 			if (config.seedingTimeLimit < 0) {
-				args.seedIdleMode = 2;
+				args.seedIdleMode = TransmissionIdleMode.UNLIMITED;
 			} else {
-				args.seedIdleMode = 1;
+				args.seedIdleMode = TransmissionIdleMode.SINGLE;
 				args.seedIdleLimit = Math.max(0, Math.round(config.seedingTimeLimit));
 			}
 		}


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
According to the Transmission RPC documentation: https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#34-adding-a-torrent
Seed idle time and ration can not be provided to a torrent upon creation, but it can be updated after it has been added.
So let's do that.
No LLM was used fixing this bug.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Removed passing unused parameters upon torrent creation
- When seed ratio, or seed idle time needs to be set, update the created torrent with these info after it's creation
- Added Transmission enums, so no magic numbers needs to be used (from: https://github.com/transmission/transmission/blob/7dc14d2fd4ed5d26f06bd7ed0dfd57aba7428926/libtransmission/types.h#L163)

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [ ] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
