### PR TITLE
fix: Replace GO style date parser with a working one

### DIFF
--- a/data/indexers/definitions/bitsearch.yaml
+++ b/data/indexers/definitions/bitsearch.yaml
@@ -79,7 +79,7 @@ search:
       optional: true
       filters:
         - name: dateparse
-          args: 'M/d/yyyy'
+          args: 'M/D/YYYY'
     date_ago:
       selector: div.space-y-2 > span:nth-child(3):contains("ago"), span.space-x-1:nth-child(3):contains("ago")
       optional: true

--- a/data/indexers/definitions/kinozal-magnet.yaml
+++ b/data/indexers/definitions/kinozal-magnet.yaml
@@ -286,7 +286,7 @@ search:
         - name: replace
           args: [' в', '']
         - name: dateparse
-          args: 'dd.MM.yyyy HH:mm'
+          args: 'DD.MM.YYYY HH:mm'
     date:
       text: '{{ if or .Result.date_day .Result.date_year }}{{ or .Result.date_day .Result.date_year }}{{ else }}now{{ end }}'
     downloadvolumefactor:

--- a/data/indexers/definitions/kinozal.yaml
+++ b/data/indexers/definitions/kinozal.yaml
@@ -279,7 +279,7 @@ search:
         - name: replace
           args: [' в', '']
         - name: dateparse
-          args: 'dd.MM.yyyy HH:mm'
+          args: 'DD.MM.YYYY HH:mm'
     date:
       text: '{{ if or .Result.date_day .Result.date_year }}{{ or .Result.date_day .Result.date_year }}{{ else }}now{{ end }}'
     downloadvolumefactor:

--- a/data/indexers/definitions/milkie.yaml
+++ b/data/indexers/definitions/milkie.yaml
@@ -131,7 +131,7 @@ search:
       selector: createdAt
       filters:
         - name: dateparse
-          args: '2006-01-02T15:04:05.000000Z'
+          args: 'YYYY-MM-DDTHH:mm:ssZ'
     size:
       selector: size
     grabs:

--- a/data/indexers/definitions/ncore.yaml
+++ b/data/indexers/definitions/ncore.yaml
@@ -169,7 +169,7 @@ search:
         - name: append
           args: ' +01:00' # CET
         - name: dateparse
-          args: 'yyyy-MM-ddHH:mm:ss zzz'
+          args: 'YYYY-MM-DDHH:mm:ss Z'
     downloadvolumefactor:
       text: 0
     uploadvolumefactor:

--- a/data/indexers/definitions/newznab.yaml
+++ b/data/indexers/definitions/newznab.yaml
@@ -109,7 +109,7 @@ search:
       selector: pubDate
       filters:
         - name: dateparse
-          args: 'Mon, 02 Jan 2006 15:04:05 -0700'
+          args: 'ddd, DD MMM YYYY HH:mm:ss ZZ'
     size:
       selector: enclosure
       attribute: length

--- a/data/indexers/definitions/oldtoonsworld.yaml
+++ b/data/indexers/definitions/oldtoonsworld.yaml
@@ -148,7 +148,7 @@ search:
       selector: attributes.created_at
       filters:
         - name: dateparse
-          args: '2006-01-02T15:04:05.000000Z'
+          args: 'YYYY-MM-DDTHH:mm:ss.SSSZ'
     category:
       selector: attributes.category_id
     imdbid:

--- a/data/indexers/definitions/scenetime.yaml
+++ b/data/indexers/definitions/scenetime.yaml
@@ -206,7 +206,7 @@ search:
       optional: true
       filters:
         - name: dateparse
-          args: 'Monday, January 02, 2006 at 3:04pm'
+          args: 'dddd, MMMM DD, YYYY at H:mma'
     category:
       selector: td:nth-child(1) a[href*="cat="]
       attribute: href

--- a/data/indexers/definitions/torznab.yaml
+++ b/data/indexers/definitions/torznab.yaml
@@ -134,7 +134,7 @@ search:
       selector: pubDate
       filters:
         - name: dateparse
