### PR TITLE
feat(root-folders,naming,library): scan filters, rename fixes, and folder path correction UI

### DIFF
--- a/src/lib/components/library/FolderBrowser.svelte
+++ b/src/lib/components/library/FolderBrowser.svelte
@@ -131,13 +131,11 @@
 	</div>
 
 	<!-- Footer with actions -->
-	<div
-		class="flex flex-col gap-2 border-t border-base-300 bg-base-200 p-3 sm:flex-row sm:items-center sm:justify-between"
-	>
+	<div class="flex flex-col gap-2 border-t border-base-300 bg-base-200 p-3">
 		<div class="text-sm text-base-content/60">
 			{m.library_folderBrowser_hint()}
 		</div>
-		<div class="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row">
+		<div class="flex justify-end gap-2">
 			<button type="button" class="btn btn-ghost btn-sm" onclick={onCancel}>
 				{m.action_cancel()}
 			</button>

--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -213,6 +213,11 @@
 	);
 
 	const folderPathChanged = $derived(folderPath.trim() !== (movie.path ?? '').trim());
+	const resolvedFolderPath = $derived(
+		selectedRootFolderObj?.path && folderPath.trim()
+			? `${selectedRootFolderObj.path}/${folderPath.trim()}`
+			: null
+	);
 
 	function handleSave() {
 		onSave({
@@ -400,9 +405,12 @@
 							<FolderOpen class="h-4 w-4" />
 						</button>
 					</div>
+					{#if resolvedFolderPath}
+						<p class="mt-1 font-mono text-xs text-base-content/50">{resolvedFolderPath}</p>
+					{/if}
 					<p class="mt-1 text-xs text-base-content/60">
-						Folder name relative to the root folder. Edit only if the name on disk no longer matches
-						— saving will update the database and trigger a rescan to re-link existing files.
+						Folder name relative to the root folder. Edit only if the name on disk no longer
+						matches; saving will update the database and trigger a rescan to re-link existing files.
 					</p>
 					{#if folderPathChanged}
 						<p class="mt-1 text-xs text-warning">

--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { X } from 'lucide-svelte';
+	import { X, FolderOpen } from 'lucide-svelte';
+	import { FolderBrowser } from '$lib/components/library';
 	import type { LibraryMovie } from '$lib/types/library';
 	import { ModalWrapper, ModalFooter } from '$lib/components/ui/modal';
 	import { FormCheckbox } from '$lib/components/ui/form';
@@ -46,6 +47,7 @@
 		minimumAvailability: string;
 		wantsSubtitles: boolean;
 		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
+		folderPath?: string;
 	}
 
 	let { open, movie, qualityProfiles, rootFolders, saving, onClose, onSave }: Props = $props();
@@ -59,6 +61,8 @@
 	let metadataProvider = $state<'auto' | 'tmdb' | 'anilist' | 'mal'>('auto');
 	let moveFilesOnRootChange = $state(false);
 	let moveOptionTouched = $state(false);
+	let folderPath = $state('');
+	let showFolderPicker = $state(false);
 	let animeRootWarningShown = $state(false);
 	let enforceAnimeSubtype = $state(false);
 	let detectedAnime = $state(false);
@@ -133,6 +137,7 @@
 			animeRootWarningShown = false;
 			enforceAnimeSubtype = false;
 			detectedAnime = false;
+			folderPath = movie.path ?? '';
 			void loadAnimeRoutingContext(movie.tmdbId);
 		}
 	});
@@ -207,6 +212,8 @@
 		qualityProfiles.find((p) => p.id === qualityProfileId) ?? defaultProfile
 	);
 
+	const folderPathChanged = $derived(folderPath.trim() !== (movie.path ?? '').trim());
+
 	function handleSave() {
 		onSave({
 			monitored,
@@ -215,7 +222,8 @@
 			moveFilesOnRootChange,
 			minimumAvailability,
 			wantsSubtitles,
-			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto'
+			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto',
+			...(folderPathChanged && folderPath.trim() ? { folderPath: folderPath.trim() } : {})
 		});
 	}
 </script>
@@ -264,7 +272,7 @@
 				<select
 					id="movie-metadata-provider"
 					bind:value={metadataProvider}
-					class="select-bordered select w-full"
+					class="select-bordered select select-sm w-full"
 				>
 					<option value="auto">Auto (inherit from library)</option>
 					<option value="tmdb">TMDB</option>
@@ -282,7 +290,7 @@
 			<select
 				id="movie-quality-profile"
 				bind:value={qualityProfileId}
