### PR TITLE
fix: Transmission download client ignores seed targets

### DIFF
--- a/src/lib/server/downloadClients/transmission/TransmissionClient.ts
+++ b/src/lib/server/downloadClients/transmission/TransmissionClient.ts
@@ -22,6 +22,8 @@ interface TransmissionSessionInfo {
 	version?: string;
 	'rpc-version'?: number;
 	'download-dir'?: string;
+	'idle-seeding-limit-enabled': boolean;
+	'idle-seeding-limit': number;
 }
 
 interface TransmissionTorrent {
@@ -30,6 +32,7 @@ interface TransmissionTorrent {
 	hashString: string;
 	percentDone: number;
 	status: number;
+	isFinished: boolean;
 	totalSize: number;
 	rateDownload: number;
 	rateUpload: number;
@@ -42,6 +45,7 @@ interface TransmissionTorrent {
 	uploadRatio?: number;
 	seedRatioLimit?: number;
 	seedIdleLimit?: number;
+	seedIdleMode?: TransmissionIdleMode;
 	error?: number;
 	errorString?: string;
 }
@@ -88,6 +92,7 @@ const TORRENT_FIELDS = [
 	'hashString',
 	'percentDone',
 	'status',
+	'isFinished',
 	'totalSize',
 	'rateDownload',
 	'rateUpload',
@@ -100,8 +105,17 @@ const TORRENT_FIELDS = [
 	'uploadRatio',
 	'seedRatioLimit',
 	'seedIdleLimit',
+	'seedIdleMode',
 	'error',
 	'errorString'
+];
+
+const SESSION_FIELDS = [
+	'version',
+	'rpc-version',
+	'download-dir',
+	'idle-seeding-limit-enabled',
+	'idle-seeding-limit'
 ];
 
 function mapTransmissionStatus(
@@ -146,8 +160,30 @@ export class TransmissionClient implements IDownloadClient {
 	private config: DownloadClientConfig;
 	private sessionId: string | null = null;
 
+	// Cache for session info (refresh every 5 minutes)
+	private sessionInfoCache: { prefs: TransmissionSessionInfo; expiry: number } | null = null;
+	private readonly SESSION_INFO_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
 	constructor(config: DownloadClientConfig) {
 		this.config = config;
+	}
+
+	/**
+	 * Get session info with caching
+	 */
+	private async getSessionInfo(forceUpdate: boolean = false): Promise<TransmissionSessionInfo> {
+		if (!forceUpdate && this.sessionInfoCache && Date.now() < this.sessionInfoCache.expiry) {
+			return this.sessionInfoCache.prefs;
+		}
+
+		const prefs = await this.rpcRequest<TransmissionSessionInfo>('session-get', {
+			fields: SESSION_FIELDS
+		});
+		this.sessionInfoCache = {
+			prefs,
+			expiry: Date.now() + this.SESSION_INFO_CACHE_TTL
+		};
+		return prefs;
 	}
 
 	private get rpcUrl(): string {
@@ -193,7 +229,10 @@ export class TransmissionClient implements IDownloadClient {
 		return `${normalized}/${name}`;
 	}
 
-	private mapTorrent(torrent: TransmissionTorrent): DownloadInfo {
+	private mapTorrent(
+		torrent: TransmissionTorrent,
+		sessionInfo: TransmissionSessionInfo
+	): DownloadInfo {
 		const progress = normalizeProgress(torrent.percentDone);
 		const status = mapTransmissionStatus(torrent.status, progress, torrent.error);
 		const category = torrent.labels?.[0];
@@ -223,9 +262,51 @@ export class TransmissionClient implements IDownloadClient {
 			ratioLimit: torrent.seedRatioLimit,
 			seedingTimeLimit: torrent.seedIdleLimit,
 			canMoveFiles: status !== 'downloading' && status !== 'seeding' && status !== 'queued',
-			canBeRemoved: status !== 'downloading',
+			canBeRemoved: this.hasReachedSeedLimit(torrent, status, sessionInfo),
 			errorMessage
 		};
+	}
+
+	private hasReachedSeedLimit(
+		torrent: TransmissionTorrent,
+		status:
+			| 'downloading'
+			| 'stalled'
+			| 'seeding'
+			| 'paused'
+			| 'completed'
+			| 'postprocessing'
+			| 'error'
+			| 'queued',
+		sessionInfo: TransmissionSessionInfo
+	): boolean {
+		// isFinished is true if seeding ratio or seeding idle time is reached
+		if (torrent.isFinished) {
+			return true;
+		}
+
+		// Transmission only supports **idle** seeding time, so we abuse that as a simple seed limit time,
+		if (
+			torrent.seedIdleMode !== TransmissionIdleMode.UNLIMITED &&
+			(status === 'completed' || status === 'seeding') &&
+			torrent.seedIdleLimit !== undefined &&
+			torrent.secondsSeeding !== undefined
+		) {
+			let seedIdleLimit = torrent.seedIdleLimit; // seedIdleLimit is in minutes
+			if (torrent.seedIdleMode === TransmissionIdleMode.GLOBAL) {
+				if (!sessionInfo['idle-seeding-limit-enabled']) {
+					return false;
+				}
+
+				seedIdleLimit = sessionInfo['idle-seeding-limit'];
+			}
+
+			if (torrent.secondsSeeding >= seedIdleLimit * 60) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private async rpcRequest<T>(method: string, args: Record<string, unknown> = {}): Promise<T> {
@@ -291,7 +372,7 @@ export class TransmissionClient implements IDownloadClient {
 	async test(): Promise<ConnectionTestResult> {
 		try {
 			const [session, torrents] = await Promise.all([
-				this.rpcRequest<TransmissionSessionInfo>('session-get'),
+				this.getSessionInfo(true),
 				this.rpcRequest<{ torrents: Array<{ labels?: string[] }> }>('torrent-get', {
 					fields: ['labels'],
 					ids: 'recently-active'
@@ -405,11 +486,16 @@ export class TransmissionClient implements IDownloadClient {
 	}
 
 	async getDownloads(category?: string): Promise<DownloadInfo[]> {
-		const response = await this.rpcRequest<TransmissionTorrentGetResponse>('torrent-get', {
-			fields: TORRENT_FIELDS
-		});
+		const [response, sessionInfo] = await Promise.all([
+			this.rpcRequest<TransmissionTorrentGetResponse>('torrent-get', {
+				fields: TORRENT_FIELDS
+			}),
+			this.getSessionInfo()
+		]);
 
-		let downloads = (response.torrents || []).map((torrent) => this.mapTorrent(torrent));
+		let downloads = (response.torrents || []).map((torrent) =>
+			this.mapTorrent(torrent, sessionInfo)
+		);
 		if (category?.trim()) {
 			const needle = category.trim().toLowerCase();
 			downloads = downloads.filter((download) => download.category?.toLowerCase() === needle);
@@ -419,13 +505,16 @@ export class TransmissionClient implements IDownloadClient {
 	}
 
 	async getDownload(id: string): Promise<DownloadInfo | null> {
-		const response = await this.rpcRequest<TransmissionTorrentGetResponse>('torrent-get', {
-			fields: TORRENT_FIELDS,
-			ids: [this.toTransmissionId(id)]
-		});
+		const [response, sessionInfo] = await Promise.all([
+			this.rpcRequest<TransmissionTorrentGetResponse>('torrent-get', {
+				fields: TORRENT_FIELDS,
+				ids: [this.toTransmissionId(id)]
+			}),
+			this.getSessionInfo()
+		]);
 
 		const torrent = response.torrents?.[0];
-		return torrent ? this.mapTorrent(torrent) : null;
+		return torrent ? this.mapTorrent(torrent, sessionInfo) : null;
 	}
 
 	async removeDownload(id: string, deleteFiles: boolean = false): Promise<void> {


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Currently the Transmission download clients Hit'n'runs. (It means, the torrent is deleted after it has been imported, so seeding targets can not be reached, by normals means).
This PR does allow the Transmission client to reach it's target seed ratio/time before Cinephage removes it from the torrent client.
No LLM was used creating these changes.
Sorry, this PR got a little bit bigger then I wanted, probably the session info part could be split into its own dedicated PR.
I can split it if you want to.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Adds a cached session info store (inspired by code from the QBittorrent's prefs cache)
- Replaces the current session info usage to use the new session info store
- Limits the response scope of the session info store, as most of the [default values](https://github.com/transmission/transmission/blob/4.0.6/docs/rpc-spec.md#41-session-arguments) are not used
- Extends the torrent responses info needed for determining the seed target
- Allows deleting the torrent when seeding target is reached, instead of just checking if the torrent has been downloaded.

More on the seeding target reached logic:
Transmission has an `isFinished` flag for torrents, as Transmission itself calculates if the seeding target has been reached.
But! Transmission seed time is **idle** seed time, which means, time spent in seeding state **without** activity.
So we could use the `isFinished` flag to delegate the seed ratio calculations (and idle seed time calculations) to Transmission, and add a custom calculation for non-idle seed time.
I consulted Radarr's [source code](https://github.com/Radarr/Radarr/blob/92268767921bddd1625c6acb80b704464b5feb0a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs#L145) and they do the same thing about this problem.
There is an upstream issue about this change, but it does not seems it will be resolved in the near future: https://github.com/transmission/transmission/issues/111

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [ ] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