-          args: 'Mon, 02 Jan 2006 15:04:05 -0700'
+          args: 'ddd, DD MMM YYYY HH:mm:ss ZZ'
     size:
       selector: enclosure
       attribute: length

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@better-auth/api-key": "^1.6.5",
-				"@rollup/rollup-linux-x64-gnu": "4.60.2",
 				"adm-zip": "^0.5.16",
 				"better-sqlite3": "^12.9.0",
 				"camoufox-js": "^0.10.2",
 				"cheerio": "^1.2.0",
 				"chokidar": "^5.0.0",
 				"crypto-js": "^4.2.0",
+				"date-format-parse": "^0.2.7",
 				"dotenv": "^17.4.2",
 				"fast-xml-parser": "^5.7.1",
 				"fflate": "^0.8.2",
@@ -3208,6 +3208,12 @@
 			"engines": {
 				"node": ">= 12"
 			}
+		},
+		"node_modules/date-format-parse": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/date-format-parse/-/date-format-parse-0.2.7.tgz",
+			"integrity": "sha512-/+lyMUKoRogMuTeOVii6lUwjbVlesN9YRYLzZT/g3TEZ3uD9QnpjResujeEqUW+OSNbT7T1+SYdyEkTcRv+KDQ==",
+			"license": "MIT"
 		},
 		"node_modules/dateformat": {
 			"version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"cheerio": "^1.2.0",
 		"chokidar": "^5.0.0",
 		"crypto-js": "^4.2.0",
+		"date-format-parse": "^0.2.7",
 		"dotenv": "^17.4.2",
 		"fast-xml-parser": "^5.7.1",
 		"fflate": "^0.8.2",

--- a/src/lib/server/indexers/engine/FilterEngine.test.ts
+++ b/src/lib/server/indexers/engine/FilterEngine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createTemplateEngine } from './TemplateEngine';
-import { createFilterEngine } from './FilterEngine';
+import { createFilterEngine, parseDateWithLayout } from './FilterEngine';
 import type { FilterBlock } from '../schema/yamlDefinition';
 
 const RUTRACKER_STRIP_FILTERS: FilterBlock[] = [
@@ -48,5 +48,44 @@ describe('FilterEngine RuTracker strip pipeline', () => {
 
 		expect(output).toContain('Военная');
 		expect(output).toContain('War Machine');
+	});
+});
+
+const DATE_PARSER_TEST_CASES: { date: string; layout: string; expected: Date }[] = [
+	{
+		date: 'Friday, April 24, 2026 at 4:12am',
+		layout: 'dddd, MMMM DD, YYYY at H:mma',
+		expected: new Date(2026, 3, 24, 4, 12, 0, 0)
+	},
+	{ date: '2/3/2026', layout: 'M/D/YYYY', expected: new Date(2026, 1, 3, 0, 0, 0, 0) },
+	{
+		date: '2026-04-24T22:38:22+02:00',
+		layout: 'YYYY-MM-DDTHH:mm:ssZ',
+		expected: new Date(2026, 3, 24, 20, 38, 22, 0)
+	},
+	{
+		date: 'Fri, 24 Apr 2026 04:12:22 +0100',
+		layout: 'ddd, DD MMM YYYY HH:mm:ss ZZ',
+		expected: new Date(2026, 3, 24, 3, 12, 22, 0)
+	},
+	{
+		date: '14.11.2026 13:31',
+		layout: 'DD.MM.YYYY HH:mm',
+		expected: new Date(2026, 10, 14, 13, 31, 0, 0)
+	},
+	{
+		date: '2026-04-2422:38:22+02:00',
+		layout: 'YYYY-MM-DDHH:mm:ssZ',
+		expected: new Date(2026, 3, 24, 20, 38, 22, 0)
+	}
+];
+
+describe('FilterEngine Go-Style date layout parser', () => {
+	it('parses date layout correctly', () => {
+		for (const testCase of DATE_PARSER_TEST_CASES) {
+			const output = parseDateWithLayout(testCase.date, testCase.layout);
+
+			expect(output).toStrictEqual(testCase.expected);
+		}
 	});
 });

