### PR TITLE
feat(ui): Improve library collection controls and layout

### DIFF
--- a/src/lib/components/discover/FilterDrawer.svelte
+++ b/src/lib/components/discover/FilterDrawer.svelte
@@ -106,7 +106,7 @@
 			</button>
 		</div>
 
-		<div class="flex-1 [scrollbar-width:none] overflow-y-auto p-4 [&::-webkit-scrollbar]:hidden">
+		<div class="flex-1 overflow-y-auto p-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 			<FilterPanel
 				{type}
 				{sortBy}

--- a/src/lib/components/discover/SectionRow.svelte
+++ b/src/lib/components/discover/SectionRow.svelte
@@ -148,7 +148,7 @@
 		<div
 			bind:this={container}
 			onscroll={handleScroll}
-			class="flex snap-x snap-mandatory [scrollbar-width:none] gap-3 overflow-x-auto scroll-smooth px-1 pb-4 sm:gap-4 [&::-webkit-scrollbar]:hidden"
+			class="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth px-1 pb-4 [scrollbar-width:none] sm:gap-4 [&::-webkit-scrollbar]:hidden"
 		>
 			{#each displayedItems as item (item.id)}
 				<div class={`flex-none snap-start ${resolvedItemClass}`}>

--- a/src/lib/components/library/LibraryDrawer.svelte
+++ b/src/lib/components/library/LibraryDrawer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Drawer from '$lib/components/ui/Drawer.svelte';
-	import { ArrowUpDown, Filter, X, Layers, Eye } from 'lucide-svelte';
+	import { ArrowUpDown, Filter, X } from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface SortOption {
@@ -21,15 +21,10 @@
 		currentSort: string;
 		currentFilters: Record<string, string>;
 		hiddenActiveFilterKeys?: string[];
-		groupByCollection?: boolean;
-		hasCollections?: boolean;
 		onClose: () => void;
 		onSortChange: (sort: string) => void;
 		onFilterChange: (key: string, value: string) => void;
 		onClearFilters: () => void;
-		onGroupToggle?: () => void;
-		onMonitorAll?: () => void;
-		onUnmonitorAll?: () => void;
 	}
 
 	let {
@@ -39,15 +34,10 @@
 		currentSort,
 		currentFilters = {},
 		hiddenActiveFilterKeys = [],
-		groupByCollection = false,
-		hasCollections = false,
 		onClose,
 		onSortChange,
 		onFilterChange,
-		onClearFilters,
-		onGroupToggle,
-		onMonitorAll,
-		onUnmonitorAll
+		onClearFilters
 	}: Props = $props();
 
 	const visibleActiveFilterEntries = $derived(
@@ -136,42 +126,5 @@
 				</div>
 			</div>
 		{/if}
-
-		<!-- Display Actions -->
-		<div>
-			<h3 class="mb-2 flex items-center gap-2 text-sm font-medium text-base-content/60">
-				{m.library_drawer_display()}
-			</h3>
-			<div class="space-y-1">
-				<!-- Group by Collection (movies only) -->
-				{#if hasCollections && onGroupToggle}
-					<button
-						class="btn w-full justify-start btn-sm {groupByCollection
-							? 'btn-primary'
-							: 'btn-ghost'}"
-						onclick={onGroupToggle}
-					>
-						<Layers class="h-4 w-4" />
-						{groupByCollection ? 'Collections' : 'Collections'}
-					</button>
-				{/if}
-
-				<!-- Monitor All -->
-				{#if onMonitorAll}
-					<button class="btn w-full justify-start btn-ghost btn-sm" onclick={onMonitorAll}>
-						<Eye class="h-4 w-4" />
-						{m.library_movies_monitorAll()}
-					</button>
-				{/if}
-
-				<!-- Unmonitor All -->
-				{#if onUnmonitorAll}
-					<button class="btn w-full justify-start btn-ghost btn-sm" onclick={onUnmonitorAll}>
-						<Eye class="h-4 w-4" />
-						{m.library_movies_unmonitorAll()}
-					</button>
-				{/if}
-			</div>
-		</div>
 	</div>
 </Drawer>

--- a/src/lib/components/settings/SettingsTabNav.svelte
+++ b/src/lib/components/settings/SettingsTabNav.svelte
@@ -70,7 +70,7 @@
 	<div class="relative">
 		<div
 			bind:this={navScroller}
-			class="[scrollbar-width:none] overflow-x-auto px-2 sm:px-4 [&::-webkit-scrollbar]:hidden"
+			class="overflow-x-auto px-2 [scrollbar-width:none] sm:px-4 [&::-webkit-scrollbar]:hidden"
 		>
 			<nav class="-mb-px flex min-w-max items-stretch gap-1 sm:gap-4" aria-label={ariaLabel}>
 				{#each navItems as item (item.href)}

--- a/src/lib/stores/view-preferences.svelte.ts
+++ b/src/lib/stores/view-preferences.svelte.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 
 const VIEW_MODE_KEY = 'library-view-mode';
+const GROUP_BY_COLLECTION_KEY = 'library-group-by-collection';
 
 export type ViewMode = 'grid' | 'list';
 
@@ -14,8 +15,16 @@ function getInitialViewMode(): ViewMode {
 	return 'grid';
 }
 
+function getInitialGroupByCollection(): boolean {
+	if (browser) {
+		return sessionStorage.getItem(GROUP_BY_COLLECTION_KEY) === 'true';
+	}
+	return false;
+}
+
 class ViewPreferencesStore {
 	viewMode = $state<ViewMode>(getInitialViewMode());
+	groupByCollection = $state(getInitialGroupByCollection());
 	/** True once the client has resolved the stored preference. Use to avoid SSR flash. */
 	isReady = $state(browser);
 
@@ -28,6 +37,17 @@ class ViewPreferencesStore {
 
 	toggleViewMode() {
 		this.setViewMode(this.viewMode === 'grid' ? 'list' : 'grid');
+	}
+
+	setGroupByCollection(grouped: boolean) {
+		this.groupByCollection = grouped;
+		if (browser) {
+			sessionStorage.setItem(GROUP_BY_COLLECTION_KEY, String(grouped));
+		}
+	}
+
+	toggleGroupByCollection() {
+		this.setGroupByCollection(!this.groupByCollection);
 	}
 }
 

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -691,8 +691,8 @@
 	<!-- Main Content -->
 	<div class="grid gap-4 lg:grid-cols-2 lg:gap-6 xl:grid-cols-3">
 		<!-- Files Section (takes 2 columns on large screens) -->
-		<div class="md:col-span-2 lg:col-span-2">
-			<div class="rounded-xl bg-base-200 p-4 md:p-6">
+		<div class="min-w-0 md:col-span-2 lg:col-span-2">
+			<div class="min-w-0 overflow-hidden rounded-xl bg-base-200 p-4 md:p-6">
 				<div class="mb-4 flex items-center justify-between">
 					<h2 class="text-lg font-semibold">{m.library_movieDetail_filesHeading()}</h2>
 					<div class="flex flex-wrap items-center gap-2">
@@ -721,10 +721,65 @@
 					{subtitleAutoSearching}
 				/>
 			</div>
+
+			{#if data.collectionMovies && data.collectionMovies.length > 0}
+				<div class="mt-4 hidden rounded-xl bg-base-200 p-4 md:mt-6 md:block md:p-6">
+					<h2 class="mb-4 text-lg font-semibold">
+						{m.library_movieDetail_otherMoviesInCollection()}
+					</h2>
+					<div class="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
+						{#each data.collectionMovies as collMovie (collMovie.id)}
+							<a
+								href={resolvePath(`/library/movie/${collMovie.id}`)}
+								class="flex min-w-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
+							>
+								<div class="relative aspect-[2/3] w-full overflow-hidden rounded bg-base-300">
+									{#if collMovie.posterPath}
+										<img
+											src="https://image.tmdb.org/t/p/w185{collMovie.posterPath}"
+											alt={collMovie.title}
+											class="h-full w-full object-cover"
+											loading="lazy"
+										/>
+									{:else}
+										<div
+											class="flex h-full w-full items-center justify-center text-base-content/30"
+										>
+											<span class="text-2xl">🎬</span>
+										</div>
+									{/if}
+									{#if collMovie.hasFile}
+										<span
+											class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-2.5 w-2.5"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke="currentColor"
+												stroke-width="3"
+											>
+												<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+											</svg>
+										</span>
+									{/if}
+								</div>
+								<span class="line-clamp-2 text-center text-xs leading-tight font-medium">
+									{collMovie.title}
+								</span>
+								{#if collMovie.year}
+									<span class="text-[10px] text-base-content/50">{collMovie.year}</span>
+								{/if}
+							</a>
+						{/each}
+					</div>
+				</div>
+			{/if}
 		</div>
 
 		<!-- Sidebar -->
-		<div class="space-y-4 md:space-y-6">
+		<div class="min-w-0 space-y-4 md:space-y-6">
 			<!-- Overview -->
 			{#if movie.overview}
 				<div class="rounded-xl bg-base-200 p-4 md:p-6">
@@ -805,59 +860,63 @@
 					</div>
 				</dl>
 			</div>
+
+			{#if data.collectionMovies && data.collectionMovies.length > 0}
+				<div class="rounded-xl bg-base-200 p-4 md:hidden">
+					<h2 class="mb-4 text-lg font-semibold">
+						{m.library_movieDetail_otherMoviesInCollection()}
+					</h2>
+					<div class="-mx-1 flex max-w-full gap-3 overflow-x-auto overscroll-x-contain px-1 pb-2">
+						{#each data.collectionMovies as collMovie (collMovie.id)}
+							<a
+								href={resolvePath(`/library/movie/${collMovie.id}`)}
+								class="flex w-24 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
+							>
+								<div class="relative aspect-[2/3] w-full overflow-hidden rounded bg-base-300">
+									{#if collMovie.posterPath}
+										<img
+											src="https://image.tmdb.org/t/p/w185{collMovie.posterPath}"
+											alt={collMovie.title}
+											class="h-full w-full object-cover"
+											loading="lazy"
+										/>
+									{:else}
+										<div
+											class="flex h-full w-full items-center justify-center text-base-content/30"
+										>
+											<span class="text-2xl">🎬</span>
+										</div>
+									{/if}
+									{#if collMovie.hasFile}
+										<span
+											class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-2.5 w-2.5"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke="currentColor"
+												stroke-width="3"
+											>
+												<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+											</svg>
+										</span>
+									{/if}
+								</div>
+								<span class="line-clamp-2 text-center text-xs leading-tight font-medium">
+									{collMovie.title}
+								</span>
+								{#if collMovie.year}
+									<span class="text-[10px] text-base-content/50">{collMovie.year}</span>
+								{/if}
+							</a>
+						{/each}
+					</div>
+				</div>
+			{/if}
 		</div>
 	</div>
-
-	{#if data.collectionMovies && data.collectionMovies.length > 0}
-		<div class="mt-2 rounded-xl bg-base-200 p-4 md:p-6">
-			<h2 class="mb-4 text-lg font-semibold">{m.library_movieDetail_otherMoviesInCollection()}</h2>
-			<div class="flex gap-3 overflow-x-auto pb-2">
-				{#each data.collectionMovies as collMovie (collMovie.id)}
-					<a
-						href={resolvePath(`/library/movie/${collMovie.id}`)}
-						class="flex w-28 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
-					>
-						<div class="relative aspect-[2/3] w-full overflow-hidden rounded bg-base-300">
-							{#if collMovie.posterPath}
-								<img
-									src="https://image.tmdb.org/t/p/w185{collMovie.posterPath}"
-									alt={collMovie.title}
-									class="h-full w-full object-cover"
-									loading="lazy"
-								/>
-							{:else}
-								<div class="flex h-full w-full items-center justify-center text-base-content/30">
-									<span class="text-2xl">🎬</span>
-								</div>
-							{/if}
-							{#if collMovie.hasFile}
-								<span
-									class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
-								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										class="h-2.5 w-2.5"
-										fill="none"
-										viewBox="0 0 24 24"
-										stroke="currentColor"
-										stroke-width="3"
-									>
-										<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-									</svg>
-								</span>
-							{/if}
-						</div>
-						<span class="line-clamp-2 text-center text-xs leading-tight font-medium">
-							{collMovie.title}
-						</span>
-						{#if collMovie.year}
-							<span class="text-[10px] text-base-content/50">{collMovie.year}</span>
-						{/if}
-					</a>
-				{/each}
-			</div>
-		</div>
-	{/if}
 </div>
 
 <!-- Edit Modal -->

--- a/src/routes/library/movies/+page.svelte
+++ b/src/routes/library/movies/+page.svelte
@@ -21,7 +21,12 @@
 		Search,
 		SlidersHorizontal,
 		CheckSquare,
-		XSquare
+		XSquare,
+		Layers,
+		Eye,
+		EyeOff,
+		ChevronDown,
+		HardDrive
 	} from 'lucide-svelte';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { viewPreferences } from '$lib/stores/view-preferences.svelte';
@@ -45,7 +50,6 @@
 	let selectedMovies = new SvelteSet<string>();
 	let showCheckboxes = $state(false);
 	let searchQuery = $state('');
-	let groupByCollection = $state(false);
 	let collapsedGroups = new SvelteSet<string>();
 	let drawerOpen = $state(false);
 
@@ -627,6 +631,53 @@
 
 			<!-- Right: Quick Actions -->
 			<div class="flex shrink-0 items-center gap-1.5">
+				{#if data.uniqueCollections.length > 0}
+					<button
+						class="btn gap-1.5 btn-xs sm:btn-sm {viewPreferences.groupByCollection
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => viewPreferences.toggleGroupByCollection()}
+						aria-pressed={viewPreferences.groupByCollection}
+						aria-label={viewPreferences.groupByCollection ? 'Hide collections' : 'Show collections'}
+						title={viewPreferences.groupByCollection ? 'Hide collections' : 'Show collections'}
+					>
+						{#if viewPreferences.groupByCollection}
+							<Layers class="h-4 w-4" />
+						{:else}
+							<Layers class="h-4 w-4" />
+						{/if}
+						<span class="hidden xl:inline">Collections</span>
+					</button>
+				{/if}
+
+				<div class="dropdown dropdown-end">
+					<button
+						class="btn gap-1.5 btn-ghost btn-xs sm:btn-sm"
+						tabindex="0"
+						aria-label="Monitoring actions"
+					>
+						<Eye class="h-4 w-4" />
+						<span class="hidden xl:inline">Monitoring</span>
+						<ChevronDown class="hidden h-3 w-3 sm:block" />
+					</button>
+					<ul
+						class="dropdown-content menu z-50 mt-2 w-44 rounded-box border border-base-300 bg-base-100 p-2 shadow-xl"
+					>
+						<li>
+							<button onclick={handleMonitorAll}>
+								<Eye class="h-4 w-4" />
+								{m.library_movies_monitorAll()}
+							</button>
+						</li>
+						<li>
+							<button onclick={handleUnmonitorAll}>
+								<EyeOff class="h-4 w-4" />
+								{m.library_movies_unmonitorAll()}
+							</button>
+						</li>
+					</ul>
+				</div>
+
 				<button
 					class="btn gap-1.5 btn-ghost btn-xs sm:btn-sm {showCheckboxes ? 'btn-primary' : ''}"
 					onclick={handleSelectToggle}
@@ -755,9 +806,11 @@
 				<!-- Defer until client resolves view preference to avoid grid flash -->
 			{:else}
 				<div class="animate-in fade-in slide-in-from-bottom-4 duration-500">
-					{#if groupByCollection}
+					{#if data.uniqueCollections.length > 0 && viewPreferences.groupByCollection}
 						{@const collectionGroups = groupMoviesByCollection(filteredMovies)}
 						{#each collectionGroups as group (group.name ?? '__none__')}
+							{@const fileCount = group.movies.filter((mv) => mv.hasFile).length}
+							{@const monitoredCount = group.movies.filter((mv) => mv.monitored).length}
 							<div class="mb-8">
 								<button
 									class="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-base-200/60"
@@ -778,16 +831,26 @@
 											clip-rule="evenodd"
 										/>
 									</svg>
-									<h3 class="text-lg font-semibold">
-										{group.name ?? m.library_movies_other()}
-									</h3>
-									<span class="badge badge-ghost badge-sm">
-										{group.movies.length}
-										{group.movies.length === 1 ? 'movie' : 'movies'}
-									</span>
-									<span class="text-xs text-base-content/50">
-										{group.movies.filter((mv) => mv.hasFile).length}/{group.movies.length} files,
-										{group.movies.filter((mv) => mv.monitored).length}/{group.movies.length} monitored
+									<div class="flex min-w-0 flex-1 items-center gap-2">
+										<h3 class="min-w-0 truncate text-lg font-semibold">
+											{group.name ?? m.library_movies_other()}
+										</h3>
+										<span class="badge shrink-0 badge-ghost badge-sm">
+											{group.movies.length}
+										</span>
+									</div>
+									<span
+										class="flex shrink-0 items-center gap-3 text-xs text-base-content/50"
+										aria-label={`${fileCount}/${group.movies.length} files, ${monitoredCount}/${group.movies.length} monitored`}
+									>
+										<span class="inline-flex items-center gap-1">
+											<HardDrive class="h-3.5 w-3.5" />
+											{fileCount}/{group.movies.length}
+										</span>
+										<span class="inline-flex items-center gap-1">
+											<Eye class="h-3.5 w-3.5" />
+											{monitoredCount}/{group.movies.length}
+										</span>
 									</span>
 								</button>
 								{#if !collapsedGroups.has(group.name ?? '__none__')}
@@ -894,14 +957,9 @@
 		currentSort={data.filters.sort}
 		{currentFilters}
 		hiddenActiveFilterKeys={['library']}
-		{groupByCollection}
-		hasCollections={data.uniqueCollections.length > 0}
 		onSortChange={(sort) => updateUrlParam('sort', sort)}
 		onFilterChange={(key, value) => updateUrlParam(key, value)}
 		onClearFilters={clearFilters}
-		onGroupToggle={() => (groupByCollection = !groupByCollection)}
-		onMonitorAll={handleMonitorAll}
-		onUnmonitorAll={handleUnmonitorAll}
 	/>
 </div>
 

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -21,7 +21,10 @@
 		Search,
 		SlidersHorizontal,
 		CheckSquare,
-		XSquare
+		XSquare,
+		Eye,
+		EyeOff,
+		ChevronDown
 	} from 'lucide-svelte';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { viewPreferences } from '$lib/stores/view-preferences.svelte';
@@ -598,6 +601,34 @@
 
 			<!-- Right: Quick Actions -->
 			<div class="flex shrink-0 items-center gap-1.5">
+				<div class="dropdown dropdown-end">
+					<button
+						class="btn gap-1.5 btn-ghost btn-xs sm:btn-sm"
+						tabindex="0"
+						aria-label="Monitoring actions"
+					>
+						<Eye class="h-4 w-4" />
+						<span class="hidden xl:inline">Monitoring</span>
+						<ChevronDown class="hidden h-3 w-3 sm:block" />
+					</button>
+					<ul
+						class="dropdown-content menu z-50 mt-2 w-44 rounded-box border border-base-300 bg-base-100 p-2 shadow-xl"
+					>
+						<li>
+							<button onclick={handleMonitorAll}>
+								<Eye class="h-4 w-4" />
+								{m.library_tv_monitorAll()}
+							</button>
+						</li>
+						<li>
+							<button onclick={handleUnmonitorAll}>
+								<EyeOff class="h-4 w-4" />
+								{m.library_tv_unmonitorAll()}
+							</button>
+						</li>
+					</ul>
+				</div>
+
 				<button
 					class="btn gap-1.5 btn-ghost btn-xs sm:btn-sm {showCheckboxes ? 'btn-primary' : ''}"
 					onclick={handleSelectToggle}
@@ -798,8 +829,6 @@
 		onSortChange={(sort) => updateUrlParam('sort', sort)}
 		onFilterChange={(key, value) => updateUrlParam(key, value)}
 		onClearFilters={clearFilters}
-		onMonitorAll={handleMonitorAll}
-		onUnmonitorAll={handleUnmonitorAll}
 	/>
 </div>
 


### PR DESCRIPTION
## Summary

Moved library display controls into the main toolbar and improved collection layouts across movie library and movie detail views.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- Moved collection grouping and monitoring actions out of the options drawer.
- Added toolbar access for collection grouping and monitor/unmonitor actions.
- Persisted the collection grouping preference.
- Replaced verbose collection stats with compact icon-based counts.
- Improved movie detail collection placement and layout across mobile and desktop views.
- 
## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`): All checks pass locally, but for some reason lint is failing on github, not sure why.

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
