### PR TITLE
fix: Don't expose saved passwords

### DIFF
--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -55,6 +55,7 @@ export class IndexerManager {
 	private indexerFactory: YamlIndexerFactory;
 	private indexerInstances: Map<string, IIndexer> = new Map();
 	private indexerCreationInFlight: Map<string, Promise<IIndexer | null>> = new Map();
+	static readonly REDACTED_KEY_VALUE = '[REDACTED]';
 
 	constructor(options: IndexerManagerOptions = {}) {
 		const path = options.definitionsPath;
@@ -306,7 +307,15 @@ export class IndexerManager {
 		if (updates.baseUrl !== undefined) updateData.baseUrl = updates.baseUrl;
 		if (updates.alternateUrls !== undefined) updateData.alternateUrls = updates.alternateUrls;
 		if (updates.priority !== undefined) updateData.priority = updates.priority;
-		if (updates.settings !== undefined) updateData.settings = updates.settings;
+
+		const definition = this.getDefinition(existing.definitionId);
+		if (existing.settings && updates.settings && definition) {
+			updateData.settings = this.reintroduceSecrets(
+				existing.settings,
+				updates.settings,
+				definition
+			);
+		}
 
 		// Search capability toggles
 		if (updates.enableAutomaticSearch !== undefined)
@@ -506,11 +515,50 @@ export class IndexerManager {
 		return orchestrator.searchEnhanced(indexers, criteria, options);
 	}
 
+	private reintroduceSecrets(
+		existingSettings: Record<string, string | boolean | number | undefined>,
+		updatedSettings: Record<string, string | boolean | number | undefined>,
+		definition: YamlDefinition
+	): Record<string, string | boolean | number | undefined> {
+		if (!definition.settings) {
+			return updatedSettings;
+		}
+
+		// Merge settings while preserving existing sensitive values (passwords, keys, etc.)
+		// Only update fields that do not have IndexerManager.REDACTED_KEY_VALUE value in the update payload
+		const mergedSettings = { ...existingSettings };
+		const settingTypes = Object.fromEntries(definition.settings.map((s) => [s.name, s.type]));
+		for (const [key, value] of Object.entries(updatedSettings)) {
+			const isSensitive = settingTypes?.[key] === 'password';
+
+			if (isSensitive) {
+				if (value && value !== IndexerManager.REDACTED_KEY_VALUE) {
+					mergedSettings[key] = value;
+				}
+			} else {
+				mergedSettings[key] = value;
+			}
+		}
+
+		return mergedSettings;
+	}
+
 	/** Test an indexer's connectivity (YAML-only) */
 	async testIndexer(config: Omit<IndexerConfig, 'id'>, statusIndexerId?: string): Promise<void> {
 		const definition = this.definitionLoader.get(config.definitionId);
 		if (!definition) {
 			throw new Error(`Unknown definition: ${config.definitionId}`);
+		}
+
+		if (statusIndexerId) {
+			const existingIndexer = await managerInstance?.getIndexer(statusIndexerId);
+			if (existingIndexer?.settings && config.settings && definition) {
+				config.settings = this.reintroduceSecrets(
+					existingIndexer.settings,
+					config.settings,
+					definition
+				);
+			}
 		}
 
 		const tempConfig: IndexerConfig = {

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
+import { getIndexerManager, IndexerManager } from '$lib/server/indexers/IndexerManager';
 import { toUIDefinition } from '$lib/server/indexers/loader';
 import { getPersistentStatusTracker } from '$lib/server/indexers/status';
 import { CINEPHAGE_STREAM_DEFINITION_ID } from '$lib/server/indexers/types';
@@ -50,10 +50,29 @@ export const load: PageServerLoad = async () => {
 		return `${protocol}://${host}`.replace(/\/$/, '');
 	};
 
+	const definitions: IndexerDefinition[] = manager
+		.getUnifiedDefinitions()
+		.map(toUIDefinition)
+		.sort((a, b) => a.name.localeCompare(b.name));
+
 	const indexers: IndexerWithStatus[] = indexerConfigs.map((config) => {
 		const status = statusByIndexerId.get(config.id);
 		const settings = toStringSettings(config.settings);
 		const displayBaseUrl = getDisplayBaseUrl(config, settings);
+
+		let redactedSettings: Record<string, string> | null = null;
+		if (settings) {
+			const redactedSettingKeys = definitions
+				.filter((d) => d.id === config.definitionId)[0]
+				.settings.filter((s) => s.type === 'password')
+				.map((s) => s.name);
+			redactedSettings = Object.fromEntries(
+				Object.entries(settings).map(([key, value]) => [
+					key,
+					redactedSettingKeys.includes(key) ? IndexerManager.REDACTED_KEY_VALUE : value
+				])
+			);
+		}
 
 		return {
 			id: config.id,
@@ -64,7 +83,7 @@ export const load: PageServerLoad = async () => {
 			alternateUrls: config.alternateUrls,
 			priority: config.priority,
 			protocol: config.protocol,
-			settings,
+			settings: redactedSettings,
 			enableAutomaticSearch: config.enableAutomaticSearch,
 			enableInteractiveSearch: config.enableInteractiveSearch,
 			minimumSeeders: config.minimumSeeders,
@@ -84,11 +103,6 @@ export const load: PageServerLoad = async () => {
 				: undefined
 		};
 	});
-
-	const definitions: IndexerDefinition[] = manager
-		.getUnifiedDefinitions()
-		.map(toUIDefinition)
-		.sort((a, b) => a.name.localeCompare(b.name));
 
 	return {
 		indexers,


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Don't send down saved passwords / API key for indexers.
LLM was used to navigate the codebase, and find related functionality.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- List the specific changes made in this PR -->

- For every `password` type value in indexer settings we replace the value with the string: `[REDACTED]`
- On update or testing the indexer, we:
  - Load the value from the saved settings, if the input value is `[REDACTED]`
  - Update the value from the input if it is not `[REDACTED]`

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [ ] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
