### PR TITLE
revert: roll back #351 to migrate indexer password fields to existing blank-field pattern

### DIFF
--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -55,7 +55,6 @@ export class IndexerManager {
 	private indexerFactory: YamlIndexerFactory;
 	private indexerInstances: Map<string, IIndexer> = new Map();
 	private indexerCreationInFlight: Map<string, Promise<IIndexer | null>> = new Map();
-	static readonly REDACTED_KEY_VALUE = '[REDACTED]';
 
 	constructor(options: IndexerManagerOptions = {}) {
 		const path = options.definitionsPath;
@@ -307,15 +306,7 @@ export class IndexerManager {
 		if (updates.baseUrl !== undefined) updateData.baseUrl = updates.baseUrl;
 		if (updates.alternateUrls !== undefined) updateData.alternateUrls = updates.alternateUrls;
 		if (updates.priority !== undefined) updateData.priority = updates.priority;
-
-		const definition = this.getDefinition(existing.definitionId);
-		if (existing.settings && updates.settings && definition) {
-			updateData.settings = this.reintroduceSecrets(
-				existing.settings,
-				updates.settings,
-				definition
-			);
-		}
+		if (updates.settings !== undefined) updateData.settings = updates.settings;
 
 		// Search capability toggles
 		if (updates.enableAutomaticSearch !== undefined)
@@ -515,50 +506,11 @@ export class IndexerManager {
 		return orchestrator.searchEnhanced(indexers, criteria, options);
 	}
 
-	private reintroduceSecrets(
-		existingSettings: Record<string, string | boolean | number | undefined>,
-		updatedSettings: Record<string, string | boolean | number | undefined>,
-		definition: YamlDefinition
-	): Record<string, string | boolean | number | undefined> {
-		if (!definition.settings) {
-			return updatedSettings;
-		}
-
-		// Merge settings while preserving existing sensitive values (passwords, keys, etc.)
-		// Only update fields that do not have IndexerManager.REDACTED_KEY_VALUE value in the update payload
-		const mergedSettings = { ...existingSettings };
-		const settingTypes = Object.fromEntries(definition.settings.map((s) => [s.name, s.type]));
-		for (const [key, value] of Object.entries(updatedSettings)) {
-			const isSensitive = settingTypes?.[key] === 'password';
-
-			if (isSensitive) {
-				if (value && value !== IndexerManager.REDACTED_KEY_VALUE) {
-					mergedSettings[key] = value;
-				}
-			} else {
-				mergedSettings[key] = value;
-			}
-		}
-
-		return mergedSettings;
-	}
-
 	/** Test an indexer's connectivity (YAML-only) */
 	async testIndexer(config: Omit<IndexerConfig, 'id'>, statusIndexerId?: string): Promise<void> {
 		const definition = this.definitionLoader.get(config.definitionId);
 		if (!definition) {
 			throw new Error(`Unknown definition: ${config.definitionId}`);
-		}
-
-		if (statusIndexerId) {
-			const existingIndexer = await managerInstance?.getIndexer(statusIndexerId);
-			if (existingIndexer?.settings && config.settings && definition) {
-				config.settings = this.reintroduceSecrets(
-					existingIndexer.settings,
-					config.settings,
-					definition
-				);
-			}
 		}
 
 		const tempConfig: IndexerConfig = {

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { getIndexerManager, IndexerManager } from '$lib/server/indexers/IndexerManager';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
 import { toUIDefinition } from '$lib/server/indexers/loader';
 import { getPersistentStatusTracker } from '$lib/server/indexers/status';
 import { CINEPHAGE_STREAM_DEFINITION_ID } from '$lib/server/indexers/types';
@@ -50,29 +50,10 @@ export const load: PageServerLoad = async () => {
 		return `${protocol}://${host}`.replace(/\/$/, '');
 	};
 
-	const definitions: IndexerDefinition[] = manager
-		.getUnifiedDefinitions()
-		.map(toUIDefinition)
-		.sort((a, b) => a.name.localeCompare(b.name));
-
 	const indexers: IndexerWithStatus[] = indexerConfigs.map((config) => {
 		const status = statusByIndexerId.get(config.id);
 		const settings = toStringSettings(config.settings);
 		const displayBaseUrl = getDisplayBaseUrl(config, settings);
-
-		let redactedSettings: Record<string, string> | null = null;
-		if (settings) {
-			const redactedSettingKeys = definitions
-				.filter((d) => d.id === config.definitionId)[0]
-				.settings.filter((s) => s.type === 'password')
-				.map((s) => s.name);
-			redactedSettings = Object.fromEntries(
-				Object.entries(settings).map(([key, value]) => [
-					key,
-					redactedSettingKeys.includes(key) ? IndexerManager.REDACTED_KEY_VALUE : value
-				])
-			);
-		}
 
 		return {
 			id: config.id,
@@ -83,7 +64,7 @@ export const load: PageServerLoad = async () => {
 			alternateUrls: config.alternateUrls,
 			priority: config.priority,
 			protocol: config.protocol,
-			settings: redactedSettings,
+			settings,
 			enableAutomaticSearch: config.enableAutomaticSearch,
 			enableInteractiveSearch: config.enableInteractiveSearch,
 			minimumSeeders: config.minimumSeeders,
@@ -103,6 +84,11 @@ export const load: PageServerLoad = async () => {
 				: undefined
 		};
 	});
+
+	const definitions: IndexerDefinition[] = manager
+		.getUnifiedDefinitions()
+		.map(toUIDefinition)
+		.sort((a, b) => a.name.localeCompare(b.name));
 
 	return {
 		indexers,


### PR DESCRIPTION
Reverts MoldyTaint/Cinephage#351 - Rolling back to reimplement using the established blank-field convention already used in other integration API/Password fields.