### PR TITLE
refactor(credits): use const for movie and tv credits filtering

### DIFF
--- a/src/routes/api/tmdb/person/[id]/credits/+server.ts
+++ b/src/routes/api/tmdb/person/[id]/credits/+server.ts
@@ -49,8 +49,8 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 
 		// Batch mode: return all types in one response
 		if (!type) {
-			let movieCredits = sortedCast.filter((c) => c.media_type === 'movie');
-			let tvCredits = sortedCast.filter((c) => c.media_type === 'tv');
+			const movieCredits = sortedCast.filter((c) => c.media_type === 'movie');
+			const tvCredits = sortedCast.filter((c) => c.media_type === 'tv');
 
 			const filteredMovies = await filterBlockedMedia(movieCredits, 'movie');
 			const filteredTv = await filterBlockedMedia(tvCredits, 'tv');


### PR DESCRIPTION
## Summary
Improves code quality and type safety by changing variable declarations from `let` to `const` where variables are never reassigned.

## Related Issues
*None*

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made
- Changed `movieCredits` and `tvCredits` from `let` to `const` inside the `GET` request handler within `src/routes/api/tmdb/person/[id]/credits/+server.ts`.

## Areas Affected
- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist
- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`refactor(credits): ...`)
- [ ] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [x] Documentation updated (if applicable)

## Screenshots
*None (No UI changes)*