-				class="select-bordered select w-full"
+				class="select-bordered select select-sm w-full"
 			>
 				<option value=""
 					>{m.library_movies_profileDefault({
@@ -312,7 +320,7 @@
 			<select
 				id="movie-root-folder"
 				bind:value={rootFolderId}
-				class="select-bordered select w-full"
+				class="select-bordered select select-sm w-full"
 			>
 				{#if !rootFolderId}
 					<option value="" disabled>{m.common_notSet()}</option>
@@ -356,6 +364,55 @@
 			/>
 		{/if}
 
+		<!-- Folder path correction -->
+		{#if movie.path}
+			<div class="form-control">
+				<label class="label" for="movie-folder-path">
+					<span class="label-text font-medium">Folder name</span>
+				</label>
+				{#if showFolderPicker}
+					<FolderBrowser
+						value={selectedRootFolderObj?.path ?? '/'}
+						onSelect={(selected) => {
+							const root = selectedRootFolderObj?.path ?? '';
+							folderPath =
+								root && selected.startsWith(root + '/')
+									? selected.slice(root.length + 1)
+									: selected;
+							showFolderPicker = false;
+						}}
+						onCancel={() => (showFolderPicker = false)}
+					/>
+				{:else}
+					<div class="join w-full">
+						<input
+							id="movie-folder-path"
+							type="text"
+							class="input-bordered input input-sm join-item flex-1 font-mono"
+							bind:value={folderPath}
+						/>
+						<button
+							type="button"
+							class="btn join-item border border-base-300 btn-ghost btn-sm"
+							onclick={() => (showFolderPicker = true)}
+							title="Browse folders"
+						>
+							<FolderOpen class="h-4 w-4" />
+						</button>
+					</div>
+					<p class="mt-1 text-xs text-base-content/60">
+						Folder name relative to the root folder. Edit only if the name on disk no longer matches
+						— saving will update the database and trigger a rescan to re-link existing files.
+					</p>
+					{#if folderPathChanged}
+						<p class="mt-1 text-xs text-warning">
+							Folder name changed. A rescan will run automatically after saving.
+						</p>
+					{/if}
+				{/if}
+			</div>
+		{/if}
+
 		<!-- Minimum Availability -->
 		<div class="form-control">
 			<label class="label" for="movie-min-availability">
@@ -364,7 +421,7 @@
 			<select
 				id="movie-min-availability"
 				bind:value={minimumAvailability}
-				class="select-bordered select w-full"
+				class="select-bordered select select-sm w-full"
 			>
 				{#each availabilityOptions as option (option.value)}
 					<option value={option.value}>{option.label}</option>

--- a/src/lib/components/library/RenamePreviewModal.svelte
+++ b/src/lib/components/library/RenamePreviewModal.svelte
@@ -56,6 +56,8 @@
 				? await getMovieRenamePreview(mediaId)
 				: await getSeriesRenamePreview(mediaId)) as unknown as RenamePreviewResult | null;
 
+			preview = previewResult;
+
 			// Auto-select all "will change" items
 			selectedIds.clear();
 			for (const item of previewResult?.willChange || []) {

--- a/src/lib/components/library/SeriesEditModal.svelte
+++ b/src/lib/components/library/SeriesEditModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { X } from 'lucide-svelte';
+	import { X, FolderOpen } from 'lucide-svelte';
+	import { FolderBrowser } from '$lib/components/library';
 	import { ModalWrapper, ModalFooter } from '$lib/components/ui/modal';
 	import { FormCheckbox } from '$lib/components/ui/form';
 	import { sortRootFoldersForMediaType } from '$lib/utils/root-folders.js';
@@ -23,6 +24,7 @@
 		wantsSubtitles: boolean | null;
 		seriesType: string | null;
 		metadataProvider?: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
+		path?: string | null;
 	}
 
 	interface QualityProfileOption {
@@ -61,6 +63,7 @@
 		wantsSubtitles: boolean;
 		seriesType: 'standard' | 'anime' | 'daily';
 		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
+		folderPath?: string;
 	}
 
 	let { open, series, qualityProfiles, rootFolders, saving, onClose, onSave }: Props = $props();
@@ -75,6 +78,8 @@
 	let metadataProvider = $state<'auto' | 'tmdb' | 'anilist' | 'mal'>('auto');
 	let moveFilesOnRootChange = $state(false);
 	let moveOptionTouched = $state(false);
+	let folderPath = $state('');
+	let showFolderPicker = $state(false);
 	let animeRootWarningShown = $state(false);
 	let enforceAnimeSubtype = $state(false);
 	let detectedAnime = $state(false);
@@ -177,6 +182,7 @@
 			animeRootWarningShown = false;
 			enforceAnimeSubtype = false;
 			detectedAnime = false;
+			folderPath = series.path ?? '';
 			void loadAnimeRoutingContext(series.tmdbId);
 		}
 	});
@@ -228,6 +234,8 @@
 		qualityProfiles.find((p) => p.id === qualityProfileId) ?? defaultProfile
 	);
 
+	const folderPathChanged = $derived(folderPath.trim() !== (series.path ?? '').trim());
+
 	function handleSave() {
 		onSave({
 			monitored,
@@ -237,7 +245,8 @@
 			seasonFolder,
 			wantsSubtitles,
 			seriesType,
-			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto'
+			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto',
+			...(folderPathChanged && folderPath.trim() ? { folderPath: folderPath.trim() } : {})
 		});
 	}
 </script>
@@ -291,7 +300,11 @@
 			<label class="label" for="series-type">
 				<span class="label-text font-medium">{m.library_seriesEdit_seriesType()}</span>
 			</label>
-			<select id="series-type" bind:value={seriesType} class="select-bordered select w-full">
+			<select
+				id="series-type"
+				bind:value={seriesType}
+				class="select-bordered select select-sm w-full"
+			>
 				{#each seriesTypeOptions as option (option.value)}
 					<option value={option.value}>{option.label}</option>
 				{/each}
@@ -312,7 +325,7 @@
 				<select
 					id="series-metadata-provider"
 					bind:value={metadataProvider}
-					class="select-bordered select w-full"
+					class="select-bordered select select-sm w-full"
 				>
 					<option value="auto">Auto (inherit from library)</option>
 					<option value="tmdb">TMDB</option>
@@ -330,7 +343,7 @@
 			<select
 				id="series-quality-profile"
 				bind:value={qualityProfileId}
-				class="select-bordered select w-full"
+				class="select-bordered select select-sm w-full"
 			>
 				<option value="">{defaultProfile?.name ?? m.common_default()} ({m.common_default()})</option
 				>
@@ -357,7 +370,7 @@
 			<select
 				id="series-root-folder"
 				bind:value={rootFolderId}
-				class="select-bordered select w-full"
+				class="select-bordered select select-sm w-full"
 			>
 				{#if !rootFolderId}
 					<option value="" disabled>{m.common_notSet()}</option>
@@ -399,6 +412,55 @@
 				variant="toggle"
 				color="warning"
 			/>
+		{/if}
+
+		<!-- Folder path correction -->
+		{#if series.path}
+			<div class="form-control">
+				<label class="label" for="series-folder-path">
+					<span class="label-text font-medium">Folder name</span>
+				</label>
+				{#if showFolderPicker}
+					<FolderBrowser
+						value={selectedRootFolderObj?.path ?? '/'}
+						onSelect={(selected) => {
+							const root = selectedRootFolderObj?.path ?? '';
+							folderPath =
+								root && selected.startsWith(root + '/')
+									? selected.slice(root.length + 1)
+									: selected;
+							showFolderPicker = false;
+						}}
+						onCancel={() => (showFolderPicker = false)}
+					/>
+				{:else}
+					<div class="join w-full">
+						<input
+							id="series-folder-path"
+							type="text"
+							class="input-bordered input input-sm join-item flex-1 font-mono"
+							bind:value={folderPath}
+						/>
+						<button
+							type="button"
+							class="btn join-item border border-base-300 btn-ghost btn-sm"
+							onclick={() => (showFolderPicker = true)}
+							title="Browse folders"
+						>
+							<FolderOpen class="h-4 w-4" />
+						</button>
+					</div>
+					<p class="mt-1 text-xs text-base-content/60">
+						Folder name relative to the root folder. Edit only if the name on disk no longer matches
+						— saving will update the database and trigger a rescan to re-link existing files.
+					</p>
+					{#if folderPathChanged}
+						<p class="mt-1 text-xs text-warning">
+							Folder name changed. A rescan will run automatically after saving.
+						</p>
+					{/if}
+				{/if}
+			</div>
 		{/if}
 	</div>
 

--- a/src/lib/components/library/SeriesEditModal.svelte
+++ b/src/lib/components/library/SeriesEditModal.svelte
@@ -235,6 +235,11 @@
 	);
 
 	const folderPathChanged = $derived(folderPath.trim() !== (series.path ?? '').trim());
+	const resolvedFolderPath = $derived(
+		selectedRootFolderObj?.path && folderPath.trim()
+			? `${selectedRootFolderObj.path}/${folderPath.trim()}`
+			: null
+	);
 
 	function handleSave() {
 		onSave({
@@ -450,9 +455,12 @@
 							<FolderOpen class="h-4 w-4" />
 						</button>
 					</div>
+					{#if resolvedFolderPath}
+						<p class="mt-1 font-mono text-xs text-base-content/50">{resolvedFolderPath}</p>
+					{/if}
 					<p class="mt-1 text-xs text-base-content/60">
-						Folder name relative to the root folder. Edit only if the name on disk no longer matches
-						— saving will update the database and trigger a rescan to re-link existing files.
+						Folder name relative to the root folder. Edit only if the name on disk no longer
+						matches; saving will update the database and trigger a rescan to re-link existing files.
 					</p>
 					{#if folderPathChanged}
 						<p class="mt-1 text-xs text-warning">

--- a/src/lib/components/rootFolders/RootFolderModal.svelte
+++ b/src/lib/components/rootFolders/RootFolderModal.svelte
@@ -10,6 +10,7 @@
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
 	import ModalHeader from '$lib/components/ui/modal/ModalHeader.svelte';
 	import ModalFooter from '$lib/components/ui/modal/ModalFooter.svelte';
+	import TagInput from '$lib/components/ui/TagInput.svelte';
 
 	interface Props {
 		open: boolean;
@@ -50,6 +51,8 @@
 	let readOnly = $state(false);
 	let preserveSymlinks = $state(false);
 	let defaultMonitored = $state(true);
+	let skipFolderPatterns = $state<string[]>([]);
+	let blockedVideoExtensions = $state<string[]>([]);
 
 	// UI state
 	let validating = $state(false);
@@ -77,6 +80,8 @@
 			readOnly = folder?.readOnly ?? false;
 			preserveSymlinks = folder?.preserveSymlinks ?? false;
 			defaultMonitored = folder?.defaultMonitored ?? true;
+			skipFolderPatterns = folder?.skipFolderPatterns ?? [];
+			blockedVideoExtensions = folder?.blockedVideoExtensions ?? [];
 			validationResult = null;
 			showFolderBrowser = false;
 		}
@@ -91,7 +96,9 @@
 			isDefault,
 			readOnly,
 			preserveSymlinks,
-			defaultMonitored
+			defaultMonitored,
+			skipFolderPatterns,
+			blockedVideoExtensions
 		};
 	}
 
@@ -258,6 +265,26 @@
 					<Info class="h-3.5 w-3.5 shrink-0 text-base-content/50" aria-hidden="true" />
 				</button>
 			</label>
+
+			<div class="divider my-1 text-xs text-base-content/40">Scan Filters</div>
+
+			<TagInput
+				bind:values={skipFolderPatterns}
+				label="Skip Folder Patterns"
+				placeholder="e.g. backdrops"
+				hint="Folder names to ignore during scan (case-insensitive). Common Jellyfin artifacts: backdrops, extrafanart, .actors"
+			/>
+
+			<TagInput
+				bind:values={blockedVideoExtensions}
+				label="Blocked Video Extensions"
+				placeholder="e.g. .webm"
+				hint="Video file extensions to exclude from import scanning (e.g. .webm, .mp4)."
+				normalize={(v) => {
+					const t = v.trim().toLowerCase();
+					return t.startsWith('.') ? t : `.${t}`;
+				}}
+			/>
 
 			{#if preserveSymlinks}
 				<div class="alert alert-info">

--- a/src/lib/components/ui/TagInput.svelte
+++ b/src/lib/components/ui/TagInput.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import { X } from 'lucide-svelte';
+
+	interface Props {
+		values: string[];
+		placeholder?: string;
+		label?: string;
+		hint?: string;
+		normalize?: (v: string) => string;
+	}
+
+	let {
+		values = $bindable([]),
+		placeholder = 'Add and press Enter',
+		label = '',
+		hint = '',
+		normalize = (v) => v.trim()
+	}: Props = $props();
+
+	let input = $state('');
+
+	function add() {
+		if (!input.trim()) {
+			input = '';
+			return;
+		}
+		const normalized = normalize(input);
+		if (!normalized || values.includes(normalized)) {
+			input = '';
+			return;
+		}
+		values = [...values, normalized];
+		input = '';
+	}
+
+	function remove(index: number) {
+		values = values.filter((_, i) => i !== index);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			add();
+		} else if (e.key === 'Backspace' && input === '' && values.length > 0) {
+			values = values.slice(0, -1);
+		}
+	}
+</script>
+
+<div class="form-control">
+	{#if label}
+		<div class="label py-1">
+			<span class="label-text">{label}</span>
+		</div>
+	{/if}
+
+	<!--
+		.input.input-sm gives DaisyUI's native border + :focus-within outline (same colour
+		as every other field). Height is overridden inline so tags can wrap; width is left
+		to DaisyUI's built-in clamp(3rem,20rem,100%) so it matches sibling inputs.
+		The inner <input> gets outline-none so only the wrapper's focus ring is visible.
+	-->
+	<!-- Outer div acts as the compound input wrapper.
+		 Mirrors layout.css's global :focus rule — border-color → transparent, outline → none,
+		 inset box-shadow with --color-primary — applied via :focus-within since the div
+		 itself is never directly focused (only the inner <input> is). -->
+	<div
+		class="input input-sm flex flex-wrap items-center gap-1 focus-within:border-transparent focus-within:[outline:none] focus-within:[box-shadow:inset_0_0_0_2px_var(--color-primary,oklch(var(--p)))]"
+		style="height: auto; min-height: var(--size, 2rem); padding-block: 0.25rem;"
+	>
+		{#each values as tag, i (tag)}
+			<span class="badge badge-neutral gap-1 shrink-0 text-xs">
+				{tag}
+				<button
+					type="button"
+					class="hover:text-error"
+					onclick={() => remove(i)}
+					aria-label="Remove {tag}"
+				>
+					<X class="h-3 w-3" />
+				</button>
+			</span>
+		{/each}
+		<!-- outline suppressed via inline style so browser UA and DaisyUI's :where rule
+		     both lose to the highest-specificity rule, leaving only the outer ring visible. -->
+		<input
+			type="text"
+			class="min-w-24 flex-1 bg-transparent text-sm"
+			style="height: auto; width: auto; outline: none;"
+			{placeholder}
+			bind:value={input}
+			onkeydown={handleKeydown}
+			onblur={add}
+		/>
+	</div>
+
+	{#if hint}
+		<p class="mt-1 text-xs text-base-content/60">{hint}</p>
+	{/if}
+</div>

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -1,4 +1,5 @@
 // Core UI components
+export { default as TagInput } from './TagInput.svelte';
 export { default as Toasts } from './Toasts.svelte';
 export { default as TmdbConfigRequired } from './TmdbConfigRequired.svelte';
 export { default as ThemeSelector } from './ThemeSelector.svelte';

--- a/src/lib/server/db/migrations/088-add-root-folder-scan-filters.ts
+++ b/src/lib/server/db/migrations/088-add-root-folder-scan-filters.ts
@@ -1,0 +1,27 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+import { columnExists } from '../migration-helpers.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'system' as const });
+
+export const migration_v088: MigrationDefinition = {
+	version: 88,
+	name: 'add_root_folder_scan_filters',
+	apply: (sqlite) => {
+		if (!columnExists(sqlite, 'root_folders', 'skip_folder_patterns')) {
+			sqlite
+				.prepare(`ALTER TABLE "root_folders" ADD COLUMN "skip_folder_patterns" text DEFAULT NULL`)
+				.run();
+			logger.info('[Migration v088] Added skip_folder_patterns column to root_folders');
+		}
+
+		if (!columnExists(sqlite, 'root_folders', 'blocked_video_extensions')) {
+			sqlite
+				.prepare(
+					`ALTER TABLE "root_folders" ADD COLUMN "blocked_video_extensions" text DEFAULT NULL`
+				)
+				.run();
+			logger.info('[Migration v088] Added blocked_video_extensions column to root_folders');
+		}
+	}
+};

--- a/src/lib/server/db/migrations/index.ts
+++ b/src/lib/server/db/migrations/index.ts
@@ -85,6 +85,7 @@ import { migration_v084 } from './084-add-release-date-columns.js';
 import { migration_v085 } from './085-add-metadata-provider-columns.js';
 import { migration_v086 } from './086-add-movie-metadata-provider-columns.js';
 import { migration_v087 } from './087-add-blocked-media-table.js';
+import { migration_v088 } from './088-add-root-folder-scan-filters.js';
 
 export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v002,
@@ -172,5 +173,6 @@ export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v084,
 	migration_v085,
 	migration_v086,
-	migration_v087
+	migration_v087,
+	migration_v088
 ];

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -586,6 +586,10 @@ export const rootFolders = sqliteTable('root_folders', {
 	freeSpaceBytes: integer('free_space_bytes'),
 	// Last time free space was checked
 	lastCheckedAt: text('last_checked_at'),
+	// JSON string[] — folder names to skip during disk scan (case-insensitive exact match)
+	skipFolderPatterns: text('skip_folder_patterns'),
+	// JSON string[] — video file extensions to exclude from scan (e.g. [".webm"])
+	blockedVideoExtensions: text('blocked_video_extensions'),
 	createdAt: text('created_at').$defaultFn(() => new Date().toISOString())
 });
 

--- a/src/lib/server/downloadClients/RootFolderService.ts
+++ b/src/lib/server/downloadClients/RootFolderService.ts
@@ -44,6 +44,8 @@ export interface RootFolderInput {
 	readOnly?: boolean;
 	preserveSymlinks?: boolean;
 	defaultMonitored?: boolean;
+	skipFolderPatterns?: string[];
+	blockedVideoExtensions?: string[];
 }
 
 export interface DeleteRootFolderResult {
@@ -163,7 +165,15 @@ export class RootFolderService {
 			defaultMonitored: input.defaultMonitored ?? true,
 			freeSpaceBytes: input.readOnly ? null : validation.freeSpaceBytes,
 			lastCheckedAt: now,
-			createdAt: now
+			createdAt: now,
+			skipFolderPatterns:
+				input.skipFolderPatterns && input.skipFolderPatterns.length > 0
+					? JSON.stringify(input.skipFolderPatterns)
+					: null,
+			blockedVideoExtensions:
+				input.blockedVideoExtensions && input.blockedVideoExtensions.length > 0
+					? JSON.stringify(input.blockedVideoExtensions)
+					: null
 		});
 
 		logger.info(
@@ -255,6 +265,14 @@ export class RootFolderService {
 			updateData.preserveSymlinks = updates.preserveSymlinks;
 		if (updates.defaultMonitored !== undefined)
 			updateData.defaultMonitored = updates.defaultMonitored;
+		if (updates.skipFolderPatterns !== undefined)
+			updateData.skipFolderPatterns =
+				updates.skipFolderPatterns.length > 0 ? JSON.stringify(updates.skipFolderPatterns) : null;
+		if (updates.blockedVideoExtensions !== undefined)
+			updateData.blockedVideoExtensions =
+				updates.blockedVideoExtensions.length > 0
+					? JSON.stringify(updates.blockedVideoExtensions)
+					: null;
 
 		await db.update(rootFoldersTable).set(updateData).where(eq(rootFoldersTable.id, id));
 
@@ -625,7 +643,13 @@ export class RootFolderService {
 			freeSpaceFormatted,
 			accessible,
 			lastCheckedAt: row.lastCheckedAt ?? undefined,
-			createdAt: row.createdAt ?? undefined
+			createdAt: row.createdAt ?? undefined,
+			skipFolderPatterns: row.skipFolderPatterns
+				? (JSON.parse(row.skipFolderPatterns) as string[])
+				: [],
+			blockedVideoExtensions: row.blockedVideoExtensions
+				? (JSON.parse(row.blockedVideoExtensions) as string[])
+				: []
 		};
 	}
 

--- a/src/lib/server/library/disk-scan.ts
+++ b/src/lib/server/library/disk-scan.ts
@@ -143,18 +143,34 @@ export class DiskScanService extends EventEmitter {
 		return this.currentScanId;
 	}
 
-	private shouldExcludeFolder(folderName: string): boolean {
-		return EXCLUDED_PATTERNS.excludedFolders.some((pattern) => pattern.test(folderName));
+	private shouldExcludeFolder(folderName: string, customPatterns: string[] = []): boolean {
+		if (EXCLUDED_PATTERNS.excludedFolders.some((pattern) => pattern.test(folderName))) {
+			return true;
+		}
+		const lower = folderName.toLowerCase();
+		return customPatterns.some((p) => p.toLowerCase() === lower);
 	}
 
-	private shouldExcludeFile(fileName: string, filePath: string): boolean {
+	private shouldExcludeFile(
+		fileName: string,
+		filePath: string,
+		customPatterns: string[] = [],
+		blockedExtensions: string[] = []
+	): boolean {
 		if (EXCLUDED_PATTERNS.samples.some((pattern) => pattern.test(fileName))) {
 			return true;
 		}
 
+		if (blockedExtensions.length > 0) {
+			const ext = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
+			if (blockedExtensions.includes(ext)) {
+				return true;
+			}
+		}
+
 		const pathParts = filePath.split('/');
 		for (const part of pathParts) {
-			if (this.shouldExcludeFolder(part)) {
+			if (this.shouldExcludeFolder(part, customPatterns)) {
 				return true;
 			}
 		}
@@ -164,7 +180,9 @@ export class DiskScanService extends EventEmitter {
 
 	private async discoverFiles(
 		rootPath: string,
-		currentPath: string = rootPath
+		currentPath: string = rootPath,
+		customPatterns: string[] = [],
+		blockedExtensions: string[] = []
 	): Promise<DiscoveredFile[]> {
 		const files: DiscoveredFile[] = [];
 
@@ -175,11 +193,16 @@ export class DiskScanService extends EventEmitter {
 				const fullPath = join(currentPath, entry.name);
 
 				if (entry.isDirectory()) {
-					if (this.shouldExcludeFolder(entry.name)) {
+					if (this.shouldExcludeFolder(entry.name, customPatterns)) {
 						continue;
 					}
 
-					const subFiles = await this.discoverFiles(rootPath, fullPath);
+					const subFiles = await this.discoverFiles(
+						rootPath,
+						fullPath,
+						customPatterns,
+						blockedExtensions
+					);
 					files.push(...subFiles);
 				} else if (entry.isFile()) {
 					if (!isVideoFile(entry.name)) {
@@ -187,7 +210,7 @@ export class DiskScanService extends EventEmitter {
 					}
 
 					const relativePath = relative(rootPath, fullPath);
-					if (this.shouldExcludeFile(entry.name, relativePath)) {
+					if (this.shouldExcludeFile(entry.name, relativePath, customPatterns, blockedExtensions)) {
 						continue;
 					}
 
@@ -220,7 +243,7 @@ export class DiskScanService extends EventEmitter {
 					}
 
 					const relativePath = relative(rootPath, fullPath);
-					if (this.shouldExcludeFile(entry.name, relativePath)) {
+					if (this.shouldExcludeFile(entry.name, relativePath, customPatterns, blockedExtensions)) {
 						continue;
 					}
 
@@ -307,7 +330,19 @@ export class DiskScanService extends EventEmitter {
 			this.emit('progress', progress);
 			await this.assertNoRootFolderOverlap(rootFolderId, rootFolder.path);
 
-			const discoveredFiles = await this.discoverFiles(rootFolder.path);
+			const customPatterns = rootFolder.skipFolderPatterns
+				? (JSON.parse(rootFolder.skipFolderPatterns) as string[])
+				: [];
+			const blockedExtensions = rootFolder.blockedVideoExtensions
+				? (JSON.parse(rootFolder.blockedVideoExtensions) as string[])
+				: [];
+
+			const discoveredFiles = await this.discoverFiles(
+				rootFolder.path,
+				rootFolder.path,
+				customPatterns,
+				blockedExtensions
+			);
 			progress.filesFound = discoveredFiles.length;
 			progress.phase = 'processing';
 			this.emit('progress', progress);

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -476,21 +476,26 @@ export class RenamePreviewService {
 
 					// Verify source exists before renaming folder
 					const dirExisted = await fileExists(actualOldFolder);
-					if (dirExisted && actualOldFolder !== actualNewFolder) {
-						await rename(actualOldFolder, actualNewFolder);
-					}
+					const folderRenamed =
+						dirExisted && actualOldFolder !== actualNewFolder
+							? (await rename(actualOldFolder, actualNewFolder), true)
+							: false;
 
-					// Update db
-					if (firstItem.mediaType === 'movie') {
-						db.update(movies)
-							.set({ path: firstItem.newParentPath })
-							.where(eq(movies.id, mediaId))
-							.run();
-					} else {
-						db.update(series)
-							.set({ path: firstItem.newParentPath })
-							.where(eq(series.id, mediaId))
-							.run();
+					// Only update the DB path when the folder was actually renamed on disk.
+					// Updating unconditionally would cause all episodes to appear missing on
+					// the next scan if the source folder didn't exist or the rename failed.
+					if (folderRenamed || actualOldFolder === actualNewFolder) {
+						if (firstItem.mediaType === 'movie') {
+							db.update(movies)
+								.set({ path: firstItem.newParentPath })
+								.where(eq(movies.id, mediaId))
+								.run();
+						} else {
+							db.update(series)
+								.set({ path: firstItem.newParentPath })
+								.where(eq(series.id, mediaId))
+								.run();
+						}
 					}
 
 					if (dirExisted) {

--- a/src/lib/types/downloadClient.ts
+++ b/src/lib/types/downloadClient.ts
@@ -125,6 +125,10 @@ export interface RootFolder {
 	readOnly: boolean;
 	preserveSymlinks: boolean;
 	defaultMonitored: boolean;
+	/** Folder names to skip during disk scan (case-insensitive exact match) */
+	skipFolderPatterns: string[];
+	/** Video file extensions to exclude from scan (e.g. ".webm") */
+	blockedVideoExtensions: string[];
 	freeSpaceBytes?: number | null;
 	totalSpaceBytes?: number | null;
 	freeSpaceFormatted?: string;
@@ -168,6 +172,8 @@ export interface RootFolderFormData {
 	readOnly?: boolean;
 	preserveSymlinks?: boolean;
 	defaultMonitored?: boolean;
+	skipFolderPatterns?: string[];
+	blockedVideoExtensions?: string[];
 }
 
 /**

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1404,7 +1404,16 @@ export const movieUpdateSchema = z.object({
 	rootFolderId: z.string().optional(),
 	moveFilesOnRootChange: z.boolean().optional(),
 	wantsSubtitles: z.boolean().optional(),
-	languageProfileId: z.string().nullable().optional()
+	languageProfileId: z.string().nullable().optional(),
+	/** Relative folder name within the root folder (e.g. "Brokenwood Mysteries"). Used to
+	 *  correct a drifted DB path without touching files on disk. */
+	folderPath: z
+		.string()
+		.min(1)
+		.refine((v) => !v.includes('..') && !v.startsWith('/'), {
+			message: 'Folder path must be a relative name with no path traversal'
+		})
+		.optional()
 });
 
 /**
@@ -1419,7 +1428,15 @@ export const seriesUpdateSchema = z.object({
 	providerRefs: z.partialRecord(z.enum(['tmdb', 'anilist', 'mal']), z.string().min(1)).optional(),
 	rootFolderId: z.string().optional(),
 	wantsSubtitles: z.boolean().optional(),
-	languageProfileId: z.string().nullable().optional()
+	languageProfileId: z.string().nullable().optional(),
+	/** Relative folder name within the root folder. Used to correct a drifted DB path. */
+	folderPath: z
+		.string()
+		.min(1)
+		.refine((v) => !v.includes('..') && !v.startsWith('/'), {
+			message: 'Folder path must be a relative name with no path traversal'
+		})
+		.optional()
 });
 
 /**

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -545,7 +545,17 @@ export const rootFolderCreateSchema = z.object({
 	isDefault: z.boolean().default(false),
 	readOnly: z.boolean().default(false),
 	preserveSymlinks: z.boolean().default(false),
-	defaultMonitored: z.boolean().default(true)
+	defaultMonitored: z.boolean().default(true),
+	skipFolderPatterns: z.array(z.string().min(1).max(200)).default([]),
+	blockedVideoExtensions: z
+		.array(
+			z
+				.string()
+				.min(1)
+				.max(20)
+				.transform((v) => (v.startsWith('.') ? v.toLowerCase() : `.${v.toLowerCase()}`))
+		)
+		.default([])
 });
 
 /**

--- a/src/routes/api/library/movies/[id]/+server.ts
+++ b/src/routes/api/library/movies/[id]/+server.ts
@@ -1,5 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
+import { stat } from 'node:fs/promises';
+import { join, resolve, normalize } from 'node:path';
 import { db } from '$lib/server/db/index.js';
 import {
 	downloadHistory,
@@ -335,7 +337,33 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		updateData.languageProfileId = languageProfileId;
 	}
 	if (folderPath !== undefined) {
-		updateData.path = folderPath.trim();
+		const trimmed = folderPath.trim();
+		if (currentMovie?.rootFolderId) {
+			const [rootFolder] = await db
+				.select({ path: rootFolders.path })
+				.from(rootFolders)
+				.where(eq(rootFolders.id, currentMovie.rootFolderId))
+				.limit(1);
+			if (!rootFolder) {
+				return json({ success: false, error: 'Root folder not found' }, { status: 400 });
+			}
+			const resolved = normalize(join(rootFolder.path, trimmed));
+			if (!resolved.startsWith(normalize(rootFolder.path) + '/')) {
+				return json(
+					{ success: false, error: 'Folder must be within the root folder' },
+					{ status: 400 }
+				);
+			}
+			try {
+				await stat(resolved);
+			} catch {
+				return json(
+					{ success: false, error: `Folder does not exist on disk: ${resolve(resolved)}` },
+					{ status: 400 }
+				);
+			}
+		}
+		updateData.path = trimmed;
 	}
 
 	if (Object.keys(updateData).length === 0 && !moveRequest) {

--- a/src/routes/api/library/movies/[id]/+server.ts
+++ b/src/routes/api/library/movies/[id]/+server.ts
@@ -29,6 +29,7 @@ import {
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { mediaMoveService } from '$lib/server/library/MediaMoveService.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
+import { getLibraryScheduler } from '$lib/server/library/library-scheduler.js';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
 import { buildMetadataProviderRegistry } from '$lib/server/metadata/provider-registry.js';
@@ -211,7 +212,8 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		rootFolderId,
 		moveFilesOnRootChange,
 		wantsSubtitles,
-		languageProfileId
+		languageProfileId,
+		folderPath
 	} = body;
 
 	// Capture current state before update (for subtitle trigger detection)
@@ -332,6 +334,9 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	if (languageProfileId !== undefined) {
 		updateData.languageProfileId = languageProfileId;
 	}
+	if (folderPath !== undefined) {
+		updateData.path = folderPath.trim();
+	}
 
 	if (Object.keys(updateData).length === 0 && !moveRequest) {
 		return json({ success: false, error: 'No valid fields to update' }, { status: 400 });
@@ -390,6 +395,12 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	}
 
 	libraryMediaEvents.emitMovieUpdated(params.id);
+
+	// When the folder path was corrected, queue a rescan of the root folder so
+	// the scanner re-links files at the new path without any manual intervention.
+	if (folderPath !== undefined && currentMovie?.rootFolderId) {
+		getLibraryScheduler().queueFolderScan(currentMovie.rootFolderId);
+	}
 
 	return json({
 		success: true,

--- a/src/routes/api/library/series/[id]/+server.ts
+++ b/src/routes/api/library/series/[id]/+server.ts
@@ -1,5 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
+import { stat } from 'node:fs/promises';
+import { join, resolve, normalize } from 'node:path';
 import { db } from '$lib/server/db/index.js';
 import {
 	series,
@@ -354,7 +356,33 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 			updateData.languageProfileId = languageProfileId;
 		}
 		if (folderPath !== undefined) {
-			updateData.path = folderPath.trim();
+			const trimmed = folderPath.trim();
+			if (currentSeries?.rootFolderId) {
+				const [rootFolder] = await db
+					.select({ path: rootFolders.path })
+					.from(rootFolders)
+					.where(eq(rootFolders.id, currentSeries.rootFolderId))
+					.limit(1);
+				if (!rootFolder) {
+					return json({ success: false, error: 'Root folder not found' }, { status: 400 });
+				}
+				const resolved = normalize(join(rootFolder.path, trimmed));
+				if (!resolved.startsWith(normalize(rootFolder.path) + '/')) {
+					return json(
+						{ success: false, error: 'Folder must be within the root folder' },
+						{ status: 400 }
+					);
+				}
+				try {
+					await stat(resolved);
+				} catch {
+					return json(
+						{ success: false, error: `Folder does not exist on disk: ${resolve(resolved)}` },
+						{ status: 400 }
+					);
+				}
+			}
+			updateData.path = trimmed;
 		}
 
 		if (Object.keys(updateData).length === 0 && !moveRequest) {

--- a/src/routes/api/library/series/[id]/+server.ts
+++ b/src/routes/api/library/series/[id]/+server.ts
@@ -27,6 +27,7 @@ import {
 } from '$lib/server/library/LibraryAddService.js';
 import { mediaMoveService } from '$lib/server/library/MediaMoveService.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
+import { getLibraryScheduler } from '$lib/server/library/library-scheduler.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { seriesUpdateSchema } from '$lib/validation/schemas.js';
 import { tmdb } from '$lib/server/tmdb.js';
@@ -222,7 +223,8 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 			providerRefs,
 			rootFolderId,
 			wantsSubtitles,
-			languageProfileId
+			languageProfileId,
+			folderPath
 		} = body;
 		const moveFilesOnRootChange = rawBody.moveFilesOnRootChange;
 
@@ -351,6 +353,9 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		if (languageProfileId !== undefined) {
 			updateData.languageProfileId = languageProfileId;
 		}
+		if (folderPath !== undefined) {
+			updateData.path = folderPath.trim();
+		}
 
 		if (Object.keys(updateData).length === 0 && !moveRequest) {
 			return json({ success: false, error: 'No valid fields to update' }, { status: 400 });
@@ -451,6 +456,10 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		}
 
 		libraryMediaEvents.emitSeriesUpdated(params.id);
+
+		if (folderPath !== undefined && currentSeries?.rootFolderId) {
+			getLibraryScheduler().queueFolderScan(currentSeries.rootFolderId);
+		}
 
 		return json({
 			success: true,

--- a/src/routes/api/rename/preview/+server.ts
+++ b/src/routes/api/rename/preview/+server.ts
@@ -54,7 +54,7 @@ export const GET: RequestHandler = async (event) => {
 			};
 		}
 
-		return json(result);
+		return json({ success: true, ...result });
 	} catch (error) {
 		logger.error(
 			{

--- a/src/routes/api/rename/preview/movie/[id]/+server.ts
+++ b/src/routes/api/rename/preview/movie/[id]/+server.ts
@@ -30,7 +30,7 @@ export const GET: RequestHandler = async (event) => {
 		const service = new RenamePreviewService();
 		const result = await service.previewMovie(id);
 
-		return json(result);
+		return json({ success: true, ...result });
 	} catch (error) {
 		logger.error(
 			{

--- a/src/routes/api/rename/preview/series/[id]/+server.ts
+++ b/src/routes/api/rename/preview/series/[id]/+server.ts
@@ -30,7 +30,7 @@ export const GET: RequestHandler = async (event) => {
 		const service = new RenamePreviewService();
 		const result = await service.previewSeries(id);
 
-		return json(result);
+		return json({ success: true, ...result });
 	} catch (error) {
 		logger.error(
 			{

--- a/src/routes/api/root-folders/+server.ts
+++ b/src/routes/api/root-folders/+server.ts
@@ -36,7 +36,9 @@ export const POST: RequestHandler = async (event) => {
 		isDefault: validated.isDefault,
 		readOnly: validated.readOnly,
 		preserveSymlinks: validated.preserveSymlinks,
-		defaultMonitored: validated.defaultMonitored
+		defaultMonitored: validated.defaultMonitored,
+		skipFolderPatterns: validated.skipFolderPatterns,
+		blockedVideoExtensions: validated.blockedVideoExtensions
 	});
 
 	return json({ success: true, folder: created });


### PR DESCRIPTION
## Summary

Three related improvements: configurable scan filters per root folder to suppress media server artifacts, a fix for the rename flow's DB/disk path drift bug, and a new in-UI folder path correction field so users can recover from drift without CLI access.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- **Root folder scan filters (migration v088):** Two new per-root-folder settings persisted as JSON in new `skip_folder_patterns` and `blocked_video_extensions` columns. Skip patterns perform case-insensitive exact matching against folder names during recursive scan (e.g. `backdrops`, `extrafanart`, `.actors` ; common Jellyfin artifacts not covered by the existing hard-coded exclusions). The extension blocklist excludes specific video file types from import scanning (e.g. `.webm` backdrop videos). Both are configurable via tag-chip inputs in the root folder modal under a new "Scan Filters" section.
- **Rename preview always failed:** The bulk rename plan page checked `!result.success` on a `RenamePreviewResult` that has no `success` field; always throwing. The per-series/movie rename modal fetched the preview result but never assigned it to the `preview` state variable, leaving the list permanently empty. Fixed by adding `success: true` to all three preview endpoints and assigning the result in the modal.
- **DB path drift on failed folder rename:** `RenamePreviewService.executeRenames` updated `series.path` / `movies.path` unconditionally after attempting a folder rename. If the source folder didn't exist on disk the rename was skipped but the DB was still overwritten; causing all episodes to appear missing on the next scan and triggering mass re-downloads. The DB update is now gated on the rename actually succeeding on disk.
- **Folder path correction in edit modals:** Added a **Folder name** field to both the movie and series edit modals, showing the current relative folder name with a folder browser picker (opens at the root folder path). On save, the API validates the resolved path exists on disk and is within the root folder before writing, then queues an automatic rescan to re-link existing files; no CLI or manual scan step needed to recover from drift.

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

<img width="832" height="965" alt="image" src="https://github.com/user-attachments/assets/9a3d426f-02e8-43d8-8c29-d25d8edcd91d" />