--- a/src/lib/server/indexers/engine/FilterEngine.ts
+++ b/src/lib/server/indexers/engine/FilterEngine.ts
@@ -8,6 +8,7 @@ import type { FilterBlock } from '../schema/yamlDefinition';
 import type { TemplateEngine } from './TemplateEngine';
 import { createSafeRegex, safeMatch, safeReplace } from './safeRegex';
 import { createChildLogger } from '$lib/logging';
+import { parse as dateParse } from 'date-format-parse';
 
 const logger = createChildLogger({ logDomain: 'indexers' as const });
 
@@ -18,24 +19,10 @@ export type FilterFunction = (
 ) => string;
 
 /**
- * Parse Go-style date layout to JavaScript Date.
- * Go reference: Mon Jan 2 15:04:05 MST 2006
- * - 2006 = year (YYYY)
- * - 01 = month (MM)
- * - 02 = day (DD)
- * - 15 = hour 24h (HH)
- * - 03 = hour 12h (hh)
- * - 04 = minute (mm)
- * - 05 = second (ss)
- * - Mon = weekday short
- * - Monday = weekday long
- * - Jan = month short
- * - January = month long
- * - PM/pm = AM/PM indicator
- * - MST = timezone
- * - -0700 = timezone offset
+ * Parse ISO token-based date layout to JavaScript Date.
+ * Available tokens: https://www.npmjs.com/package/date-format-parse#tokens
  */
