### PR TITLE
fix(integrations): unify secret-field preserve behavior and required markers across integrations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1695,7 +1695,7 @@
 	"livetv_form_xstream_myXstreamAccount": "My XStream Account",
 	"livetv_form_xstream_nameLabel": "Name",
 	"livetv_form_xstream_namePlaceholder": "My XStream Account",
-	"livetv_form_xstream_passwordKeep": "Keep current password",
+	"livetv_form_xstream_passwordKeep": "(blank to keep)",
 	"livetv_form_xstream_passwordLabel": "Password",
 	"livetv_form_xstream_serverUrlHint": "Your XStream server URL",
 	"livetv_form_xstream_serverUrlLabel": "Server URL",

--- a/src/lib/components/discover/FilterDrawer.svelte
+++ b/src/lib/components/discover/FilterDrawer.svelte
@@ -106,7 +106,7 @@
 			</button>
 		</div>
 
-		<div class="flex-1 overflow-y-auto p-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+		<div class="flex-1 [scrollbar-width:none] overflow-y-auto p-4 [&::-webkit-scrollbar]:hidden">
 			<FilterPanel
 				{type}
 				{sortBy}

--- a/src/lib/components/discover/SectionRow.svelte
+++ b/src/lib/components/discover/SectionRow.svelte
@@ -148,7 +148,7 @@
 		<div
 			bind:this={container}
 			onscroll={handleScroll}
