### PR TITLE
fix(settings): resolve smartlist editor client crash and improve duplicate profile-name validation UX

### DIFF
--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -359,5 +359,5 @@ export async function downloadLogos(payload: Record<string, unknown>) {
 }
 
 export async function updateUserLanguage(language: string) {
-	return apiPut('/api/user/language', { language });
+	return apiPost('/api/user/language', { language });
 }

--- a/src/lib/components/profiles/ProfileModal.svelte
+++ b/src/lib/components/profiles/ProfileModal.svelte
@@ -19,6 +19,7 @@
 		defaultCopyFromId?: string;
 		saving?: boolean;
 		error?: string | null;
+		errorHtml?: string | null;
 		onClose: () => void;
 		onSave: (data: ScoringProfileFormData) => void;
 		/** Called when resetting a built-in profile's scores to defaults */
@@ -34,6 +35,7 @@
 		defaultCopyFromId = 'balanced',
 		saving = false,
 		error = null,
+		errorHtml = null,
 		onClose,
 		onSave,
 		onReset
@@ -299,7 +301,11 @@
 
 	{#if error}
 		<div class="mb-4 alert alert-error">
-			<span>{error}</span>
+			{#if errorHtml}
+				<span>{@html errorHtml}</span>
+			{:else}
+				<span>{error}</span>
+			{/if}
 		</div>
 	{/if}
 

--- a/src/lib/components/profiles/ProfileModal.svelte
+++ b/src/lib/components/profiles/ProfileModal.svelte
@@ -19,7 +19,9 @@
 		defaultCopyFromId?: string;
 		saving?: boolean;
 		error?: string | null;
-		errorHtml?: string | null;
+		errorPrefix?: string | null;
+		errorEmphasis?: string | null;
+		errorSuffix?: string | null;
 		onClose: () => void;
 		onSave: (data: ScoringProfileFormData) => void;
 		/** Called when resetting a built-in profile's scores to defaults */
@@ -35,7 +37,9 @@
 		defaultCopyFromId = 'balanced',
 		saving = false,
 		error = null,
-		errorHtml = null,
+		errorPrefix = null,
+		errorEmphasis = null,
+		errorSuffix = null,
 		onClose,
 		onSave,
 		onReset
@@ -301,8 +305,8 @@
 
 	{#if error}
 		<div class="mb-4 alert alert-error">
-			{#if errorHtml}
-				<span>{@html errorHtml}</span>
+			{#if errorPrefix !== null && errorEmphasis !== null && errorSuffix !== null}
+				<span>{errorPrefix}<strong>{errorEmphasis}</strong>{errorSuffix}</span>
 			{:else}
 				<span>{error}</span>
 			{/if}

--- a/src/lib/components/smartlists/NumericRangeFilter.svelte
+++ b/src/lib/components/smartlists/NumericRangeFilter.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { randomUUID } from 'node:crypto';
-
 	interface Props {
 		minLabel: string;
 		maxLabel: string;
@@ -33,7 +31,15 @@
 		onMaxChange
 	}: Props = $props();
 
-	const id = randomUUID().slice(0, 8);
+	function createClientSafeId(): string {
+		if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+			return crypto.randomUUID().slice(0, 8);
+		}
+
+		return Math.random().toString(36).slice(2, 10);
+	}
+
+	const id = createClientSafeId();
 
 	function handleMinInput(e: Event) {
 		const target = e.target as HTMLInputElement;

--- a/src/lib/server/smartlists/SmartListService.ts
+++ b/src/lib/server/smartlists/SmartListService.ts
@@ -127,8 +127,10 @@ export class SmartListService {
 
 		logger.info({ id: result.id, name: result.name }, '[SmartListService] Created smart list');
 
-		// Perform initial refresh
-		await this.refreshSmartList(result.id, 'manual');
+		// Trigger initial refresh in the background so create/edit UX does not block on provider/network latency.
+		void this.refreshSmartList(result.id, 'manual').catch((error) => {
+			logger.error({ err: error, id: result.id }, '[SmartListService] Initial refresh failed');
+		});
 
 		return result;
 	}

--- a/src/routes/api/scoring-profiles/+server.ts
+++ b/src/routes/api/scoring-profiles/+server.ts
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db';
 import { scoringProfiles } from '$lib/server/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq, ne, sql } from 'drizzle-orm';
 import { DEFAULT_PROFILES, getProfile, isBuiltInProfile } from '$lib/server/scoring';
 import { qualityFilter } from '$lib/server/quality';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
@@ -16,6 +16,25 @@ import {
 } from '$lib/validation/schemas.js';
 
 const BUILT_IN_IDS = DEFAULT_PROFILES.map((p) => p.id);
+
+function normalizeProfileName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+async function findProfileByNameCaseInsensitive(name: string, excludeId?: string) {
+	const normalized = normalizeProfileName(name);
+	const whereClause = excludeId
+		? and(sql`lower(${scoringProfiles.name}) = ${normalized}`, ne(scoringProfiles.id, excludeId))
+		: sql`lower(${scoringProfiles.name}) = ${normalized}`;
+
+	const existing = await db
+		.select({ id: scoringProfiles.id, name: scoringProfiles.name })
+		.from(scoringProfiles)
+		.where(whereClause)
+		.limit(1);
+
+	return existing[0] ?? null;
+}
 
 export const GET: RequestHandler = async () => {
 	const dbProfiles = await db.select().from(scoringProfiles);
@@ -85,6 +104,10 @@ export const POST: RequestHandler = async (event) => {
 
 	const { request } = event;
 	const data = await parseBody(request, scoringProfileCreateSchema);
+	const duplicateByName = await findProfileByNameCaseInsensitive(data.name);
+	if (duplicateByName) {
+		return json({ error: `Profile with name '${data.name}' already exists` }, { status: 409 });
+	}
 
 	if (data.id) {
 		if (BUILT_IN_IDS.includes(data.id)) {
@@ -234,6 +257,16 @@ export const PUT: RequestHandler = async (event) => {
 
 	if (existing.length === 0) {
 		throw new NotFoundError('Profile', id);
+	}
+
+	if (updateData.name !== undefined) {
+		const duplicateByName = await findProfileByNameCaseInsensitive(updateData.name, id);
+		if (duplicateByName) {
+			return json(
+				{ error: `Profile with name '${updateData.name}' already exists` },
+				{ status: 409 }
+			);
+		}
 	}
 
 	if (updateData.isDefault) {

--- a/src/routes/api/user/language/+server.ts
+++ b/src/routes/api/user/language/+server.ts
@@ -50,3 +50,5 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json({ success: false, error: 'Failed to update language preference' }, { status: 500 });
 	}
 };
+
+export const PUT: RequestHandler = POST;

--- a/src/routes/settings/quality/+page.svelte
+++ b/src/routes/settings/quality/+page.svelte
@@ -44,6 +44,16 @@
 	let selectedProfile = $state<ScoringProfile | null>(null);
 	let profileSaving = $state(false);
 	let profileError = $state<string | null>(null);
+	let profileErrorHtml = $state<string | null>(null);
+
+	function escapeHtml(value: string): string {
+		return value
+			.replaceAll('&', '&amp;')
+			.replaceAll('<', '&lt;')
+			.replaceAll('>', '&gt;')
+			.replaceAll('"', '&quot;')
+			.replaceAll("'", '&#39;');
+	}
 
 	// Profile delete confirmation
 	let profileDeleteConfirmOpen = $state(false);
@@ -53,6 +63,7 @@
 		profileModalMode = 'add';
 		selectedProfile = null;
 		profileError = null;
+		profileErrorHtml = null;
 		profileModalOpen = true;
 	}
 
@@ -60,6 +71,7 @@
 		profileModalMode = 'edit';
 		selectedProfile = profile;
 		profileError = null;
+		profileErrorHtml = null;
 		profileModalOpen = true;
 	}
 
@@ -67,11 +79,13 @@
 		profileModalOpen = false;
 		selectedProfile = null;
 		profileError = null;
+		profileErrorHtml = null;
 	}
 
 	async function handleProfileSave(formData: ScoringProfileFormData) {
 		profileSaving = true;
 		profileError = null;
+		profileErrorHtml = null;
 
 		try {
 			if (profileModalMode === 'add') {
@@ -86,6 +100,11 @@
 			closeProfileModal();
 		} catch (e) {
 			profileError = e instanceof Error ? e.message : 'An unexpected error occurred';
+			const duplicateMatch = profileError.match(/^Profile with name '(.+)' already exists$/);
+			if (duplicateMatch) {
+				const profileName = escapeHtml(duplicateMatch[1] ?? '');
+				profileErrorHtml = `Profile with name '<strong>${profileName}</strong>' already exists`;
+			}
 		} finally {
 			profileSaving = false;
 		}
@@ -287,6 +306,7 @@
 	defaultCopyFromId={data.defaultProfileId}
 	saving={profileSaving}
 	error={profileError}
+	errorHtml={profileErrorHtml}
 	onClose={closeProfileModal}
 	onSave={handleProfileSave}
 	onReset={handleProfileReset}

--- a/src/routes/settings/quality/+page.svelte
+++ b/src/routes/settings/quality/+page.svelte
@@ -44,16 +44,9 @@
 	let selectedProfile = $state<ScoringProfile | null>(null);
 	let profileSaving = $state(false);
 	let profileError = $state<string | null>(null);
-	let profileErrorHtml = $state<string | null>(null);
-
-	function escapeHtml(value: string): string {
-		return value
-			.replaceAll('&', '&amp;')
-			.replaceAll('<', '&lt;')
-			.replaceAll('>', '&gt;')
-			.replaceAll('"', '&quot;')
-			.replaceAll("'", '&#39;');
-	}
+	let profileErrorPrefix = $state<string | null>(null);
+	let profileErrorEmphasis = $state<string | null>(null);
+	let profileErrorSuffix = $state<string | null>(null);
 
 	// Profile delete confirmation
 	let profileDeleteConfirmOpen = $state(false);
@@ -63,7 +56,9 @@
 		profileModalMode = 'add';
 		selectedProfile = null;
 		profileError = null;
-		profileErrorHtml = null;
+		profileErrorPrefix = null;
+		profileErrorEmphasis = null;
+		profileErrorSuffix = null;
 		profileModalOpen = true;
 	}
 
@@ -71,7 +66,9 @@
 		profileModalMode = 'edit';
 		selectedProfile = profile;
 		profileError = null;
-		profileErrorHtml = null;
+		profileErrorPrefix = null;
+		profileErrorEmphasis = null;
+		profileErrorSuffix = null;
 		profileModalOpen = true;
 	}
 
@@ -79,13 +76,17 @@
 		profileModalOpen = false;
 		selectedProfile = null;
 		profileError = null;
-		profileErrorHtml = null;
+		profileErrorPrefix = null;
+		profileErrorEmphasis = null;
+		profileErrorSuffix = null;
 	}
 
 	async function handleProfileSave(formData: ScoringProfileFormData) {
 		profileSaving = true;
 		profileError = null;
-		profileErrorHtml = null;
+		profileErrorPrefix = null;
+		profileErrorEmphasis = null;
+		profileErrorSuffix = null;
 
 		try {
 			if (profileModalMode === 'add') {
@@ -102,8 +103,9 @@
 			profileError = e instanceof Error ? e.message : 'An unexpected error occurred';
 			const duplicateMatch = profileError.match(/^Profile with name '(.+)' already exists$/);
 			if (duplicateMatch) {
-				const profileName = escapeHtml(duplicateMatch[1] ?? '');
-				profileErrorHtml = `Profile with name '<strong>${profileName}</strong>' already exists`;
+				profileErrorPrefix = "Profile with name '";
+				profileErrorEmphasis = duplicateMatch[1] ?? '';
+				profileErrorSuffix = "' already exists";
 			}
 		} finally {
 			profileSaving = false;
@@ -306,7 +308,9 @@
 	defaultCopyFromId={data.defaultProfileId}
 	saving={profileSaving}
 	error={profileError}
-	errorHtml={profileErrorHtml}
+	errorPrefix={profileErrorPrefix}
+	errorEmphasis={profileErrorEmphasis}
+	errorSuffix={profileErrorSuffix}
 	onClose={closeProfileModal}
 	onSave={handleProfileSave}
 	onReset={handleProfileReset}


### PR DESCRIPTION
## Summary
Fixes a client-side crash in the smartlist editor, resolves a display-language update flow regression, and improves duplicate quality profile name validation with proper conflict responses and visible UI feedback.

## Related Issues
<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made
- Fixed smartlist editor crash on `/smartlists/new` and `/smartlists/[id]/edit` by replacing `node:crypto` with a browser-safe ID generator in `NumericRangeFilter`
- Made initial smartlist refresh non-blocking in `SmartListService` (background refresh with error logging) to prevent UX stalls on create/edit
- Fixed display-language update flow by aligning client/server HTTP method handling for `/api/user/language` (client now uses `POST`; server accepts `PUT` as alias for compatibility)
- Added case-insensitive duplicate name checks on quality profile create and update in `/api/scoring-profiles`
- Returns `409` conflict responses for duplicate profile names instead of a generic 500
- Improved profile modal error visibility with a highlighted message showing the conflicting profile name in bold

## Areas Affected
- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist
- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)