-function parseGoDateLayout(dateStr: string, layout: string): Date | null {
+function parseDateWithLayout(dateStr: string, layout: string): Date | null {
 	if (!dateStr || !layout) return null;
 
 	// Handle special unix layouts
@@ -51,129 +38,13 @@ function parseGoDateLayout(dateStr: string, layout: string): Date | null {
 		return new Date(timestamp);
 	}
 
-	// Build regex from Go layout
-	let pattern = layout;
-	const captures: string[] = [];
-
-	// Order matters - longer patterns first
-	const replacements: [RegExp, string, string][] = [
-		[/2006/g, '(\\d{4})', 'year'],
-		[/06/g, '(\\d{2})', 'year2'],
-		[/January/g, '(\\w+)', 'monthLong'],
-		[/Jan/g, '(\\w+)', 'monthShort'],
-		[/01/g, '(\\d{2})', 'month'],
-		[/1/g, '(\\d{1,2})', 'month1'],
-		[/Monday/g, '(\\w+)', 'weekdayLong'],
-		[/Mon/g, '(\\w+)', 'weekdayShort'],
-		[/02/g, '(\\d{2})', 'day'],
-		[/2/g, '(\\d{1,2})', 'day1'],
-		[/_2/g, '(\\s?\\d{1,2})', 'day_'],
-		[/15/g, '(\\d{2})', 'hour24'],
-		[/03/g, '(\\d{2})', 'hour12'],
-		[/3/g, '(\\d{1,2})', 'hour12_1'],
-		[/04/g, '(\\d{2})', 'minute'],
-		[/4/g, '(\\d{1,2})', 'minute1'],
-		[/05/g, '(\\d{2})', 'second'],
-		[/5/g, '(\\d{1,2})', 'second1'],
-		[/PM/g, '(AM|PM)', 'ampm'],
-		[/pm/g, '(am|pm)', 'ampm_lower'],
-		[/MST/g, '([A-Z]{3,4})', 'timezone'],
-		[/-0700/g, '([+-]\\d{4})', 'tzoffset'],
-		[/-07:00/g, '([+-]\\d{2}:\\d{2})', 'tzoffset_colon'],
-		[/-07/g, '([+-]\\d{2})', 'tzoffset_short']
-	];
-
-	for (const [search, replace, name] of replacements) {
-		if (pattern.match(search)) {
-			captures.push(name);
-			pattern = pattern.replace(search, replace);
-		}
+	const parsedDate: Date = dateParse(dateStr, layout);
+	if (isNaN(parsedDate.getTime())) {
+		logger.error({ dateStr, layout }, `Parsing date failed`);
+		return null;
 	}
 
-	// Escape remaining regex special chars
-	pattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, (m) => (m === '(' || m === ')' ? m : '\\' + m));
-
-	// Use safe regex creation and matching to prevent ReDoS
-	const regex = createSafeRegex(`^${pattern}$`, 'i');
-	if (!regex) return null;
-
-	const match = safeMatch(dateStr, regex);
-	if (!match) return null;
-
-	const values: Record<string, string> = {};
-	captures.forEach((name, i) => {
-		values[name] = match[i + 1];
-	});
-
-	// Build date
-	let year = new Date().getFullYear();
-	let month = 0;
-	let day = 1;
-	let hour = 0;
-	let minute = 0;
-	let second = 0;
-
-	if (values.year) year = parseInt(values.year, 10);
-	if (values.year2) year = 2000 + parseInt(values.year2, 10);
-
-	if (values.month) month = parseInt(values.month, 10) - 1;
-	if (values.month1) month = parseInt(values.month1, 10) - 1;
-	if (values.monthShort) month = parseMonthName(values.monthShort);
-	if (values.monthLong) month = parseMonthName(values.monthLong);
-
-	if (values.day) day = parseInt(values.day, 10);
-	if (values.day1) day = parseInt(values.day1, 10);
-	if (values.day_) day = parseInt(values.day_.trim(), 10);
-
-	if (values.hour24) hour = parseInt(values.hour24, 10);
-	if (values.hour12) {
-		hour = parseInt(values.hour12, 10);
-		if ((values.ampm === 'PM' || values.ampm_lower === 'pm') && hour !== 12) hour += 12;
-		if ((values.ampm === 'AM' || values.ampm_lower === 'am') && hour === 12) hour = 0;
-	}
-	if (values.hour12_1) {
-		hour = parseInt(values.hour12_1, 10);
-		if ((values.ampm === 'PM' || values.ampm_lower === 'pm') && hour !== 12) hour += 12;
-		if ((values.ampm === 'AM' || values.ampm_lower === 'am') && hour === 12) hour = 0;
-	}
-
-	if (values.minute) minute = parseInt(values.minute, 10);
-	if (values.minute1) minute = parseInt(values.minute1, 10);
-
-	if (values.second) second = parseInt(values.second, 10);
-	if (values.second1) second = parseInt(values.second1, 10);
-
-	return new Date(year, month, day, hour, minute, second);
-}
-
-function parseMonthName(name: string): number {
-	const months: Record<string, number> = {
-		jan: 0,
-		january: 0,
-		feb: 1,
-		february: 1,
-		mar: 2,
-		march: 2,
-		apr: 3,
-		april: 3,
-		may: 4,
-		jun: 5,
-		june: 5,
-		jul: 6,
-		july: 6,
-		aug: 7,
-		august: 7,
-		sep: 8,
-		sept: 8,
-		september: 8,
-		oct: 9,
-		october: 9,
-		nov: 10,
-		november: 10,
-		dec: 11,
-		december: 11
-	};
-	return months[name.toLowerCase()] ?? 0;
+	return parsedDate;
 }
 
 /**
@@ -532,7 +403,7 @@ const FILTERS: Record<string, FilterFunction> = {
 	// Date/time
 	dateparse: (data, args) => {
 		const layout = String(args ?? '');
-		const date = parseGoDateLayout(data, layout);
+		const date = parseDateWithLayout(data, layout);
 		return date ? formatRfc1123(date) : data;
 	},
 
@@ -1091,7 +962,7 @@ export function createFilterEngine(templateEngine?: TemplateEngine): FilterEngin
 
 // Export utility functions for direct use
 export {
-	parseGoDateLayout,
+	parseDateWithLayout,
 	parseRelativeTime,
 	parseFuzzyTime,
 	formatRfc1123,


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
The `dateparse` function in the FilterEngine had some serious bugs, like:
- replacing wrong tokens: for the format: 2006-01-02T15:04:05.000000Z the 15 (hour) part got matched as `month1` token.
- It even replaced already replaced tokens, like `day1`'s token which is only the number 2, replaces tokens regex value like `month1` which is `(\d{2})`

Tried to figure out, how to fix this, but instead of reinventing the wheel, I imported a library, which can parse datetimes from standard templates, and migrated all built in indexer to use that.
It is not the same go style parser, so it could be considered breaking change, but it is never worked, so /shrug

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Added new date parser library
- Replaced custom go style parser with date parser library
- Updated all current usages to new format

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [ ] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- x ] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [ ] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