-			class="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth px-1 pb-4 [scrollbar-width:none] sm:gap-4 [&::-webkit-scrollbar]:hidden"
+			class="flex snap-x snap-mandatory [scrollbar-width:none] gap-3 overflow-x-auto scroll-smooth px-1 pb-4 sm:gap-4 [&::-webkit-scrollbar]:hidden"
 		>
 			{#each displayedItems as item (item.id)}
 				<div class={`flex-none snap-start ${resolvedItemClass}`}>

--- a/src/lib/components/downloadClients/ClientFormFields.svelte
+++ b/src/lib/components/downloadClients/ClientFormFields.svelte
@@ -54,7 +54,10 @@
 
 <div class="form-control">
 	<label class="label py-1" for="name">
-		<span class="label-text">{m.common_name()}</span>
+		<span class="label-text">
+			{m.common_name()}
+			<span class="text-error">* </span>
+		</span>
 	</label>
 	<input
 		id="name"
@@ -79,7 +82,10 @@
 <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
 	<div class="form-control">
 		<label class="label py-1" for="host">
-			<span class="label-text">{m.connection_host_label()}</span>
+			<span class="label-text">
+				{m.connection_host_label()}
+				<span class="text-error">* </span>
+			</span>
 		</label>
 		<input
 			id="host"
@@ -92,7 +98,10 @@
 
 	<div class="form-control">
 		<label class="label py-1" for="port">
-			<span class="label-text">{m.common_port()}</span>
+			<span class="label-text">
+				{m.common_port()}
+				<span class="text-error">* </span>
+			</span>
 		</label>
 		<input
 			id="port"
@@ -110,6 +119,9 @@
 		<label class="label py-1" for="password">
 			<span class="label-text">
 				{m.auth_apiKey_label()}
+				{#if mode === 'add' || !hasPassword}
+					<span class="text-error">* </span>
+				{/if}
 				{#if mode === 'edit' && hasPassword}
 					<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 				{/if}
@@ -147,6 +159,9 @@
 			<label class="label py-1" for="password">
 				<span class="label-text">
 					{m.auth_password_label()}
+					{#if mode === 'add' || !hasPassword}
+						<span class="text-error">* </span>
+					{/if}
 					{#if mode === 'edit' && hasPassword}
 						<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 					{/if}

--- a/src/lib/components/downloadClients/formSerializer.ts
+++ b/src/lib/components/downloadClients/formSerializer.ts
@@ -5,6 +5,7 @@ import type {
 	DownloadPriority,
 	DownloadInitialState
 } from '$lib/types/downloadClient';
+import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 
 export interface NntpServerFormData {
 	name: string;
@@ -65,7 +66,7 @@ export function serializeDownloadClientForm(
 			priority: formState.priority,
 			enabled: formState.enabled
 		};
-		if (mode === 'edit' && !formState.password) {
+		if (mode === 'edit' && isBlankOrRedacted(formState.password?.trim())) {
 			delete (data as unknown as Record<string, unknown>).password;
 		}
 		return data;
@@ -95,7 +96,7 @@ export function serializeDownloadClientForm(
 		tempPathRemote: formState.tempPathRemote || null,
 		priority: formState.priority
 	};
-	if (mode === 'edit' && !formState.password) {
+	if (mode === 'edit' && isBlankOrRedacted(formState.password?.trim())) {
 		delete (data as unknown as Record<string, unknown>).password;
 	}
 	return data;

--- a/src/lib/components/indexers/IndexerFormRegular.svelte
+++ b/src/lib/components/indexers/IndexerFormRegular.svelte
@@ -4,6 +4,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import IndexerSettingsFields from './IndexerSettingsFields.svelte';
 	import { SectionHeader, ToggleSetting } from '$lib/components/ui/modal';
+	import { isSensitiveDefinitionSetting } from '$lib/shared/sensitiveSettings';
 
 	interface Props {
 		definition: IndexerDefinition | null;
@@ -13,6 +14,7 @@
 		priority: number;
 		enabled: boolean;
 		settings: Record<string, string>;
+		hasSensitiveSettings?: Record<string, boolean>;
 		enableAutomaticSearch: boolean;
 		enableInteractiveSearch: boolean;
 		minimumSeeders: number;
@@ -48,6 +50,7 @@
 		priority,
 		enabled,
 		settings,
+		hasSensitiveSettings = {},
 		enableAutomaticSearch,
 		enableInteractiveSearch,
 		minimumSeeders,
@@ -82,7 +85,12 @@
 	let authSettingsOpen = $state(true);
 	let torrentSettingsOpen = $state(false);
 
-	// Build auth settings summary
+	function shouldTreatSettingConfigured(name: string, type: string): boolean {
+		return isSensitiveDefinitionSetting({ name, type })
+			? Boolean(hasSensitiveSettings[name])
+			: false;
+	}
+
 	const authSummary = $derived.by(() => {
 		if (!definition?.settings) return 'No configuration required';
 
@@ -92,7 +100,7 @@
 
 		const configuredCount = editableSettings.filter((s) => {
 			const val = settings[s.name];
-			return val && val.trim() !== '';
+			return shouldTreatSettingConfigured(s.name, s.type) || (val && val.trim() !== '');
 		}).length;
 
 		if (configuredCount === 0) return 'Not configured';
@@ -107,7 +115,7 @@
 
 		const configuredCount = editableSettings.filter((s) => {
 			const val = settings[s.name];
-			return val && val.trim() !== '';
+			return shouldTreatSettingConfigured(s.name, s.type) || (val && val.trim() !== '');
 		}).length;
 
 		if (configuredCount === editableSettings.length) return Shield;
@@ -282,6 +290,7 @@
 					<IndexerSettingsFields
 						settingsDefinitions={definition.settings}
 						{settings}
+						{hasSensitiveSettings}
 						onchange={(newSettings) => onSettingsChange(newSettings)}
 					/>
 				</div>

--- a/src/lib/components/indexers/IndexerModal.svelte
+++ b/src/lib/components/indexers/IndexerModal.svelte
@@ -41,6 +41,7 @@
 	let enabled = $state(true);
 	let priority = $state(25);
 	let settings = $state<Record<string, string>>({});
+	let hasSensitiveSettings = $state<Record<string, boolean>>({});
 
 	// Form state - Search capabilities
 	let enableAutomaticSearch = $state(true);
@@ -162,6 +163,7 @@
 			enabled = indexer?.enabled ?? true;
 			priority = indexer?.priority ?? 25;
 			settings = { ...(indexer?.settings ?? {}) };
+			hasSensitiveSettings = indexer?.sensitiveSettings ?? {};
 
 			enableAutomaticSearch = indexer?.enableAutomaticSearch ?? true;
 			enableInteractiveSearch = indexer?.enableInteractiveSearch ?? true;
@@ -359,6 +361,7 @@
 				{priority}
 				{enabled}
 				{settings}
+				{hasSensitiveSettings}
 				{enableAutomaticSearch}
 				{enableInteractiveSearch}
 				{minimumSeeders}

--- a/src/lib/components/indexers/IndexerSettingsFields.svelte
+++ b/src/lib/components/indexers/IndexerSettingsFields.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import type { DefinitionSetting } from '$lib/types/indexer';
 	import { HelpCircle, Info, Cookie, Shield, User } from 'lucide-svelte';
+	import * as m from '$lib/paraglide/messages.js';
+	import { isSensitiveDefinitionSetting } from '$lib/shared/sensitiveSettings';
 
 	interface Props {
 		settingsDefinitions: DefinitionSetting[];
 		settings: Record<string, string>;
+		hasSensitiveSettings?: Record<string, boolean>;
 		onchange?: (settings: Record<string, string>) => void;
 	}
 
-	let { settingsDefinitions, settings = $bindable(), onchange }: Props = $props();
+	let {
+		settingsDefinitions,
+		settings = $bindable(),
+		hasSensitiveSettings = {},
+		onchange
+	}: Props = $props();
 
 	function updateSetting(name: string, value: string) {
 		settings[name] = value;
@@ -35,6 +43,10 @@
 				return Info;
 		}
 	}
+
+	function shouldPreserveSetting(setting: DefinitionSetting): boolean {
+		return isSensitiveDefinitionSetting(setting) && Boolean(hasSensitiveSettings[setting.name]);
+	}
 </script>
 
 {#if settingsDefinitions.length > 0}
@@ -44,7 +56,7 @@
 			{@const InfoIcon = getInfoIcon(setting.type)}
 			<div class="col-span-full rounded-lg bg-info/10 p-3">
 				<div class="flex items-start gap-2">
-					<InfoIcon class="mt-0.5 h-4 w-4 flex-shrink-0 text-info" />
+					<InfoIcon class="mt-0.5 h-4 w-4 shrink-0 text-info" />
 					<div class="min-w-0">
 						<span class="text-sm font-medium text-base-content">{setting.label}</span>
 						{#if setting.default}
@@ -59,8 +71,11 @@
 					<label class="label py-1" for={setting.name}>
 						<span class="label-text flex items-center gap-1">
 							{setting.label}
-							{#if setting.required}
-								<span class="text-error">*</span>
+							{#if setting.required && !shouldPreserveSetting(setting)}
+								<span class="text-error">* </span>
+							{/if}
+							{#if shouldPreserveSetting(setting)}
+								<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 							{/if}
 							{#if setting.helpText}
 								<div class="tooltip tooltip-right" data-tip={setting.helpText}>
@@ -76,10 +91,12 @@
 						type="password"
 						id={setting.name}
 						class="input-bordered input input-sm"
-						placeholder={String(setting.default ?? '')}
+						placeholder={shouldPreserveSetting(setting)
+							? '********'
+							: String(setting.default ?? '')}
 						value={settings[setting.name] ?? ''}
 						oninput={(e) => updateSetting(setting.name, e.currentTarget.value)}
-						required={setting.required}
+						required={setting.required && !shouldPreserveSetting(setting)}
 					/>
 				{:else if setting.type === 'checkbox'}
 					<label class="flex cursor-pointer items-start gap-3 py-2">
@@ -108,20 +125,24 @@
 						type="number"
 						id={setting.name}
 						class="input-bordered input input-sm"
-						placeholder={String(setting.default ?? '')}
+						placeholder={shouldPreserveSetting(setting)
+							? '********'
+							: String(setting.default ?? '')}
 						value={settings[setting.name] ?? ''}
 						oninput={(e) => updateSetting(setting.name, e.currentTarget.value)}
-						required={setting.required}
+						required={setting.required && !shouldPreserveSetting(setting)}
 					/>
 				{:else}
 					<input
 						type="text"
 						id={setting.name}
 						class="input-bordered input input-sm"
-						placeholder={String(setting.default ?? '')}
+						placeholder={shouldPreserveSetting(setting)
+							? '********'
+							: String(setting.default ?? '')}
 						value={settings[setting.name] ?? ''}
 						oninput={(e) => updateSetting(setting.name, e.currentTarget.value)}
-						required={setting.required}
+						required={setting.required && !shouldPreserveSetting(setting)}
 					/>
 				{/if}
 

--- a/src/lib/components/livetv/LiveTvAccountModal.svelte
+++ b/src/lib/components/livetv/LiveTvAccountModal.svelte
@@ -14,6 +14,7 @@
 		LiveTvAccountTestResult
 	} from '$lib/types/livetv';
 	import * as m from '$lib/paraglide/messages.js';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 
 	interface Props {
 		open: boolean;
@@ -157,7 +158,7 @@
 		name.trim().length > 0 &&
 			baseUrl.trim().length > 0 &&
 			username.trim().length > 0 &&
-			(mode === 'add' || password.trim().length > 0 || account?.xstreamConfig?.password)
+			(mode === 'add' || !isBlankOrRedacted(password?.trim()) || !!account?.xstreamConfig?.password)
 	);
 	const isM3uValid = $derived(() => {
 		if (name.trim().length === 0) return false;
@@ -199,7 +200,7 @@
 			case 'xstream':
 				data.baseUrl = baseUrl.trim();
 				data.username = username.trim();
-				if (password.trim()) {
+				if (!isBlankOrRedacted(password?.trim())) {
 					data.password = password.trim();
 				}
 				break;
@@ -231,7 +232,10 @@
 			case 'xstream':
 				config.baseUrl = baseUrl.trim();
 				config.username = username.trim();
-				config.password = password.trim() || account?.xstreamConfig?.password || '';
+				config.password =
+					(isBlankOrRedacted(password?.trim())
+						? account?.xstreamConfig?.password
+						: password.trim()) || '';
 				if (epgUrl.trim()) {
 					config.epgUrl = epgUrl.trim();
 				}

--- a/src/lib/components/livetv/forms/CinephageIptvAccountForm.svelte
+++ b/src/lib/components/livetv/forms/CinephageIptvAccountForm.svelte
@@ -87,7 +87,10 @@
 	<!-- Name -->
 	<div class="form-control">
 		<label class="label py-1" for="cinephage-name">
-			<span class="label-text">Account Name</span>
+			<span class="label-text">
+				Account Name
+				<span class="text-error">* </span>
+			</span>
 		</label>
 		<input
 			id="cinephage-name"
@@ -119,6 +122,7 @@
 						<span class="label-text flex items-center gap-2">
 							<Globe class="h-4 w-4" />
 							Select Countries
+							<span class="text-error">* </span>
 							<span class="text-xs text-base-content/60">({countries.length} available)</span>
 						</span>
 					</label>

--- a/src/lib/components/livetv/forms/M3uAccountForm.svelte
+++ b/src/lib/components/livetv/forms/M3uAccountForm.svelte
@@ -79,7 +79,10 @@
 	<!-- Name (full width) -->
 	<div class="form-control">
 		<label class="label py-1" for="m3u-name">
-			<span class="label-text">{m.livetv_form_m3u_nameLabel()}</span>
+			<span class="label-text">
+				{m.livetv_form_m3u_nameLabel()}
+				<span class="text-error">* </span>
+			</span>
 		</label>
 		<input
 			id="m3u-name"
@@ -122,7 +125,10 @@
 			{#if inputMode === 'url'}
 				<div class="form-control">
 					<label class="label py-1" for="m3u-url">
-						<span class="label-text">{m.livetv_form_m3u_m3uUrlLabel()}</span>
+						<span class="label-text">
+							{m.livetv_form_m3u_m3uUrlLabel()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<div class="relative">
 						<input
@@ -151,7 +157,10 @@
 			{:else if inputMode === 'file'}
 				<div class="form-control">
 					<label class="label py-1" for="m3u-file">
-						<span class="label-text">{m.livetv_form_m3u_uploadFileLabel()}</span>
+						<span class="label-text">
+							{m.livetv_form_m3u_uploadFileLabel()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<input
 						id="m3u-file"

--- a/src/lib/components/livetv/forms/StalkerAccountForm.svelte
+++ b/src/lib/components/livetv/forms/StalkerAccountForm.svelte
@@ -79,7 +79,10 @@
 
 		<div class="form-control">
 			<label class="label py-1" for="stalker-name">
-				<span class="label-text">{m.livetv_form_stalker_nameLabel()}</span>
+				<span class="label-text">
+					{m.livetv_form_stalker_nameLabel()}
+					<span class="text-error">* </span>
+				</span>
 			</label>
 			<input
 				id="stalker-name"
@@ -96,7 +99,10 @@
 
 		<div class="form-control">
 			<label class="label py-1" for="portal-url">
-				<span class="label-text">{m.livetv_form_stalker_portalUrlLabel()}</span>
+				<span class="label-text">
+					{m.livetv_form_stalker_portalUrlLabel()}
+					<span class="text-error">* </span>
+				</span>
 			</label>
 			<div class="relative">
 				<input
@@ -125,7 +131,10 @@
 
 		<div class="form-control">
 			<label class="label py-1" for="mac-address">
-				<span class="label-text">{m.livetv_form_stalker_macAddressLabel()}</span>
+				<span class="label-text">
+					{m.livetv_form_stalker_macAddressLabel()}
+					<span class="text-error">* </span>
+				</span>
 			</label>
 			<div class="relative">
 				<input

--- a/src/lib/components/livetv/forms/XstreamAccountForm.svelte
+++ b/src/lib/components/livetv/forms/XstreamAccountForm.svelte
@@ -63,7 +63,10 @@
 
 		<div class="form-control">
 			<label class="label py-1" for="xstream-name">
-				<span class="label-text">{m.livetv_form_xstream_nameLabel()}</span>
+				<span class="label-text">
+					{m.livetv_form_xstream_nameLabel()}
+					<span class="text-error">* </span>
+				</span>
 			</label>
 			<input
 				id="xstream-name"
@@ -80,7 +83,10 @@
 
 		<div class="form-control">
 			<label class="label py-1" for="base-url">
-				<span class="label-text">{m.livetv_form_xstream_serverUrlLabel()}</span>
+				<span class="label-text">
+					{m.livetv_form_xstream_serverUrlLabel()}
+					<span class="text-error">* </span>
+				</span>
 			</label>
 			<div class="relative">
 				<input
@@ -110,7 +116,10 @@
 		<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-3">
 			<div class="form-control">
 				<label class="label py-1" for="username">
-					<span class="label-text">{m.livetv_form_xstream_usernameLabel()}</span>
+					<span class="label-text">
+						{m.livetv_form_xstream_usernameLabel()}
+						<span class="text-error">* </span>
+					</span>
 				</label>
 				<input
 					id="username"
@@ -126,8 +135,11 @@
 				<label class="label py-1" for="password">
 					<span class="label-text">
 						{m.livetv_form_xstream_passwordLabel()}
+						{#if mode === 'add' || !hasPassword}
+							<span class="text-error">* </span>
+						{/if}
 						{#if mode === 'edit' && hasPassword}
-							<span class="text-xs opacity-50">{m.livetv_form_xstream_passwordKeep()}</span>
+							<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 						{/if}
 					</span>
 				</label>

--- a/src/lib/components/mediaBrowsers/MediaBrowserModal.svelte
+++ b/src/lib/components/mediaBrowsers/MediaBrowserModal.svelte
@@ -6,6 +6,7 @@
 		MediaBrowserPathMapping,
 		MediaBrowserTestResult
 	} from '$lib/server/notifications/mediabrowser/types';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
 	import { SectionHeader, TestResult, ToggleSetting } from '$lib/components/ui/modal';
 	import * as m from '$lib/paraglide/messages.js';
@@ -75,7 +76,7 @@
 	const modalTitle = $derived(
 		mode === 'add' ? m.mediaBrowser_addServer() : m.mediaBrowser_editServer()
 	);
-	const hasApiKey = $derived(!!server?.id); // In edit mode, server has existing API key
+	const hasApiKey = $derived(mode === 'edit' && !!server?.id);
 
 	// Reset form when modal opens or server changes
 	$effect(() => {
@@ -133,7 +134,7 @@
 			name,
 			serverType: serverType as MediaBrowserServerType,
 			host,
-			apiKey,
+			apiKey: isBlankOrRedacted(apiKey?.trim()) ? '' : apiKey.trim(),
 			enabled,
 			onImport,
 			onUpgrade,
@@ -250,7 +251,10 @@
 
 				<div class="form-control">
 					<label class="label py-1" for="name">
-						<span class="label-text">{m.common_name()}</span>
+						<span class="label-text">
+							{m.common_name()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<input
 						id="name"
@@ -276,7 +280,10 @@
 
 				<div class="form-control">
 					<label class="label py-1" for="host">
-						<span class="label-text">{m.mediaBrowser_host()}</span>
+						<span class="label-text">
+							{m.mediaBrowser_host()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<input
 						id="host"
@@ -294,8 +301,11 @@
 					<label class="label py-1" for="apiKey">
 						<span class="label-text">
 							{m.mediaBrowser_apiKey()}
+							{#if mode === 'add' || !hasApiKey}
+								<span class="text-error">* </span>
+							{/if}
 							{#if mode === 'edit' && hasApiKey}
-								<span class="text-xs opacity-50">({m.mediaBrowser_apiKeyKeep()})</span>
+								<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 							{/if}
 						</span>
 					</label>

--- a/src/lib/components/nntpServers/NntpServerModal.svelte
+++ b/src/lib/components/nntpServers/NntpServerModal.svelte
@@ -3,6 +3,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { SectionHeader, TestResult } from '$lib/components/ui/modal';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 
 	interface NntpServer {
 		id: string;
@@ -118,10 +119,7 @@
 			enabled
 		};
 
-		// In edit mode, only include password if user actually typed something new
-		// This prevents accidentally clearing existing passwords
-		if (mode === 'edit' && !password) {
-			// Remove password from payload to preserve existing value
+		if (mode === 'edit' && isBlankOrRedacted(password?.trim())) {
 			delete (data as unknown as Record<string, unknown>).password;
 		}
 
@@ -160,7 +158,10 @@
 
 			<div class="form-control">
 				<label class="label py-1" for="name">
-					<span class="label-text">{m.common_name()}</span>
+					<span class="label-text">
+						{m.common_name()}
+						<span class="text-error">* </span>
+					</span>
 				</label>
 				<input
 					id="name"
@@ -187,7 +188,10 @@
 			<div class="grid grid-cols-2 gap-2 sm:gap-3">
 				<div class="form-control">
 					<label class="label py-1" for="host">
-						<span class="label-text">{m.connection_host_label()}</span>
+						<span class="label-text">
+							{m.connection_host_label()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<input
 						id="host"

--- a/src/lib/components/settings/SettingsTabNav.svelte
+++ b/src/lib/components/settings/SettingsTabNav.svelte
@@ -70,7 +70,7 @@
 	<div class="relative">
 		<div
 			bind:this={navScroller}
-			class="overflow-x-auto px-2 [scrollbar-width:none] sm:px-4 [&::-webkit-scrollbar]:hidden"
+			class="[scrollbar-width:none] overflow-x-auto px-2 sm:px-4 [&::-webkit-scrollbar]:hidden"
 		>
 			<nav class="-mb-px flex min-w-max items-stretch gap-1 sm:gap-4" aria-label={ariaLabel}>
 				{#each navItems as item (item.href)}

--- a/src/lib/components/subtitleProviders/SubtitleProviderModal.svelte
+++ b/src/lib/components/subtitleProviders/SubtitleProviderModal.svelte
@@ -16,6 +16,7 @@
 	import type { ProviderDefinition } from '$lib/server/subtitles/providers/interfaces';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
 	import { SectionHeader, TestResult } from '$lib/components/ui/modal';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 
 	/**
 	 * Get access type info for display
@@ -139,6 +140,7 @@
 	const modalTitle = $derived(
 		mode === 'add' ? m.subtitleProviders_modal_addTitle() : m.subtitleProviders_modal_editTitle()
 	);
+	const hasApiKey = $derived(!!provider?.apiKey);
 	const hasPassword = $derived(!!provider?.password);
 	const selectedDefinition = $derived(
 		implementation ? definitions.find((d) => d.implementation === implementation) : null
@@ -167,7 +169,7 @@
 			name = provider?.name ?? '';
 			enabled = provider?.enabled ?? true;
 			priority = provider?.priority ?? 25;
-			apiKey = provider?.apiKey ?? '';
+			apiKey = '';
 			username = provider?.username ?? '';
 			password = '';
 			requestsPerMinute = provider?.requestsPerMinute ?? 60;
@@ -193,9 +195,9 @@
 			implementation,
 			enabled,
 			priority,
-			apiKey: apiKey || undefined,
+			apiKey: isBlankOrRedacted(apiKey?.trim()) ? undefined : apiKey.trim(),
 			username: username || undefined,
-			password: password || undefined,
+			password: isBlankOrRedacted(password?.trim()) ? undefined : password.trim(),
 			requestsPerMinute
 		};
 	}
@@ -326,7 +328,10 @@
 
 				<div class="form-control">
 					<label class="label py-1" for="name">
-						<span class="label-text">{m.subtitleProviders_modal_name()}</span>
+						<span class="label-text">
+							{m.subtitleProviders_modal_name()}
+							<span class="text-error">* </span>
+						</span>
 					</label>
 					<input
 						id="name"
@@ -403,7 +408,12 @@
 				{#if requiresApiKey}
 					<div class="form-control">
 						<label class="label py-1" for="apiKey">
-							<span class="label-text">{m.subtitleProviders_modal_apiKey()}</span>
+							<span class="label-text">
+								{m.subtitleProviders_modal_apiKey()}
+								{#if mode === 'add' || !hasApiKey}
+									<span class="text-error">* </span>
+								{/if}
+							</span>
 							<span class="badge badge-xs badge-warning"
 								>{m.subtitleProviders_modal_apiKeyRequired()}</span
 							>
@@ -413,7 +423,7 @@
 							type="password"
 							class="input-bordered input input-sm"
 							bind:value={apiKey}
-							placeholder={mode === 'edit' && provider?.apiKey
+							placeholder={mode === 'edit' && hasApiKey
 								? m.subtitleProviders_modal_apiKeyPlaceholderExisting()
 								: m.subtitleProviders_modal_apiKeyPlaceholderNew()}
 						/>
@@ -464,9 +474,7 @@
 								<span class="label-text">
 									{m.subtitleProviders_modal_password()}
 									{#if mode === 'edit' && hasPassword}
-										<span class="text-xs opacity-50"
-											>{m.subtitleProviders_modal_passwordKeep()}</span
-										>
+										<span class="text-xs opacity-50">({m.auth_blankToKeep()})</span>
 									{/if}
 								</span>
 							</label>
@@ -525,7 +533,11 @@
 			<button
 				class="btn btn-ghost"
 				onclick={handleTest}
-				disabled={testing || saving || !name || nameTooLong || (requiresApiKey && !apiKey)}
+				disabled={testing ||
+					saving ||
+					!name ||
+					nameTooLong ||
+					(requiresApiKey && !apiKey.trim() && !(mode === 'edit' && hasApiKey))}
 			>
 				{#if testing}
 					<Loader2 class="h-4 w-4 animate-spin" />
@@ -538,7 +550,10 @@
 			<button
 				class="btn btn-primary"
 				onclick={handleSave}
-				disabled={saving || !name || nameTooLong || (requiresApiKey && !apiKey)}
+				disabled={saving ||
+					!name ||
+					nameTooLong ||
+					(requiresApiKey && !apiKey.trim() && !(mode === 'edit' && hasApiKey))}
 			>
 				{#if saving}
 					<Loader2 class="h-4 w-4 animate-spin" />

--- a/src/lib/server/indexers/settingsSecrets.ts
+++ b/src/lib/server/indexers/settingsSecrets.ts
@@ -1,0 +1,87 @@
+import {
+	isBlankOrRedacted,
+	isSensitiveDefinitionSetting,
+	isSensitiveKeyName,
+	isSensitiveSettingName
+} from '$lib/shared/sensitiveSettings';
+
+interface SensitiveSettingDefinition {
+	name: string;
+	type: string;
+}
+
+function isSensitiveKey(key: string): boolean {
+	return isSensitiveKeyName(key);
+}
+
+function isSensitiveSetting(
+	key: string,
+	definitions?: SensitiveSettingDefinition[] | null
+): boolean {
+	const definition = definitions?.find((setting) => setting.name === key);
+	return definition ? isSensitiveDefinitionSetting(definition) : isSensitiveSettingName(key);
+}
+
+export function redactIndexerSettingsForForm(
+	settings: Record<string, unknown> | null | undefined,
+	definitions?: SensitiveSettingDefinition[] | null
+): Record<string, string> | null {
+	if (!settings) return null;
+
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(settings)) {
+		if (value === undefined || value === null) continue;
+		result[key] = isSensitiveSetting(key, definitions) ? '' : String(value);
+	}
+
+	return Object.keys(result).length > 0 ? result : null;
+}
+
+export function getSensitiveIndexerSettingsPresence(
+	settings: Record<string, unknown> | null | undefined,
+	definitions?: SensitiveSettingDefinition[] | null
+): Record<string, boolean> {
+	const result: Record<string, boolean> = {};
+
+	for (const definition of definitions ?? []) {
+		if (!isSensitiveSetting(definition.name, definitions)) continue;
+		const value = settings?.[definition.name];
+		result[definition.name] = value !== undefined && value !== null && value !== '';
+	}
+
+	if (settings) {
+		for (const [key, value] of Object.entries(settings)) {
+			if (!isSensitiveKey(key)) continue;
+			result[key] = value !== undefined && value !== null && value !== '';
+		}
+	}
+
+	return result;
+}
+
+export function mergeBlankSensitiveIndexerSettings(
+	incoming: Record<string, unknown> | null | undefined,
+	existing: Record<string, unknown> | null | undefined,
+	definitions?: SensitiveSettingDefinition[] | null
+): Record<string, string> {
+	const merged: Record<string, string> = {};
+
+	if (existing) {
+		for (const [key, value] of Object.entries(existing)) {
+			if (value !== undefined && value !== null) {
+				merged[key] = String(value);
+			}
+		}
+	}
+
+	for (const [key, value] of Object.entries(incoming ?? {})) {
+		if (isSensitiveSetting(key, definitions) && isBlankOrRedacted(value)) {
+			continue;
+		}
+		if (value !== undefined && value !== null) {
+			merged[key] = String(value);
+		}
+	}
+
+	return merged;
+}

--- a/src/lib/shared/sensitiveSettings.ts
+++ b/src/lib/shared/sensitiveSettings.ts
@@ -1,0 +1,24 @@
+const SENSITIVE_KEY_PATTERNS = ['key', 'password', 'secret', 'token', 'cookie', 'passkey'];
+const REDACTED_VALUE = '[REDACTED]';
+
+export interface SensitiveSettingLike {
+	name: string;
+	type: string;
+}
+
+export function isSensitiveKeyName(name: string): boolean {
+	const lowerName = name.toLowerCase();
+	return SENSITIVE_KEY_PATTERNS.some((pattern) => lowerName.includes(pattern));
+}
+
+export function isSensitiveSettingName(name: string, type?: string): boolean {
+	return type === 'password' || isSensitiveKeyName(name);
+}
+
+export function isSensitiveDefinitionSetting(setting: SensitiveSettingLike): boolean {
+	return isSensitiveSettingName(setting.name, setting.type);
+}
+
+export function isBlankOrRedacted(value: unknown): boolean {
+	return value === '' || value === null || value === undefined || value === REDACTED_VALUE;
+}

--- a/src/lib/types/indexer.ts
+++ b/src/lib/types/indexer.ts
@@ -137,6 +137,7 @@ export interface Indexer {
 	priority: number;
 	protocol: IndexerProtocol;
 	settings?: Record<string, string> | null;
+	sensitiveSettings?: Record<string, boolean>;
 
 	// Search capability toggles
 	enableAutomaticSearch: boolean;

--- a/src/routes/api/indexers/+server.ts
+++ b/src/routes/api/indexers/+server.ts
@@ -69,5 +69,5 @@ export const POST: RequestHandler = async (event) => {
 		packSeedTime: validated.packSeedTime ?? null
 	});
 
-	return json({ success: true, indexer: created });
+	return json({ success: true, indexer: redactIndexer(created) });
 };

--- a/src/routes/api/indexers/[id]/+server.ts
+++ b/src/routes/api/indexers/[id]/+server.ts
@@ -4,6 +4,7 @@ import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
 import { CINEPHAGE_STREAM_DEFINITION_ID } from '$lib/server/indexers/types';
 import { sanitizeStreamingIndexerSettings } from '$lib/server/streaming/settings';
 import { indexerUpdateSchema } from '$lib/validation/schemas';
+import { mergeBlankSensitiveIndexerSettings } from '$lib/server/indexers/settingsSecrets';
 import { createChildLogger } from '$lib/logging';
 import { assertFound, parseBody } from '$lib/server/api/validate';
 import { NotFoundError } from '$lib/errors';
@@ -56,12 +57,19 @@ export const PUT: RequestHandler = async (event) => {
 	const isStreamingIndexer = existingIndexer.definitionId === CINEPHAGE_STREAM_DEFINITION_ID;
 	const oldBaseUrl = existingIndexer.baseUrl;
 	const newBaseUrl = validated.baseUrl;
+	const definition = manager
+		.getUnifiedDefinitions()
+		.find((d) => d.id === existingIndexer.definitionId);
 	const settings =
 		validated.settings === undefined
 			? undefined
 			: isStreamingIndexer
 				? sanitizeStreamingIndexerSettings(validated.settings as Record<string, unknown> | null)
-				: (validated.settings as Record<string, string> | undefined);
+				: mergeBlankSensitiveIndexerSettings(
+						validated.settings,
+						existingIndexer.settings,
+						definition?.settings
+					);
 
 	try {
 		const updated = await manager.updateIndexer(params.id, {

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
 import { getNewznabCapabilitiesProvider } from '$lib/server/indexers/newznab/NewznabCapabilitiesProvider';
 import { indexerTestSchema } from '$lib/validation/schemas';
+import { mergeBlankSensitiveIndexerSettings } from '$lib/server/indexers/settingsSecrets';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 
 function redactSensitiveDetails(message: string): string {
@@ -169,6 +170,8 @@ export const POST: RequestHandler = async (event) => {
 		);
 	}
 
+	let existingSettings: Record<string, unknown> | undefined;
+
 	// If testing an existing saved indexer from overview, verify it exists
 	// so health tracking updates apply only to real indexers.
 	if (indexerId) {
@@ -182,12 +185,17 @@ export const POST: RequestHandler = async (event) => {
 				{ status: 400 }
 			);
 		}
+		existingSettings = existing.settings;
 	}
 
 	try {
 		// Get protocol from YAML definition
 		const protocol = definition.protocol;
-		const settings = (validated.settings ?? {}) as Record<string, string | number | boolean>;
+		const settings = mergeBlankSensitiveIndexerSettings(
+			validated.settings,
+			existingSettings,
+			definition.settings
+		);
 
 		// Torznab validation uses the canonical caps endpoint.
 		// API key is optional and only included when provided.

--- a/src/routes/settings/integrations/download-clients/+page.svelte
+++ b/src/routes/settings/integrations/download-clients/+page.svelte
@@ -18,6 +18,7 @@
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import { SettingsPage } from '$lib/components/ui/settings';
 	import * as m from '$lib/paraglide/messages.js';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 	import {
 		createDownloadClient,
 		updateDownloadClient,
@@ -255,8 +256,7 @@
 		}
 
 		const dcFormData = formData as DownloadClientFormData;
-		const hasPasswordOverride =
-			typeof dcFormData.password === 'string' && dcFormData.password.trim().length > 0;
+		const hasPasswordOverride = !isBlankOrRedacted(dcFormData.password?.trim());
 		const fallbackId =
 			modalMode === 'edit' && editingClient && !hasPasswordOverride ? editingClient.id : undefined;
 

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -3,6 +3,10 @@ import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
 import { toUIDefinition } from '$lib/server/indexers/loader';
 import { getPersistentStatusTracker } from '$lib/server/indexers/status';
 import { CINEPHAGE_STREAM_DEFINITION_ID } from '$lib/server/indexers/types';
+import {
+	getSensitiveIndexerSettingsPresence,
+	redactIndexerSettingsForForm
+} from '$lib/server/indexers/settingsSecrets';
 import type { IndexerDefinition, IndexerWithStatus } from '$lib/types/indexer';
 
 export const load: PageServerLoad = async () => {
@@ -16,19 +20,9 @@ export const load: PageServerLoad = async () => {
 		)
 	);
 	const statusByIndexerId = new Map(statusEntries);
-
-	const toStringSettings = (
-		settings: Record<string, unknown> | undefined
-	): Record<string, string> | null => {
-		if (!settings) return null;
-		const result: Record<string, string> = {};
-		for (const [key, value] of Object.entries(settings)) {
-			if (value !== undefined && value !== null) {
-				result[key] = String(value);
-			}
-		}
-		return Object.keys(result).length > 0 ? result : null;
-	};
+	const definitionsById = new Map(
+		manager.getUnifiedDefinitions().map((definition) => [definition.id, definition])
+	);
 
 	const getDisplayBaseUrl = (
 		config: (typeof indexerConfigs)[number],
@@ -52,7 +46,12 @@ export const load: PageServerLoad = async () => {
 
 	const indexers: IndexerWithStatus[] = indexerConfigs.map((config) => {
 		const status = statusByIndexerId.get(config.id);
-		const settings = toStringSettings(config.settings);
+		const definition = definitionsById.get(config.definitionId);
+		const settings = redactIndexerSettingsForForm(config.settings, definition?.settings);
+		const sensitiveSettings = getSensitiveIndexerSettingsPresence(
+			config.settings,
+			definition?.settings
+		);
 		const displayBaseUrl = getDisplayBaseUrl(config, settings);
 
 		return {
@@ -65,6 +64,7 @@ export const load: PageServerLoad = async () => {
 			priority: config.priority,
 			protocol: config.protocol,
 			settings,
+			sensitiveSettings,
 			enableAutomaticSearch: config.enableAutomaticSearch,
 			enableInteractiveSearch: config.enableInteractiveSearch,
 			minimumSeeders: config.minimumSeeders,

--- a/src/routes/settings/integrations/media-browsers/+page.svelte
+++ b/src/routes/settings/integrations/media-browsers/+page.svelte
@@ -4,6 +4,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { getResponseErrorMessage } from '$lib/utils/http';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 	import type { PageData } from './$types';
 	import type {
 		MediaBrowserServerPublic,
@@ -205,7 +206,7 @@
 				const payload = await testMediaBrowserNotification(editingServer.id, {
 					host: formData.host,
 					serverType: formData.serverType,
-					apiKey: formData.apiKey?.trim() ? formData.apiKey : undefined,
+					apiKey: isBlankOrRedacted(formData.apiKey?.trim()) ? undefined : formData.apiKey,
 					persist: false
 				});
 				return payload;
@@ -235,7 +236,7 @@
 		saveError = null;
 		try {
 			const payload: Partial<MediaBrowserFormData> = { ...formData };
-			if (modalMode === 'edit' && !payload.apiKey?.trim()) {
+			if (modalMode === 'edit' && isBlankOrRedacted(payload.apiKey?.trim())) {
 				delete payload.apiKey;
 			}
 

--- a/src/routes/settings/integrations/subtitle-providers/+page.svelte
+++ b/src/routes/settings/integrations/subtitle-providers/+page.svelte
@@ -16,6 +16,7 @@
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import { SettingsPage } from '$lib/components/ui/settings';
 	import * as m from '$lib/paraglide/messages.js';
+	import { isBlankOrRedacted } from '$lib/shared/sensitiveSettings';
 	import {
 		createSubtitleProvider,
 		updateSubtitleProvider,
@@ -371,11 +372,21 @@
 		formData: SubtitleProviderFormData
 	): Promise<{ success: boolean; error?: string }> {
 		try {
+			const isEdit = modalMode === 'edit' && !!editingProvider;
+			const existingProvider = isEdit ? editingProvider : null;
+			const resolvedApiKey =
+				existingProvider && isBlankOrRedacted(formData.apiKey?.trim())
+					? existingProvider.apiKey
+					: formData.apiKey;
+			const resolvedPassword =
+				existingProvider && isBlankOrRedacted(formData.password?.trim())
+					? existingProvider.password
+					: formData.password;
 			const result = await testSubtitleProvider({
 				implementation: formData.implementation as SubtitleProviderImplementation,
-				apiKey: formData.apiKey,
+				apiKey: resolvedApiKey,
 				username: formData.username,
-				password: formData.password
+				password: resolvedPassword
 			});
 			return { success: Boolean(result.success), error: result.error };
 		} catch (e) {
@@ -399,6 +410,12 @@
 				implementation: formData.implementation as SubtitleProviderImplementation
 			};
 			if (modalMode === 'edit' && editingProvider) {
+				if (isBlankOrRedacted(typedFormData.apiKey?.trim())) {
+					delete typedFormData.apiKey;
+				}
+				if (isBlankOrRedacted(typedFormData.password?.trim())) {
+					delete typedFormData.password;
+				}
 				await updateSubtitleProvider(editingProvider.id, typedFormData);
 			} else {
 				await createSubtitleProvider(typedFormData);


### PR DESCRIPTION
## Summary

Unifies how secret/sensitive fields (API keys, passwords) are handled across all integration forms. Previously, blank-detection and preserve logic was duplicated and inconsistent across forms. This centralizes that behavior into shared helpers and applies it uniformly, while also fixing a security issue where saved secrets were being returned to the client in plaintext when opening an integration for editing.

## Related Issues

Reported-by: [@T-bond](https://github.com/T-bond) - saved secrets were being returned to the client in plaintext on edit ([MoldyTaint/Cinephage#351](https://github.com/MoldyTaint/Cinephage/pull/351))

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made
- Added `src/lib/shared/sensitiveSettings.ts` with centralized helpers for sensitive field semantics (`isBlankOrRedacted`)
- Applied shared blank-preserve detection across indexers, download clients, NNTP, media browsers, subtitle providers, and Live TV Xstream flows
- Standardized "blank to keep existing" messaging using `m.auth_blankToKeep()` wherever secret preservation is supported
- Hidden the required `*` marker when a saved secret is already present and the field is optional due to preserve behavior
- Fixed subtitle provider modal/page test and save paths to resolve secrets correctly in edit mode without exposing plaintext in UI state
- Removed duplicated ad-hoc blank checks and outdated inline comments

## Areas Affected
- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [x] Subtitles
- [ ] Documentation

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist
- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)