### PR TITLE
feat: manual import UX overhaul, episode parsing fixes, and absolute episode matching

### DIFF
--- a/src/lib/api/library.ts
+++ b/src/lib/api/library.ts
@@ -84,7 +84,7 @@ export async function getUnmatchedItems() {
 }
 
 export async function matchUnmatched(id: string, payload: UnmatchedSingleMatch) {
-	return apiPost('/api/library/unmatched/match', { id, ...payload });
+	return apiPost('/api/library/unmatched/match', { fileIds: [id], ...payload });
 }
 
 export async function autoSearchMovie(movieId: string) {

--- a/src/lib/components/library/MatchFileModal.svelte
+++ b/src/lib/components/library/MatchFileModal.svelte
@@ -100,8 +100,10 @@
 			} else {
 				toasts.error(m.library_matchFile_failedToMatch(), { description: result.error });
 			}
-		} catch {
-			toasts.error(m.library_matchFile_errorMatching());
+		} catch (err) {
+			const description =
+				err instanceof Error ? err.message : m.library_matchFile_errorMatching();
+			toasts.error(m.library_matchFile_errorMatching(), { description });
 		} finally {
 			isMatching = false;
 		}
@@ -136,8 +138,10 @@
 			} else {
 				toasts.error(m.library_matchFile_failedToMatch(), { description: result.error });
 			}
-		} catch {
-			toasts.error(m.library_matchFile_errorMatching());
+		} catch (err) {
+			const description =
+				err instanceof Error ? err.message : m.library_matchFile_errorMatching();
+			toasts.error(m.library_matchFile_errorMatching(), { description });
 		} finally {
 			isMatching = false;
 		}

--- a/src/lib/components/library/MatchFileModal.svelte
+++ b/src/lib/components/library/MatchFileModal.svelte
@@ -101,8 +101,7 @@
 				toasts.error(m.library_matchFile_failedToMatch(), { description: result.error });
 			}
 		} catch (err) {
-			const description =
-				err instanceof Error ? err.message : m.library_matchFile_errorMatching();
+			const description = err instanceof Error ? err.message : m.library_matchFile_errorMatching();
 			toasts.error(m.library_matchFile_errorMatching(), { description });
 		} finally {
 			isMatching = false;
@@ -139,8 +138,7 @@
 				toasts.error(m.library_matchFile_failedToMatch(), { description: result.error });
 			}
 		} catch (err) {
-			const description =
-				err instanceof Error ? err.message : m.library_matchFile_errorMatching();
+			const description = err instanceof Error ? err.message : m.library_matchFile_errorMatching();
 			toasts.error(m.library_matchFile_errorMatching(), { description });
 		} finally {
 			isMatching = false;

--- a/src/lib/components/library/MatchFolderModal.svelte
+++ b/src/lib/components/library/MatchFolderModal.svelte
@@ -37,6 +37,7 @@
 	let isMatching = $state(false);
 	let selectedMedia = $state<TmdbSearchResult | null>(null);
 	let matchPreview = $state<Array<{ file: string; season?: number; episode?: number }>>([]);
+	let seasonOverride = $state<number | null>(null);
 
 	// Reset state when folder changes
 	$effect(() => {
@@ -46,6 +47,7 @@
 			selectedMedia = null;
 			searchResults = [];
 			matchPreview = [];
+			seasonOverride = null;
 		}
 	});
 
@@ -62,6 +64,10 @@
 			});
 		}
 	});
+
+	const hasMissingSeasons = $derived(
+		searchType === 'tv' && matchPreview.some((item) => item.season === undefined)
+	);
 
 	// Search TMDB
 	async function search() {
@@ -106,7 +112,8 @@
 			const result = (await batchUnmatchedMatch({
 				fileIds,
 				tmdbId: selectedMedia.id,
-				mediaType: searchType
+				mediaType: searchType,
+				...(seasonOverride !== null ? { season: seasonOverride } : {})
 			})) as unknown as {
 				success: boolean;
 				data: { matched: number; failed: number };
@@ -207,6 +214,30 @@
 				<button class="btn btn-ghost btn-sm" onclick={backToSearch}> {m.action_change()} </button>
 			</div>
 
+			<!-- Season override for TV shows with unparsed seasons -->
+			{#if hasMissingSeasons}
+				<div class="rounded-lg border border-warning/40 bg-warning/10 p-3">
+					<p class="mb-2 text-sm font-medium text-warning-content">
+						Season number could not be parsed from the filenames. Specify it below to match all files correctly.
+					</p>
+					<div class="flex items-center gap-3">
+						<label class="flex items-center gap-2 text-sm">
+							Season
+							<input
+								type="number"
+								min="0"
+								class="input input-bordered input-sm w-20"
+								placeholder="1"
+								bind:value={seasonOverride}
+							/>
+						</label>
+						{#if seasonOverride !== null}
+							<span class="text-xs text-base-content/60">Will be applied to all files without a parsed season.</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
 			<!-- Match Preview -->
 			<div>
 				<p class="mb-2 text-sm font-medium">
@@ -214,12 +245,15 @@
 				</p>
 				<div class="max-h-48 space-y-1 overflow-y-auto rounded-lg bg-base-200 p-2">
 					{#each matchPreview.slice(0, 10) as item, index (`${item.file}-${index}`)}
+						{@const resolvedSeason = item.season ?? (seasonOverride !== null ? seasonOverride : undefined)}
 						<div class="flex items-center justify-between rounded bg-base-300/50 px-2 py-1 text-sm">
 							<span class="flex-1 truncate" title={item.file}>{item.file}</span>
-							{#if item.season !== undefined && item.episode !== undefined}
-								<span class="ml-2 badge shrink-0 badge-sm badge-secondary">
-									S{String(item.season).padStart(2, '0')}E{String(item.episode).padStart(2, '0')}
+							{#if resolvedSeason !== undefined && item.episode !== undefined}
+								<span class="ml-2 badge shrink-0 badge-sm {item.season === undefined ? 'badge-warning' : 'badge-secondary'}">
+									S{String(resolvedSeason).padStart(2, '0')}E{String(item.episode).padStart(2, '0')}
 								</span>
+							{:else if resolvedSeason === undefined && item.episode !== undefined}
+								<span class="ml-2 badge shrink-0 badge-sm badge-error">No season</span>
 							{/if}
 						</div>
 					{/each}
@@ -236,7 +270,11 @@
 				<button class="btn btn-ghost" onclick={backToSearch} disabled={isMatching}>
 					{m.action_back()}
 				</button>
-				<button class="btn btn-primary" onclick={matchFolder} disabled={isMatching}>
+				<button
+					class="btn btn-primary"
+					onclick={matchFolder}
+					disabled={isMatching || (hasMissingSeasons && seasonOverride === null)}
+				>
 					{#if isMatching}
 						<Loader2 class="h-4 w-4 animate-spin" />
 					{:else}

--- a/src/lib/components/library/MatchFolderModal.svelte
+++ b/src/lib/components/library/MatchFolderModal.svelte
@@ -218,7 +218,8 @@
 			{#if hasMissingSeasons}
 				<div class="rounded-lg border border-warning/40 bg-warning/10 p-3">
 					<p class="mb-2 text-sm font-medium text-warning-content">
-						Season number could not be parsed from the filenames. Specify it below to match all files correctly.
+						Season number could not be parsed from the filenames. Specify it below to match all
+						files correctly.
 					</p>
 					<div class="flex items-center gap-3">
 						<label class="flex items-center gap-2 text-sm">
@@ -232,7 +233,9 @@
 							/>
 						</label>
 						{#if seasonOverride !== null}
-							<span class="text-xs text-base-content/60">Will be applied to all files without a parsed season.</span>
+							<span class="text-xs text-base-content/60"
+								>Will be applied to all files without a parsed season.</span
+							>
 						{/if}
 					</div>
 				</div>
@@ -245,11 +248,16 @@
 				</p>
 				<div class="max-h-48 space-y-1 overflow-y-auto rounded-lg bg-base-200 p-2">
 					{#each matchPreview.slice(0, 10) as item, index (`${item.file}-${index}`)}
-						{@const resolvedSeason = item.season ?? (seasonOverride !== null ? seasonOverride : undefined)}
+						{@const resolvedSeason =
+							item.season ?? (seasonOverride !== null ? seasonOverride : undefined)}
 						<div class="flex items-center justify-between rounded bg-base-300/50 px-2 py-1 text-sm">
 							<span class="flex-1 truncate" title={item.file}>{item.file}</span>
 							{#if resolvedSeason !== undefined && item.episode !== undefined}
-								<span class="ml-2 badge shrink-0 badge-sm {item.season === undefined ? 'badge-warning' : 'badge-secondary'}">
+								<span
+									class="ml-2 badge shrink-0 badge-sm {item.season === undefined
+										? 'badge-warning'
+										: 'badge-secondary'}"
+								>
 									S{String(resolvedSeason).padStart(2, '0')}E{String(item.episode).padStart(2, '0')}
 								</span>
 							{:else if resolvedSeason === undefined && item.episode !== undefined}

--- a/src/lib/components/library/import/DetectionGroupList.svelte
+++ b/src/lib/components/library/import/DetectionGroupList.svelte
@@ -20,6 +20,7 @@
 		importedGroupIds = [],
 		skippedGroupIds = [],
 		pendingGroupCount = 0,
+		readyGroupCount = 0,
 		remainingGroupCount = 0,
 		skippedGroupCount = 0,
 		skipActionsEnabled = false,
@@ -34,7 +35,7 @@
 		getDetectedSeasonsLabel = (_section: DetectionSection) => '',
 		canApplySelectedMatchToSeason = (_season: TvSeasonSection) => false,
 		getGroupEpisodeInfo = (_group: DetectionGroup) =>
-			null as { season: number; episode: number } | null,
+			null as { season: number; episode: number; title?: string } | null,
 		onSwitchGroup = (_id: string) => {},
 		onSkipGroup = (_id: string) => {},
 		onUnskipGroup = (_id: string) => {},
@@ -58,6 +59,7 @@
 		importedGroupIds: string[];
 		skippedGroupIds: string[];
 		pendingGroupCount: number;
+		readyGroupCount: number;
 		remainingGroupCount: number;
 		skippedGroupCount: number;
 		skipActionsEnabled: boolean;
@@ -71,7 +73,11 @@
 		isSeasonSectionFullySkipped: (season: TvSeasonSection) => boolean;
 		getDetectedSeasonsLabel: (section: DetectionSection) => string;
 		canApplySelectedMatchToSeason: (season: TvSeasonSection) => boolean;
-		getGroupEpisodeInfo: (group: DetectionGroup) => { season: number; episode: number } | null;
+		getGroupEpisodeInfo: (group: DetectionGroup) => {
+			season: number;
+			episode: number;
+			title?: string;
+		} | null;
 		onSwitchGroup: (id: string) => void;
 		onSkipGroup: (id: string) => void;
 		onUnskipGroup: (id: string) => void;
@@ -147,6 +153,7 @@
 					class="btn join-item btn-sm {detectedGroupFilter === 'pending'
 						? 'btn-primary'
 						: 'btn-ghost'}"
+					disabled={pendingGroupCount === 0}
 					onclick={() => (detectedGroupFilter = 'pending')}
 				>
 					{m.library_import_filterNeedsInput()}
@@ -156,6 +163,7 @@
 					class="btn join-item btn-sm {detectedGroupFilter === 'ready'
 						? 'btn-primary'
 						: 'btn-ghost'}"
+					disabled={readyGroupCount === 0}
 					onclick={() => (detectedGroupFilter = 'ready')}
 				>
 					{m.library_import_filterReady()}
@@ -165,6 +173,7 @@
 					class="btn join-item btn-sm {detectedGroupFilter === 'skipped'
 						? 'btn-primary'
 						: 'btn-ghost'}"
+					disabled={skippedGroupCount === 0}
 					onclick={() => (detectedGroupFilter = 'skipped')}
 				>
 					{m.library_import_filterSkipped()}
@@ -174,6 +183,7 @@
 					class="btn join-item btn-sm {detectedGroupFilter === 'imported'
 						? 'btn-primary'
 						: 'btn-ghost'}"
+					disabled={importedGroupIds.length === 0}
 					onclick={() => (detectedGroupFilter = 'imported')}
 				>
 					{m.library_import_filterImported()}
@@ -403,23 +413,25 @@
 											})}
 										</div>
 										<div class="flex flex-wrap items-center gap-2">
-											<button
-												type="button"
-												class="btn btn-ghost btn-xs"
-												disabled={!canApplySelectedMatchToSeason(activeReviewSeasonSection)}
-												onclick={() => onApplyMatchToSeason(activeReviewSeasonSection)}
-											>
-												{m.library_import_applyMatchToSeason()}
-											</button>
-											<button
-												type="button"
-												class="btn btn-ghost btn-xs"
-												onclick={() => onToggleSeasonSkipped(activeReviewSeasonSection)}
-											>
-												{isSeasonSectionFullySkipped(activeReviewSeasonSection)
-													? m.library_import_selectSeason()
-													: m.library_import_skipSeason()}
-											</button>
+											{#if !lockedMediaType}
+												<button
+													type="button"
+													class="btn btn-ghost btn-xs"
+													disabled={!canApplySelectedMatchToSeason(activeReviewSeasonSection)}
+													onclick={() => onApplyMatchToSeason(activeReviewSeasonSection)}
+												>
+													{m.library_import_applyMatchToSeason()}
+												</button>
+												<button
+													type="button"
+													class="btn btn-ghost btn-xs"
+													onclick={() => onToggleSeasonSkipped(activeReviewSeasonSection)}
+												>
+													{isSeasonSectionFullySkipped(activeReviewSeasonSection)
+														? m.library_import_selectSeason()
+														: m.library_import_skipSeason()}
+												</button>
+											{/if}
 										</div>
 									</div>
 								{/if}
@@ -461,9 +473,16 @@
 														<span class="text-warning">{m.library_import_needsInput()}</span>
 													{/if}
 													{#if episodeInfo}
-														<span class="badge badge-primary badge-outline badge-xs font-mono font-bold text-base-content border-primary">
+														<span
+															class="badge badge-primary badge-outline badge-xs font-mono font-bold text-base-content border-primary"
+														>
 															{formatEpisodePill(episodeInfo)}
 														</span>
+														{#if episodeInfo.title}
+															<span class="max-w-48 truncate italic">
+																{episodeInfo.title}
+															</span>
+														{/if}
 													{/if}
 												</div>
 											</button>

--- a/src/lib/components/library/import/DetectionGroupList.svelte
+++ b/src/lib/components/library/import/DetectionGroupList.svelte
@@ -32,6 +32,8 @@
 		isSeasonSectionFullySkipped = (_season: TvSeasonSection) => false,
 		getDetectedSeasonsLabel = (_section: DetectionSection) => '',
 		canApplySelectedMatchToSeason = (_season: TvSeasonSection) => false,
+		getGroupEpisodeInfo = (_group: DetectionGroup) =>
+			null as { season: number; episode: number } | null,
 		onSwitchGroup = (_id: string) => {},
 		onSkipGroup = (_id: string) => {},
 		onUnskipGroup = (_id: string) => {},
@@ -67,6 +69,7 @@
 		isSeasonSectionFullySkipped: (season: TvSeasonSection) => boolean;
 		getDetectedSeasonsLabel: (section: DetectionSection) => string;
 		canApplySelectedMatchToSeason: (season: TvSeasonSection) => boolean;
+		getGroupEpisodeInfo: (group: DetectionGroup) => { season: number; episode: number } | null;
 		onSwitchGroup: (id: string) => void;
 		onSkipGroup: (id: string) => void;
 		onUnskipGroup: (id: string) => void;
@@ -79,6 +82,10 @@
 
 	function isGroupPending(groupId: string): boolean {
 		return !importedGroupIds.includes(groupId) && !skippedGroupIds.includes(groupId);
+	}
+
+	function formatEpisodePill(info: { season: number; episode: number }): string {
+		return `S${String(info.season).padStart(2, '0')}E${String(info.episode).padStart(2, '0')}`;
 	}
 </script>
 
@@ -411,6 +418,7 @@
 
 								<div class="mt-2 max-h-72 space-y-2 overflow-y-auto pr-1">
 									{#each activeReviewSeasonSection?.items ?? activeReviewTvSection.items as group (group.id)}
+										{@const episodeInfo = getGroupEpisodeInfo(group)}
 										<div
 											class="flex items-center gap-2 rounded-lg border p-2 sm:p-3 {selectedGroupId ===
 											group.id
@@ -443,6 +451,11 @@
 														<span class="text-success">{m.library_import_ready()}</span>
 													{:else if isGroupPending(group.id)}
 														<span class="text-warning">{m.library_import_needsInput()}</span>
+													{/if}
+													{#if episodeInfo}
+														<span class="badge badge-primary badge-outline badge-xs font-mono">
+															{formatEpisodePill(episodeInfo)}
+														</span>
 													{/if}
 												</div>
 											</button>

--- a/src/lib/components/library/import/DetectionGroupList.svelte
+++ b/src/lib/components/library/import/DetectionGroupList.svelte
@@ -15,6 +15,7 @@
 		detectedGroupQuery = $bindable(''),
 		detectedGroupFilter = $bindable('pending' as string),
 		detectedMediaFilter = $bindable('all' as QueueMediaFilter),
+		lockedMediaType = undefined as MediaType | undefined,
 		selectedGroupId = null,
 		importedGroupIds = [],
 		skippedGroupIds = [],
@@ -52,6 +53,7 @@
 		detectedGroupQuery: string;
 		detectedGroupFilter: string;
 		detectedMediaFilter: QueueMediaFilter;
+		lockedMediaType?: MediaType;
 		selectedGroupId: string | null;
 		importedGroupIds: string[];
 		skippedGroupIds: string[];
@@ -184,31 +186,37 @@
 					{m.common_all()}
 				</button>
 			</div>
-			<div class="join">
-				<button
-					type="button"
-					class="btn join-item btn-sm {detectedMediaFilter === 'all' ? 'btn-primary' : 'btn-ghost'}"
-					onclick={() => (detectedMediaFilter = 'all')}
-				>
-					{m.library_import_filterAllMedia()}
-				</button>
-				<button
-					type="button"
-					class="btn join-item btn-sm {detectedMediaFilter === 'movie'
-						? 'btn-primary'
-						: 'btn-ghost'}"
-					onclick={() => (detectedMediaFilter = 'movie')}
-				>
-					{m.common_movies()}
-				</button>
-				<button
-					type="button"
-					class="btn join-item btn-sm {detectedMediaFilter === 'tv' ? 'btn-primary' : 'btn-ghost'}"
-					onclick={() => (detectedMediaFilter = 'tv')}
-				>
-					{m.common_tvShows()}
-				</button>
-			</div>
+			{#if !lockedMediaType}
+				<div class="join">
+					<button
+						type="button"
+						class="btn join-item btn-sm {detectedMediaFilter === 'all'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (detectedMediaFilter = 'all')}
+					>
+						{m.library_import_filterAllMedia()}
+					</button>
+					<button
+						type="button"
+						class="btn join-item btn-sm {detectedMediaFilter === 'movie'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (detectedMediaFilter = 'movie')}
+					>
+						{m.common_movies()}
+					</button>
+					<button
+						type="button"
+						class="btn join-item btn-sm {detectedMediaFilter === 'tv'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (detectedMediaFilter = 'tv')}
+					>
+						{m.common_tvShows()}
+					</button>
+				</div>
+			{/if}
 		</div>
 	</div>
 
@@ -453,7 +461,7 @@
 														<span class="text-warning">{m.library_import_needsInput()}</span>
 													{/if}
 													{#if episodeInfo}
-														<span class="badge badge-primary badge-outline badge-xs font-mono">
+														<span class="badge badge-primary badge-outline badge-xs font-mono font-bold text-base-content border-primary">
 															{formatEpisodePill(episodeInfo)}
 														</span>
 													{/if}

--- a/src/lib/components/library/import/GroupEditorPanel.svelte
+++ b/src/lib/components/library/import/GroupEditorPanel.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { Check, Clapperboard, Loader2, Search, Tv, X } from 'lucide-svelte';
+	import {
+		Check,
+		ChevronDown,
+		ChevronUp,
+		Clapperboard,
+		Loader2,
+		Search,
+		Tv,
+		X
+	} from 'lucide-svelte';
 	import type { MediaType, DetectionGroup, MatchResult } from './types.js';
 
 	interface ImportRouteContext {
@@ -76,178 +85,221 @@
 		onEpisodeNumberChange: () => void;
 		onToggleSkip: () => void;
 	} = $props();
+
+	// Expand match list only when there's no match and no locked route context
+	let showMatchList = $state(!selectedMatch && !routeImportContext);
+
+	$effect(() => {
+		showMatchList = !selectedMatch && !routeImportContext;
+	});
 </script>
 
 {#if activeGroup}
-	<div class="rounded-xl border border-base-300 bg-base-100 p-4 sm:p-5">
-		<div class="grid gap-4 lg:grid-cols-2">
-			<div class="space-y-1">
-				<div class="text-sm text-base-content/60">{m.library_import_source()}</div>
-				<div class="font-medium break-all">{activeGroup.sourcePath}</div>
-				<div class="text-xs break-all text-base-content/60">
-					{m.library_import_primaryFile({ path: activeGroup.selectedFilePath })}
+	<div class="rounded-xl border border-base-300 bg-base-100 p-4 sm:p-5 space-y-4">
+		<!-- Row 1: file identity + status + skip -->
+		<div class="flex flex-wrap items-start justify-between gap-2">
+			<div class="min-w-0 flex-1">
+				<div class="truncate text-sm font-medium" title={activeGroup.sourcePath}>
+					{activeGroup.displayName}
 				</div>
-				<div class="text-sm text-base-content/70">
-					{m.library_import_parsed()}
-					<span class="font-medium">{activeGroup.parsedTitle}</span>
-					{#if activeGroup.parsedYear}
-						({activeGroup.parsedYear})
-					{/if}
+				<div
+					class="mt-0.5 text-xs text-base-content/50 truncate"
+					title={activeGroup.selectedFilePath}
+				>
+					{activeGroup.selectedFilePath}
 				</div>
-				<div class="text-sm text-base-content/70">
-					{m.library_import_filesDetected()}
-					<span class="font-medium">{activeGroup.detectedFileCount}</span>
-					{#if activeGroup.detectedSeasons && activeGroup.detectedSeasons.length > 1}
-						<span class="ml-2"
-							>{m.library_import_seasonsDetectedInline({
-								seasons: activeGroup.detectedSeasons.join(', ')
-							})}</span
+				{#if activeGroup.detectedFileCount > 1 || (activeGroup.detectedSeasons && activeGroup.detectedSeasons.length > 1)}
+					<div class="mt-1 text-xs text-base-content/60">
+						{m.library_import_filesDetected()}
+						<span class="font-medium">{activeGroup.detectedFileCount}</span>
+						{#if activeGroup.detectedSeasons && activeGroup.detectedSeasons.length > 1}
+							<span class="ml-2"
+								>{m.library_import_seasonsDetectedInline({
+									seasons: activeGroup.detectedSeasons.join(', ')
+								})}</span
+							>
+						{/if}
+					</div>
+				{/if}
+			</div>
+			<div class="flex shrink-0 items-center gap-2">
+				{#if isGroupImported}
+					<span class="badge badge-sm badge-success">{m.library_import_badgeImported()}</span>
+				{:else if isGroupSkipped}
+					<span class="badge badge-ghost badge-sm">{m.library_import_badgeSkipped()}</span>
+				{:else if canImportGroup(activeGroup)}
+					<span class="badge badge-sm badge-primary">{m.library_import_badgeReady()}</span>
+				{:else}
+					<span class="badge badge-sm badge-warning">{m.library_import_badgeNeedsInput()}</span>
+				{/if}
+				{#if !isGroupImported && skipActionsEnabled}
+					<button class="btn btn-ghost btn-xs" onclick={onToggleSkip}>
+						{isGroupSkipped ? m.library_import_selectItem() : m.library_import_skipItem()}
+					</button>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Row 2: media type + season/episode -->
+		<div class="flex flex-wrap items-end gap-3">
+			{#if !isMediaTypeLockedByContext}
+				<div class="space-y-1">
+					<div class="text-xs text-base-content/60">{m.library_import_mediaTypeHeading()}</div>
+					<div class="flex gap-1">
+						<button
+							type="button"
+							class="btn btn-xs {selectedMediaType === 'movie' ? 'btn-primary' : 'btn-ghost'}"
+							onclick={() => onSwitchMediaType('movie')}
 						>
-					{/if}
+							<Clapperboard class="h-3 w-3" />
+							{m.common_movie()}
+						</button>
+						<button
+							type="button"
+							class="btn btn-xs {selectedMediaType === 'tv' ? 'btn-primary' : 'btn-ghost'}"
+							onclick={() => onSwitchMediaType('tv')}
+						>
+							<Tv class="h-3 w-3" />
+							{m.ui_mediaType_tv()}
+						</button>
+					</div>
 				</div>
-				<div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
-					{#if isGroupImported}
-						<span class="badge badge-sm badge-success">{m.library_import_badgeImported()}</span>
-					{:else if isGroupSkipped}
-						<span class="badge badge-ghost badge-sm">{m.library_import_badgeSkipped()}</span>
-					{:else if canImportGroup(activeGroup)}
-						<span class="badge badge-sm badge-primary">{m.library_import_badgeReady()}</span>
+			{:else}
+				<div
+					class="flex items-center gap-1.5 rounded-md bg-base-200/60 px-2.5 py-1.5 text-xs text-base-content/60"
+				>
+					{#if selectedMediaType === 'tv'}
+						<Tv class="h-3.5 w-3.5" />
+						{m.ui_mediaType_tv()}
 					{:else}
-						<span class="badge badge-sm badge-warning">{m.library_import_badgeNeedsInput()}</span>
+						<Clapperboard class="h-3.5 w-3.5" />
+						{m.common_movie()}
 					{/if}
-					{#if !isGroupImported && skipActionsEnabled}
-						<button class="btn btn-ghost btn-xs" onclick={onToggleSkip}>
-							{isGroupSkipped ? m.library_import_selectItem() : m.library_import_skipItem()}
+					<span class="text-base-content/40">·</span>
+					{m.library_import_mediaTypeLocked()}
+				</div>
+			{/if}
+
+			{#if selectedMediaType === 'tv' && !isBatchTvImport}
+				<div class="flex items-end gap-2">
+					<label class="form-control">
+						<span class="label-text text-xs">{m.library_import_seasonLabel()}</span>
+						<input
+							type="number"
+							min="0"
+							class="input-bordered input input-sm w-20"
+							bind:value={seasonNumber}
+							onchange={onSeasonNumberChange}
+						/>
+					</label>
+					<label class="form-control">
+						<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
+						<input
+							type="number"
+							min="1"
+							class="input-bordered input input-sm w-20"
+							bind:value={episodeNumber}
+							onchange={onEpisodeNumberChange}
+						/>
+					</label>
+					{#if canApplyActiveSeasonOverride()}
+						<button type="button" class="btn btn-ghost btn-sm" onclick={onSeasonNumberChange}>
+							{m.action_apply()}
 						</button>
 					{/if}
 				</div>
-			</div>
-			<div class="space-y-2">
-				<div class="text-sm text-base-content/60">{m.library_import_mediaTypeHeading()}</div>
-				<div class="flex gap-2">
-					<button
-						type="button"
-						class="btn btn-sm {selectedMediaType === 'movie' ? 'btn-primary' : 'btn-ghost'}"
-						onclick={() => onSwitchMediaType('movie')}
-						disabled={isMediaTypeLockedByContext}
-					>
-						<Clapperboard class="h-4 w-4" />
-						{m.common_movie()}
-					</button>
-					<button
-						type="button"
-						class="btn btn-sm {selectedMediaType === 'tv' ? 'btn-primary' : 'btn-ghost'}"
-						onclick={() => onSwitchMediaType('tv')}
-						disabled={isMediaTypeLockedByContext}
-					>
-						<Tv class="h-4 w-4" />
-						{m.ui_mediaType_tv()}
-					</button>
-				</div>
-				{#if isMediaTypeLockedByContext}
-					<div class="text-xs text-base-content/60">
-						{m.library_import_mediaTypeLocked()}
+			{:else if selectedMediaType === 'tv' && isBatchTvImport}
+				<div class="flex-1 rounded border border-base-300 bg-base-200/40 p-2">
+					<div class="text-xs text-base-content/70 mb-1">
+						{m.library_import_episodeMappingAutoDetected()}
 					</div>
-				{/if}
-				{#if selectedMediaType === 'tv' && !isBatchTvImport}
-					<div class="grid grid-cols-2 gap-2">
-						<label class="form-control">
-							<span class="label-text text-xs">{m.library_import_seasonLabel()}</span>
-							<input
-								type="number"
-								min="0"
-								class="input-bordered input input-sm"
-								bind:value={seasonNumber}
-								onchange={onSeasonNumberChange}
-							/>
-							{#if canApplyActiveSeasonOverride()}
-								<div class="mt-2">
-									<button type="button" class="btn btn-ghost btn-xs" onclick={onSeasonNumberChange}>
-										{m.action_apply()}
-									</button>
-								</div>
-							{/if}
-						</label>
-						<label class="form-control">
-							<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
-							<input
-								type="number"
-								min="1"
-								class="input-bordered input input-sm"
-								bind:value={episodeNumber}
-								onchange={onEpisodeNumberChange}
-							/>
-						</label>
-					</div>
-				{:else if selectedMediaType === 'tv' && isBatchTvImport}
-					<div class="space-y-2 rounded border border-base-300 bg-base-200/40 p-2">
-						<div class="text-xs text-base-content/70">
-							{m.library_import_episodeMappingAutoDetected()}
+					<label class="form-control">
+						<span class="label-text text-xs">{m.library_import_seasonOverrideLabel()}</span>
+						<input
+							type="number"
+							min="0"
+							class="input-bordered input input-sm w-24"
+							placeholder={m.library_import_seasonOverridePlaceholder()}
+							bind:value={batchSeasonOverride}
+							onchange={onEpisodeNumberChange}
+						/>
+						<div class="label-text-alt text-xs text-base-content/60">
+							{m.library_import_seasonOverrideHint()}
 						</div>
-						<label class="form-control">
-							<span class="label-text text-xs">{m.library_import_seasonOverrideLabel()}</span>
-							<input
-								type="number"
-								min="0"
-								class="input-bordered input input-sm"
-								placeholder={m.library_import_seasonOverridePlaceholder()}
-								bind:value={batchSeasonOverride}
-								onchange={onEpisodeNumberChange}
-							/>
-							<div class="label-text-alt text-xs text-base-content/60">
-								{m.library_import_seasonOverrideHint()}
-							</div>
-						</label>
-					</div>
-				{/if}
-				{#if isGroupImported}
-					<div class="text-xs text-success">
-						{m.library_import_alreadyImported()}
-					</div>
-				{:else if isGroupSkipped}
-					<div class="text-xs text-base-content/70">
-						{m.library_import_itemSkipped()}
-					</div>
-				{/if}
-			</div>
-			{#if parsedSourceContextMismatch && routeImportContext}
-				<div class="alert text-sm alert-warning lg:col-span-2">
-					<span>
-						{m.library_import_parsedFileSuggests()}
-						<strong
-							>{activeGroup.parsedTitle}
-							{#if activeGroup.parsedYear}
-								({activeGroup.parsedYear})
-							{/if}</strong
-						>, {m.library_import_butImportOpenedFor()}
-						<strong
-							>{routeImportContext.title || `TMDB ${routeImportContext.tmdbId}`}
-							{#if routeImportContext.year}
-								({routeImportContext.year})
-							{/if}</strong
-						>.
-					</span>
+					</label>
 				</div>
 			{/if}
-		</div>
-	</div>
 
-	<div class="rounded-xl border border-base-300 bg-base-100 p-4 sm:p-5">
-		{#if routeImportContext}
-			<div class="mb-3 alert text-sm alert-info">
+			{#if isGroupImported}
+				<div class="text-xs text-success self-center">{m.library_import_alreadyImported()}</div>
+			{:else if isGroupSkipped}
+				<div class="text-xs text-base-content/70 self-center">{m.library_import_itemSkipped()}</div>
+			{/if}
+		</div>
+
+		<!-- Warnings -->
+		{#if parsedSourceContextMismatch && routeImportContext}
+			<div class="alert text-sm alert-warning">
 				<span>
-					{m.library_import_directImportFor()}
+					{m.library_import_parsedFileSuggests()}
 					<strong
-						>{routeImportContext.title || `TMDB ${routeImportContext.tmdbId}`}
-						{#if routeImportContext.year}
-							({routeImportContext.year})
-						{/if}</strong
+						>{activeGroup.parsedTitle}{#if activeGroup.parsedYear}
+							({activeGroup.parsedYear}){/if}</strong
+					>,
+					{m.library_import_butImportOpenedFor()}
+					<strong
+						>{routeImportContext.title ||
+							`TMDB ${routeImportContext.tmdbId}`}{#if routeImportContext.year}
+							({routeImportContext.year}){/if}</strong
 					>.
 				</span>
 			</div>
+		{/if}
+		{#if selectedMatchContextMismatch && routeImportContext && selectedMatch}
+			<div class="alert text-sm alert-warning">
+				<span>
+					{m.library_import_importOpenedFor()}
+					<strong
+						>{routeImportContext.title ||
+							`TMDB ${routeImportContext.tmdbId}`}{#if routeImportContext.year}
+							({routeImportContext.year}){/if}</strong
+					>,
+					{m.library_import_butSelectedMatchIs()}
+					<strong
+						>{selectedMatch.title}{#if selectedMatch.year}
+							({selectedMatch.year}){/if}</strong
+					>".
+				</span>
+			</div>
+		{/if}
+
+		<!-- Divider -->
+		<div class="border-t border-base-300"></div>
+
+		<!-- Match section -->
+		{#if routeImportContext && !selectedMatchContextMismatch}
+			<!-- Direct import context: show selected match as a compact row -->
+			<div class="min-w-0">
+				<div class="text-xs text-base-content/50 mb-1">{m.library_import_directImportFor()}</div>
+				{#if selectedMatch}
+					<div class="flex flex-wrap items-center gap-2">
+						<span class="font-medium truncate">
+							{selectedMatch.title}{#if selectedMatch.year}
+								<span class="text-base-content/60">({selectedMatch.year})</span>{/if}
+						</span>
+						<span class="badge badge-outline badge-xs"
+							>{selectedMatch.mediaType === 'movie' ? m.common_movie() : m.ui_mediaType_tv()}</span
+						>
+						{#if selectedMatch.inLibrary}
+							<span class="badge badge-xs badge-success">{m.library_import_inLibrary()}</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
 		{:else}
-			<div class="mb-3 flex items-center gap-2">
-				<div class="group relative w-full">
+			<!-- No context: search bar always visible -->
+			<div class="flex items-center justify-between gap-2">
+				<div class="group relative flex-1">
 					<div class="pointer-events-none absolute top-1/2 left-3.5 -translate-y-1/2">
 						{#if searchingMatches}
 							<Loader2
@@ -262,7 +314,7 @@
 					<input
 						type="text"
 						placeholder={m.library_import_searchTmdbPlaceholder()}
-						class="input input-md w-full rounded-full border-base-content/20 bg-base-200/60 pr-9 pl-10 transition-all duration-200 placeholder:text-base-content/40 hover:bg-base-200 focus:border-primary/50 focus:bg-base-200 focus:ring-1 focus:ring-primary/20 focus:outline-none"
+						class="input input-sm w-full rounded-full border-base-content/20 bg-base-200/60 pr-9 pl-10 transition-all duration-200 placeholder:text-base-content/40 hover:bg-base-200 focus:border-primary/50 focus:bg-base-200 focus:ring-1 focus:ring-primary/20 focus:outline-none"
 						value={searchQuery}
 						oninput={onSearchInput}
 						onkeydown={(event) => {
@@ -285,33 +337,27 @@
 						</button>
 					{/if}
 				</div>
+				{#if selectedMatch}
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs shrink-0"
+						onclick={() => (showMatchList = !showMatchList)}
+					>
+						{showMatchList ? m.action_collapse() : m.action_change()}
+						{#if showMatchList}
+							<ChevronUp class="h-3 w-3" />
+						{:else}
+							<ChevronDown class="h-3 w-3" />
+						{/if}
+					</button>
+				{/if}
 			</div>
 		{/if}
-		{#if selectedMatchContextMismatch && routeImportContext && selectedMatch}
-			<div class="mt-3 mb-3 alert text-sm alert-warning">
-				<span>
-					{m.library_import_importOpenedFor()}
-					<strong
-						>{routeImportContext.title || `TMDB ${routeImportContext.tmdbId}`}
-						{#if routeImportContext.year}
-							({routeImportContext.year})
-						{/if}</strong
-					>, {m.library_import_butSelectedMatchIs()}
-					<strong
-						>{selectedMatch.title}
-						{#if selectedMatch.year}
-							({selectedMatch.year})
-						{/if}</strong
-					>".
-				</span>
-			</div>
-		{/if}
-		{#if canApplyMatchSelectionToActiveSeason}
-			<div class="mt-3 mb-3 rounded-lg border border-base-300 bg-base-200/40 p-3">
+
+		{#if canApplyMatchSelectionToActiveSeason && !(routeImportContext && !selectedMatchContextMismatch)}
+			<div class="rounded-lg border border-base-300 bg-base-200/40 p-3">
 				<label class="flex cursor-pointer items-center justify-between gap-3">
-					<span class="text-sm font-medium">
-						{m.library_import_matchEntireSelectedSeason()}
-					</span>
+					<span class="text-sm font-medium">{m.library_import_matchEntireSelectedSeason()}</span>
 					<input
 						type="checkbox"
 						class="toggle toggle-sm"
@@ -324,50 +370,53 @@
 			</div>
 		{/if}
 
-		{#if matchCandidates.length === 0}
-			<div class="rounded-lg border border-dashed border-base-300 p-4 text-sm text-base-content/60">
-				{m.library_import_noMatchesYet()}
-			</div>
-		{:else}
-			<div class="max-h-80 space-y-2 overflow-y-auto pr-1">
-				{#each matchCandidates as match (match.mediaType + '-' + match.tmdbId)}
-					<button
-						type="button"
-						class="flex w-full items-center justify-between rounded-lg border p-3 text-left transition-colors hover:border-primary/50 {selectedMatch?.tmdbId ===
-							match.tmdbId && selectedMatch?.mediaType === match.mediaType
-							? 'border-primary bg-primary/5'
-							: 'border-base-300'}"
-						onclick={() => onChooseMatch(match)}
-					>
-						<div class="min-w-0">
-							<div class="truncate font-medium">
-								{match.title}
-								{#if match.year}
-									<span class="text-base-content/60">({match.year})</span>
-								{/if}
-							</div>
-							<div class="mt-1 flex flex-wrap items-center gap-2 text-xs">
-								<span class="badge badge-outline badge-sm">
-									{match.mediaType === 'movie' ? m.common_movie() : m.ui_mediaType_tv()}
-								</span>
-								{#if match.confidence > 0}
-									<span class="badge badge-ghost badge-sm"
-										>{m.library_import_confidenceMatch({
-											percent: Math.round(match.confidence * 100)
-										})}</span
+		<!-- Match candidates (collapsed when match selected + in context) -->
+		{#if showMatchList}
+			{#if matchCandidates.length === 0}
+				<div
+					class="rounded-lg border border-dashed border-base-300 p-4 text-sm text-base-content/60"
+				>
+					{m.library_import_noMatchesYet()}
+				</div>
+			{:else}
+				<div class="max-h-72 space-y-2 overflow-y-auto pr-1">
+					{#each matchCandidates as match (match.mediaType + '-' + match.tmdbId)}
+						<button
+							type="button"
+							class="flex w-full items-center justify-between rounded-lg border p-3 text-left transition-colors hover:border-primary/50 {selectedMatch?.tmdbId ===
+								match.tmdbId && selectedMatch?.mediaType === match.mediaType
+								? 'border-primary bg-primary/5'
+								: 'border-base-300'}"
+							onclick={() => onChooseMatch(match)}
+						>
+							<div class="min-w-0">
+								<div class="truncate font-medium">
+									{match.title}
+									{#if match.year}<span class="text-base-content/60">({match.year})</span>{/if}
+								</div>
+								<div class="mt-1 flex flex-wrap items-center gap-2 text-xs">
+									<span class="badge badge-outline badge-sm"
+										>{match.mediaType === 'movie' ? m.common_movie() : m.ui_mediaType_tv()}</span
 									>
-								{/if}
-								{#if match.inLibrary}
-									<span class="badge badge-sm badge-success">{m.library_import_inLibrary()}</span>
-								{/if}
+									{#if match.confidence > 0}
+										<span class="badge badge-ghost badge-sm"
+											>{m.library_import_confidenceMatch({
+												percent: Math.round(match.confidence * 100)
+											})}</span
+										>
+									{/if}
+									{#if match.inLibrary}
+										<span class="badge badge-sm badge-success">{m.library_import_inLibrary()}</span>
+									{/if}
+								</div>
 							</div>
-						</div>
-						{#if selectedMatch?.tmdbId === match.tmdbId && selectedMatch?.mediaType === match.mediaType}
-							<Check class="h-4 w-4 text-primary" />
-						{/if}
-					</button>
-				{/each}
-			</div>
+							{#if selectedMatch?.tmdbId === match.tmdbId && selectedMatch?.mediaType === match.mediaType}
+								<Check class="h-4 w-4 text-primary" />
+							{/if}
+						</button>
+					{/each}
+				</div>
+			{/if}
 		{/if}
 	</div>
 {/if}

--- a/src/lib/components/library/import/Step3MultiImport.svelte
+++ b/src/lib/components/library/import/Step3MultiImport.svelte
@@ -32,7 +32,7 @@
 		canImport = (_group: DetectionGroup) => false,
 		getEffectiveMediaType = (_group: DetectionGroup) => 'movie' as MediaType,
 		getGroupEpisodeInfo = (_group: DetectionGroup) =>
-			null as { season: number; episode: number } | null,
+			null as { season: number; episode: number; title?: string } | null,
 		lockedMediaType = undefined as MediaType | undefined,
 		getSectionDestinations = (_section: DetectionSection): DestinationLibrary[] => [],
 		getSectionEligibleCount = (_section: DetectionSection) => 0,
@@ -59,7 +59,11 @@
 		executingImport: boolean;
 		canImport: (group: DetectionGroup) => boolean;
 		getEffectiveMediaType: (group: DetectionGroup) => MediaType;
-		getGroupEpisodeInfo: (group: DetectionGroup) => { season: number; episode: number } | null;
+		getGroupEpisodeInfo: (group: DetectionGroup) => {
+			season: number;
+			episode: number;
+			title?: string;
+		} | null;
 		lockedMediaType?: MediaType;
 		getSectionDestinations: (section: DetectionSection) => DestinationLibrary[];
 		getSectionEligibleCount: (section: DetectionSection) => number;
@@ -126,9 +130,7 @@
 				<div class="join">
 					<button
 						type="button"
-						class="btn join-item btn-sm {importMediaFilter === 'all'
-							? 'btn-primary'
-							: 'btn-ghost'}"
+						class="btn join-item btn-sm {importMediaFilter === 'all' ? 'btn-primary' : 'btn-ghost'}"
 						onclick={() => (importMediaFilter = 'all')}
 					>
 						{m.library_import_filterAllMedia()}
@@ -138,15 +140,15 @@
 						class="btn join-item btn-sm {importMediaFilter === 'movie'
 							? 'btn-primary'
 							: 'btn-ghost'}"
+						disabled={importMovieSections.length === 0}
 						onclick={() => (importMediaFilter = 'movie')}
 					>
 						{m.common_movies()}
 					</button>
 					<button
 						type="button"
-						class="btn join-item btn-sm {importMediaFilter === 'tv'
-							? 'btn-primary'
-							: 'btn-ghost'}"
+						class="btn join-item btn-sm {importMediaFilter === 'tv' ? 'btn-primary' : 'btn-ghost'}"
+						disabled={importTvSections.length === 0}
 						onclick={() => (importMediaFilter = 'tv')}
 					>
 						{m.common_tvShows()}
@@ -356,6 +358,11 @@
 															<span class="badge badge-primary badge-outline badge-xs font-mono">
 																{formatEpisodePill(episodeInfo)}
 															</span>
+															{#if episodeInfo.title}
+																<span class="max-w-48 truncate italic">
+																	{episodeInfo.title}
+																</span>
+															{/if}
 														{/if}
 													</div>
 												</div>

--- a/src/lib/components/library/import/Step3MultiImport.svelte
+++ b/src/lib/components/library/import/Step3MultiImport.svelte
@@ -31,6 +31,8 @@
 		executingImport = false,
 		canImport = (_group: DetectionGroup) => false,
 		getEffectiveMediaType = (_group: DetectionGroup) => 'movie' as MediaType,
+		getGroupEpisodeInfo = (_group: DetectionGroup) =>
+			null as { season: number; episode: number } | null,
 		getSectionDestinations = (_section: DetectionSection): DestinationLibrary[] => [],
 		getSectionEligibleCount = (_section: DetectionSection) => 0,
 		canApplyDestination = (_section: DetectionSection) => false,
@@ -56,6 +58,7 @@
 		executingImport: boolean;
 		canImport: (group: DetectionGroup) => boolean;
 		getEffectiveMediaType: (group: DetectionGroup) => MediaType;
+		getGroupEpisodeInfo: (group: DetectionGroup) => { season: number; episode: number } | null;
 		getSectionDestinations: (section: DetectionSection) => DestinationLibrary[];
 		getSectionEligibleCount: (section: DetectionSection) => number;
 		canApplyDestination: (section: DetectionSection) => boolean;
@@ -70,6 +73,10 @@
 
 	function formatMediaTypeLabel(mediaType: MediaType): string {
 		return mediaType === 'movie' ? m.library_import_movieLabel() : m.library_import_tvShowLabel();
+	}
+
+	function formatEpisodePill(info: { season: number; episode: number }): string {
+		return `S${String(info.season).padStart(2, '0')}E${String(info.episode).padStart(2, '0')}`;
 	}
 
 	function getDetectedSeasonsLabel(section: DetectionSection): string {
@@ -310,6 +317,7 @@
 
 									<div class="mt-2 max-h-72 space-y-2 overflow-y-auto pr-1">
 										{#each activeImportSeasonSection?.items ?? activeImportTvSection.items as group (group.id)}
+											{@const episodeInfo = getGroupEpisodeInfo(group)}
 											<div
 												class="flex items-center justify-between gap-3 rounded-lg border border-base-300 p-3"
 											>
@@ -333,6 +341,11 @@
 															<span class="text-success">{m.library_import_ready()}</span>
 														{:else}
 															<span class="text-warning">{m.library_import_needsInput()}</span>
+														{/if}
+														{#if episodeInfo}
+															<span class="badge badge-primary badge-outline badge-xs font-mono">
+																{formatEpisodePill(episodeInfo)}
+															</span>
 														{/if}
 													</div>
 												</div>

--- a/src/lib/components/library/import/Step3MultiImport.svelte
+++ b/src/lib/components/library/import/Step3MultiImport.svelte
@@ -33,6 +33,7 @@
 		getEffectiveMediaType = (_group: DetectionGroup) => 'movie' as MediaType,
 		getGroupEpisodeInfo = (_group: DetectionGroup) =>
 			null as { season: number; episode: number } | null,
+		lockedMediaType = undefined as MediaType | undefined,
 		getSectionDestinations = (_section: DetectionSection): DestinationLibrary[] => [],
 		getSectionEligibleCount = (_section: DetectionSection) => 0,
 		canApplyDestination = (_section: DetectionSection) => false,
@@ -59,6 +60,7 @@
 		canImport: (group: DetectionGroup) => boolean;
 		getEffectiveMediaType: (group: DetectionGroup) => MediaType;
 		getGroupEpisodeInfo: (group: DetectionGroup) => { season: number; episode: number } | null;
+		lockedMediaType?: MediaType;
 		getSectionDestinations: (section: DetectionSection) => DestinationLibrary[];
 		getSectionEligibleCount: (section: DetectionSection) => number;
 		canApplyDestination: (section: DetectionSection) => boolean;
@@ -118,32 +120,40 @@
 
 	<div class="rounded-xl border border-base-300 bg-base-100 p-4 sm:p-5">
 		<h3 class="font-semibold">{m.library_import_selectedItemsHeading()}</h3>
-		<div class="mt-3 flex flex-wrap items-center justify-between gap-2">
-			<p class="text-xs text-base-content/70">{m.library_import_filterByMediaType()}</p>
-			<div class="join">
-				<button
-					type="button"
-					class="btn join-item btn-sm {importMediaFilter === 'all' ? 'btn-primary' : 'btn-ghost'}"
-					onclick={() => (importMediaFilter = 'all')}
-				>
-					{m.library_import_filterAllMedia()}
-				</button>
-				<button
-					type="button"
-					class="btn join-item btn-sm {importMediaFilter === 'movie' ? 'btn-primary' : 'btn-ghost'}"
-					onclick={() => (importMediaFilter = 'movie')}
-				>
-					{m.common_movies()}
-				</button>
-				<button
-					type="button"
-					class="btn join-item btn-sm {importMediaFilter === 'tv' ? 'btn-primary' : 'btn-ghost'}"
-					onclick={() => (importMediaFilter = 'tv')}
-				>
-					{m.common_tvShows()}
-				</button>
+		{#if !lockedMediaType}
+			<div class="mt-3 flex flex-wrap items-center justify-between gap-2">
+				<p class="text-xs text-base-content/70">{m.library_import_filterByMediaType()}</p>
+				<div class="join">
+					<button
+						type="button"
+						class="btn join-item btn-sm {importMediaFilter === 'all'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (importMediaFilter = 'all')}
+					>
+						{m.library_import_filterAllMedia()}
+					</button>
+					<button
+						type="button"
+						class="btn join-item btn-sm {importMediaFilter === 'movie'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (importMediaFilter = 'movie')}
+					>
+						{m.common_movies()}
+					</button>
+					<button
+						type="button"
+						class="btn join-item btn-sm {importMediaFilter === 'tv'
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => (importMediaFilter = 'tv')}
+					>
+						{m.common_tvShows()}
+					</button>
+				</div>
 			</div>
-		</div>
+		{/if}
 		{#if selectedImportGroupCount === 0}
 			<div
 				class="mt-3 rounded-lg border border-dashed border-base-300 p-4 text-sm text-base-content/60"

--- a/src/lib/components/settings/SettingsTabNav.svelte
+++ b/src/lib/components/settings/SettingsTabNav.svelte
@@ -70,7 +70,7 @@
 	<div class="relative">
 		<div
 			bind:this={navScroller}
-			class="[scrollbar-width:none] overflow-x-auto px-2 sm:px-4 [&::-webkit-scrollbar]:hidden"
+			class="scrollbar-none overflow-x-auto px-2 sm:px-4 [&::-webkit-scrollbar]:hidden"
 		>
 			<nav class="-mb-px flex min-w-max items-stretch gap-1 sm:gap-4" aria-label={ariaLabel}>
 				{#each navItems as item (item.href)}

--- a/src/lib/server/indexers/parser/ReleaseParser.test.ts
+++ b/src/lib/server/indexers/parser/ReleaseParser.test.ts
@@ -577,6 +577,32 @@ describe('ReleaseParser', () => {
 		});
 	});
 
+	describe('Fansub anime with season prefix (Moozzi2-style)', () => {
+		const moozziFiles = [
+			{ stem: '[Moozzi2] Seitokai Yakuindomo S1 - 01 (BD 1920x1080 x.264 FLACx2)', episode: 1 },
+			{ stem: '[Moozzi2] Seitokai Yakuindomo S1 - 02 (BD 1920x1080 x.264 FLACx2)', episode: 2 },
+			{ stem: '[Moozzi2] Seitokai Yakuindomo S1 - 06 (BD 1920x1080 x.264 FLACx2)', episode: 6 },
+			{ stem: '[Moozzi2] Seitokai Yakuindomo S1 - 12 (BD 1920x1080 x.264 FLACx2)', episode: 12 },
+			{ stem: '[Moozzi2] Seitokai Yakuindomo S1 - 13 END (BD 1920x1080 x.264 FLACx2)', episode: 13 }
+		];
+
+		for (const { stem, episode } of moozziFiles) {
+			it(`should parse episode ${episode} from "${stem}"`, () => {
+				const result = parseRelease(stem);
+				expect(result.episode?.isSeasonPack).toBe(false);
+				expect(result.episode?.season).toBe(1);
+				expect(result.episode?.episodes).toEqual([episode]);
+			});
+		}
+
+		it('should not treat "S1 - 02" as a multi-season range', () => {
+			const result = parseRelease('[Moozzi2] Show S1 - 02 (BD 1080p)');
+			expect(result.episode?.isSeasonPack).toBe(false);
+			expect(result.episode?.season).toBe(1);
+			expect(result.episode?.episodes).toEqual([2]);
+		});
+	});
+
 	describe('Real-world samples', () => {
 		it('should parse streaming service releases', () => {
 			const result = parseRelease(

--- a/src/lib/server/indexers/parser/patterns/episode.ts
+++ b/src/lib/server/indexers/parser/patterns/episode.ts
@@ -99,8 +99,28 @@ const EPISODE_PATTERNS: Array<{
 
 	// Multi-season pack patterns: S01-S05, Season 1-5, S01-05, Seasons 1-5
 	// These must come BEFORE generic "complete series" text patterns
+	//
+	// Split into two patterns to avoid consuming fansub episode notation like "S1 - 08":
+	// - With explicit S prefix before second number: allows spaces (S01-S05, S1 - S3)
+	// - Without S prefix: tight separators only, no spaces (S01-05, S1-3)
+	//   "S1 - 08" uses spaces + no second S, so it must NOT match here.
 	{
-		pattern: /\bS(\d{1,2})[\s._-]*[-–—][\s._-]*S?(\d{1,2})\b(?![\s._-]?E)/i,
+		pattern: /\bS(\d{1,2})[\s._-]*[-–—][\s._-]*S(\d{1,2})\b(?![\s._-]?E)/i,
+		extract: (match) => {
+			const startSeason = parseInt(match[1], 10);
+			const endSeason = parseInt(match[2], 10);
+			if (endSeason > startSeason && endSeason - startSeason < 20) {
+				const seasons: number[] = [];
+				for (let s = startSeason; s <= endSeason; s++) {
+					seasons.push(s);
+				}
+				return { seasons, isSeasonPack: true, isCompleteSeries: startSeason === 1 };
+			}
+			return { seasons: [startSeason, endSeason], isSeasonPack: true };
+		}
+	},
+	{
+		pattern: /\bS(\d{1,2})[._-]?[-–—][._-]?(\d{1,2})\b(?![\s._-]?E)/i,
 		extract: (match) => {
 			const startSeason = parseInt(match[1], 10);
 			const endSeason = parseInt(match[2], 10);

--- a/src/lib/server/indexers/parser/patterns/episode.ts
+++ b/src/lib/server/indexers/parser/patterns/episode.ts
@@ -305,6 +305,18 @@ const EPISODE_PATTERNS: Array<{
 		}
 	},
 
+	// Fansub/anime season+episode with dash notation: "S1 - 08", "S2 - 12v2"
+	// Must appear before the season-pack S\d pattern so "S1 - 08" is not
+	// consumed as a season-1 pack with a leftover " - 08" that can't be parsed.
+	{
+		pattern: /\bS(\d{1,2})\s+-\s+(\d{2,4})(?:v\d+)?(?=[\s(]|$)/i,
+		extract: (match) => ({
+			season: parseInt(match[1], 10),
+			episodes: [parseInt(match[2], 10)],
+			isSeasonPack: false
+		})
+	},
+
 	// Season pack patterns
 	{
 		pattern: /\bSeason[\s._-]?(\d{1,2})\b(?![\s._-]?E)/i,
@@ -339,9 +351,9 @@ const EPISODE_PATTERNS: Array<{
 			absoluteEpisode: parseInt(match[1], 10)
 		})
 	},
-	// - 045 - anime style with dashes around number
+	// - 045 or - 01v2 - anime style with dashes around number, optional version suffix
 	{
-		pattern: /\s-\s(\d{2,4})(?=\s|$)/,
+		pattern: /\s-\s(\d{2,4})(?:v\d+)?(?=\s|$)/,
 		extract: (match) => ({
 			absoluteEpisode: parseInt(match[1], 10)
 		})

--- a/src/lib/server/library/disk-scan.ts
+++ b/src/lib/server/library/disk-scan.ts
@@ -941,7 +941,12 @@ export class DiskScanService extends EventEmitter {
 			parsedTitle: parsed.cleanTitle || null,
 			parsedYear: parsed.year || null,
 			parsedSeason: identifier?.numbering === 'standard' ? identifier.seasonNumber : null,
-			parsedEpisode: identifier?.numbering === 'standard' ? identifier.episodeNumbers[0] : null,
+			parsedEpisode:
+				identifier?.numbering === 'standard'
+					? identifier.episodeNumbers[0]
+					: identifier?.numbering === 'absolute'
+						? identifier.absoluteEpisode
+						: null,
 			reason: 'no_match'
 		});
 	}

--- a/src/lib/server/library/manual-import-service.ts
+++ b/src/lib/server/library/manual-import-service.ts
@@ -229,7 +229,11 @@ export class ManualImportService {
 			parsedYear: parsed.year,
 			parsedSeason: tvIdentifier?.numbering === 'standard' ? tvIdentifier.seasonNumber : undefined,
 			parsedEpisode:
-				tvIdentifier?.numbering === 'standard' ? tvIdentifier.episodeNumbers[0] : undefined,
+				tvIdentifier?.numbering === 'standard'
+					? tvIdentifier.episodeNumbers[0]
+					: tvIdentifier?.numbering === 'absolute'
+						? tvIdentifier.absoluteEpisode
+						: undefined,
 			inferredMediaType,
 			matches: enrichedMatches
 		};

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -26,6 +26,11 @@ import { searchSubtitlesForNewMedia } from '$lib/server/subtitles/services/Subti
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
 import { logger } from '$lib/logging/index.js';
 import { parseRelease, extractExternalIds } from '$lib/server/indexers/parser/ReleaseParser.js';
+import {
+	resolveTvEpisodeIdentifier,
+	extractSeasonFromPath,
+	getMediaParseStem
+} from './tv-episode-resolver.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { resolveProviderWithFallback } from '$lib/server/metadata/provider-resolution.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
@@ -975,13 +980,50 @@ export class MediaMatcherService {
 			}
 		}
 
-		// Determine season and episode from parsed info
-		if (file.parsedSeason === null || file.parsedEpisode === null) {
+		// Determine season and episode - fall back to re-parsing when DB values are incomplete
+		let resolvedSeason = file.parsedSeason;
+		let resolvedEpisode = file.parsedEpisode;
+
+		if (resolvedSeason === null || resolvedEpisode === null) {
+			const stem = getMediaParseStem(file.path);
+			const reparsed = parseRelease(stem);
+			const tvId = resolveTvEpisodeIdentifier({
+				filePath: file.path,
+				parsed: reparsed,
+				seasonHint: extractSeasonFromPath(file.path)
+			});
+
+			if (tvId?.numbering === 'standard') {
+				resolvedSeason = resolvedSeason ?? tvId.seasonNumber;
+				resolvedEpisode = resolvedEpisode ?? tvId.episodeNumbers[0];
+			} else if (tvId?.numbering === 'absolute') {
+				// Absolute episode - resolve to season/episode via DB (populated above)
+				const [epRecord] = await db
+					.select({
+						seasonNumber: episodes.seasonNumber,
+						episodeNumber: episodes.episodeNumber
+					})
+					.from(episodes)
+					.where(
+						and(
+							eq(episodes.seriesId, seriesId),
+							eq(episodes.absoluteEpisodeNumber, tvId.absoluteEpisode)
+						)
+					)
+					.limit(1);
+				if (epRecord) {
+					resolvedSeason = epRecord.seasonNumber;
+					resolvedEpisode = epRecord.episodeNumber;
+				}
+			}
+		}
+
+		if (resolvedSeason === null || resolvedEpisode === null) {
 			throw new Error('Could not determine season/episode from filename');
 		}
 
-		const seasonNumber = file.parsedSeason;
-		const episodeNumber = file.parsedEpisode;
+		const seasonNumber = resolvedSeason;
+		const episodeNumber = resolvedEpisode;
 
 		// Fetch season details from TMDB (needed for both season and episode metadata)
 		let tmdbSeason: Awaited<ReturnType<typeof tmdb.getSeason>> | null = null;

--- a/src/lib/server/library/tv-episode-resolver.ts
+++ b/src/lib/server/library/tv-episode-resolver.ts
@@ -66,15 +66,30 @@ export function getMediaParseStem(pathValue: string): string {
 
 export function extractSeasonFromPath(pathValue: string): number | undefined {
 	const normalizedPath = resolve(pathValue).replace(/\\/g, '/');
-	const seasonPatterns = [
+
+	// First pass: match season as a complete path segment boundary
+	// e.g. /Season 1/, /s01/, /Season.1/
+	const segmentPatterns = [
 		/(?:^|\/)season[\s._-]*(\d{1,3})(?:\/|$)/i,
 		/(?:^|\/)s(\d{1,3})(?:\/|$)/i
 	];
 
-	for (const pattern of seasonPatterns) {
+	for (const pattern of segmentPatterns) {
 		const match = normalizedPath.match(pattern);
 		const season = match?.[1] ? parseInt(match[1], 10) : NaN;
 		if (!isNaN(season)) {
+			return season;
+		}
+	}
+
+	// Second pass: scan each path segment for a standalone S-number token
+	// Handles folder names like "[Group] Title S1 BD-BOX" or "Show S2 Complete"
+	// Requires word boundary on both sides and must not be followed by an episode number
+	for (const segment of normalizedPath.split('/')) {
+		const match = segment.match(/\bS(\d{1,2})\b(?![\s._-]?E\d)/i);
+		if (!match) continue;
+		const season = parseInt(match[1], 10);
+		if (!isNaN(season) && season >= 1 && season <= 30) {
 			return season;
 		}
 	}

--- a/src/lib/server/library/unmatched-file-service.ts
+++ b/src/lib/server/library/unmatched-file-service.ts
@@ -313,7 +313,7 @@ export class UnmatchedFileService {
 	 * Match files to TMDB entry
 	 */
 	async matchFiles(request: MatchRequest): Promise<BatchMatchResult> {
-		const { fileIds, tmdbId, mediaType, season, episodeMapping } = request;
+		const { fileIds, tmdbId, mediaType, season, episode, episodeMapping } = request;
 		const errors: string[] = [];
 		let matched = 0;
 		let failed = 0;
@@ -347,13 +347,17 @@ export class UnmatchedFileService {
 						fileEpisode = episodeMapping[fileId].episode;
 					} else {
 						fileSeason = fileSeason ?? file.parsedSeason ?? undefined;
-						fileEpisode = file.parsedEpisode ?? undefined;
+						// Prefer explicitly supplied episode, fall back to parsed value
+						fileEpisode = episode ?? file.parsedEpisode ?? undefined;
 					}
 
 					if (fileSeason === undefined || fileEpisode === undefined) {
-						errors.push(
-							`Failed to match ${fileId}: could not determine season/episode from filename`
+						const reason = `Could not determine ${fileSeason === undefined ? 'season' : 'episode'} for "${file.path}" - the filename could not be parsed and no value was provided`;
+						logger.warn(
+							{ fileId, filePath: file.path, fileSeason, fileEpisode },
+							`[UnmatchedFileService] ${reason}`
 						);
+						errors.push(reason);
 						failed++;
 						continue;
 					}
@@ -411,7 +415,6 @@ export class UnmatchedFileService {
 		episode: number
 	): Promise<{ success: boolean; mediaId?: string; error?: string }> {
 		try {
-			// Get the file record to use with mediaMatcherService
 			const [fileRecord] = await db
 				.select()
 				.from(unmatchedFiles)
@@ -421,22 +424,21 @@ export class UnmatchedFileService {
 				return { success: false, error: 'File record not found' };
 			}
 
-			// Update parsed season/episode before matching
+			// Write season/episode before acceptMatch reads them from the DB
 			await db
 				.update(unmatchedFiles)
-				.set({
-					parsedSeason: season,
-					parsedEpisode: episode
-				})
+				.set({ parsedSeason: season, parsedEpisode: episode })
 				.where(eq(unmatchedFiles.id, file.id));
 
 			await mediaMatcherService.acceptMatch(file.id, tmdbId, 'tv');
 			return { success: true };
 		} catch (err) {
-			return {
-				success: false,
-				error: err instanceof Error ? err.message : 'Failed to match episode'
-			};
+			const errorMsg = err instanceof Error ? err.message : 'Failed to match episode';
+			logger.error(
+				{ fileId: file.id, filePath: file.path, tmdbId, season, episode, err },
+				`[UnmatchedFileService] Episode match failed: ${errorMsg}`
+			);
+			return { success: false, error: errorMsg };
 		}
 	}
 

--- a/src/lib/server/library/unmatched-file-service.ts
+++ b/src/lib/server/library/unmatched-file-service.ts
@@ -13,6 +13,8 @@ import { createChildLogger } from '$lib/logging';
 
 const logger = createChildLogger({ logDomain: 'scans' as const });
 import { mediaMatcherService } from './media-matcher.js';
+import { parseRelease } from '$lib/server/indexers/parser/ReleaseParser.js';
+import { resolveTvEpisodeIdentifier, getMediaParseStem } from './tv-episode-resolver.js';
 import type {
 	UnmatchedFile,
 	UnmatchedFolder,
@@ -347,8 +349,25 @@ export class UnmatchedFileService {
 						fileEpisode = episodeMapping[fileId].episode;
 					} else {
 						fileSeason = fileSeason ?? file.parsedSeason ?? undefined;
-						// Prefer explicitly supplied episode, fall back to parsed value
 						fileEpisode = episode ?? file.parsedEpisode ?? undefined;
+
+						// If episode still missing, re-parse the filename (handles absolute episode
+						// numbering for files indexed before this was stored in parsedEpisode)
+						if (fileEpisode === undefined) {
+							const fileStem = getMediaParseStem(file.path);
+							const parsed = parseRelease(fileStem);
+							const tvId = resolveTvEpisodeIdentifier({
+								filePath: file.path,
+								parsed,
+								seasonHint: fileSeason
+							});
+							if (tvId?.numbering === 'standard') {
+								fileSeason = fileSeason ?? tvId.seasonNumber;
+								fileEpisode = tvId.episodeNumbers[0];
+							} else if (tvId?.numbering === 'absolute') {
+								fileEpisode = tvId.absoluteEpisode;
+							}
+						}
 					}
 
 					if (fileSeason === undefined || fileEpisode === undefined) {

--- a/src/lib/types/unmatched.ts
+++ b/src/lib/types/unmatched.ts
@@ -71,6 +71,7 @@ export interface MatchRequest {
 	tmdbId: number;
 	mediaType: 'movie' | 'tv';
 	season?: number;
+	episode?: number;
 	episodeMapping?: Record<string, { season: number; episode: number }>;
 }
 

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1754,6 +1754,7 @@ export const unmatchedMatchSchema = z.object({
 	tmdbId: z.number().int(),
 	mediaType: z.enum(['movie', 'tv']),
 	season: z.number().int().optional(),
+	episode: z.number().int().optional(),
 	episodeMapping: z
 		.record(
 			z.string(),

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -436,7 +436,7 @@
 			<label for="main-drawer" aria-label={m.nav_closeSidebar()} class="drawer-overlay"></label>
 			<aside
 				class:sidebar-collapsed={!layoutState.isSidebarExpanded}
-				class="relative z-40 flex min-h-full flex-col overflow-x-visible bg-base-200 transition-[width] duration-300 ease-in-out
+				class="relative z-40 flex h-dvh flex-col overflow-x-visible bg-base-200 transition-[width] duration-300 ease-in-out
 		            {layoutState.isSidebarExpanded ? 'w-64' : 'w-20'}"
 			>
 				<!-- Sidebar Header -->
@@ -489,7 +489,7 @@
 
 				<!-- Navigation -->
 				<div
-					class="grow"
+					class="min-h-0 grow overflow-y-auto"
 					class:px-2={layoutState.isSidebarExpanded}
 					class:pl-2={!layoutState.isSidebarExpanded}
 					class:pr-0={!layoutState.isSidebarExpanded}

--- a/src/routes/api/library/unmatched/match/+server.ts
+++ b/src/routes/api/library/unmatched/match/+server.ts
@@ -7,7 +7,7 @@ import { unmatchedMatchSchema } from '$lib/validation/schemas.js';
 
 export const POST: RequestHandler = async ({ request }: { request: Request }) => {
 	try {
-		const { fileIds, tmdbId, mediaType, season, episodeMapping } = await parseBody(
+		const { fileIds, tmdbId, mediaType, season, episode, episodeMapping } = await parseBody(
 			request,
 			unmatchedMatchSchema
 		);
@@ -17,11 +17,15 @@ export const POST: RequestHandler = async ({ request }: { request: Request }) =>
 			tmdbId,
 			mediaType,
 			season,
+			episode,
 			episodeMapping
 		});
 
+		const firstError = result.errors.length > 0 ? result.errors[0] : undefined;
+
 		return json({
 			success: result.matched > 0,
+			error: result.matched === 0 ? firstError : undefined,
 			data: result,
 			meta: {
 				timestamp: new Date().toISOString(),
@@ -33,7 +37,10 @@ export const POST: RequestHandler = async ({ request }: { request: Request }) =>
 			}
 		});
 	} catch (error) {
-		logger.error('[API] Error matching files', error instanceof Error ? error : undefined);
+		logger.error(
+			{ error: error instanceof Error ? error.message : String(error) },
+			'[API] Error matching files'
+		);
 		return json(
 			{
 				success: false,

--- a/src/routes/library/import/+page.svelte
+++ b/src/routes/library/import/+page.svelte
@@ -130,7 +130,6 @@
 	let selectedGroupId = $state<string | null>(null);
 	let importedGroupIds = $state<string[]>([]);
 	let skippedGroupIds = $state<string[]>([]);
-	let showSelectedItemEditor = $state(false);
 	let groupReviewState = $state<Record<string, GroupReviewState>>({});
 	let detectedGroupQuery = $state('');
 	let detectedGroupFilter = $state<'all' | 'pending' | 'ready' | 'imported' | 'skipped'>('pending');
@@ -686,7 +685,9 @@
 
 	async function fetchSeasonEpisodeTitles(tmdbId: number, season: number, cacheKey: string) {
 		try {
-			const data = await getTmdb(`tv/${tmdbId}/season/${season}`);
+			const data = (await getTmdb(`tv/${tmdbId}/season/${season}`)) as {
+				episodes?: Array<{ episode_number?: number; name?: string }>;
+			} | null;
 			if (data?.episodes && Array.isArray(data.episodes)) {
 				const titles: Record<number, string> = {};
 				for (const ep of data.episodes) {
@@ -963,9 +964,6 @@
 		persistActiveGroupState();
 		selectedGroupId = groupId;
 		loadGroupState(groupId);
-		if (isMultiGroupReview) {
-			showSelectedItemEditor = true;
-		}
 	}
 
 	function markGroupImported(groupId: string) {
@@ -1721,7 +1719,6 @@
 			detectedGroupFilter = 'pending';
 			detectedMediaFilter = 'all';
 			importMediaFilter = 'all';
-			showSelectedItemEditor = true;
 			reviewSelectedSeriesSectionId = null;
 			reviewSelectedSeasonSectionKey = null;
 			importSelectedSeriesSectionId = null;
@@ -1951,7 +1948,6 @@
 		detectedGroupFilter = 'pending';
 		detectedMediaFilter = 'all';
 		importMediaFilter = 'all';
-		showSelectedItemEditor = false;
 		reviewSelectedSeriesSectionId = null;
 		reviewSelectedSeasonSectionKey = null;
 		importSelectedSeriesSectionId = null;
@@ -2263,7 +2259,6 @@
 			onReviewGroup={(groupId) => {
 				switchGroup(groupId);
 				step = 2;
-				showSelectedItemEditor = true;
 			}}
 			onGoToStep={(s: number) => goToStep(s as WizardStep)}
 		/>

--- a/src/routes/library/import/+page.svelte
+++ b/src/routes/library/import/+page.svelte
@@ -21,6 +21,7 @@
 		getLibraryStatus
 	} from '$lib/api';
 	import { searchTmdb as searchTmdbApi } from '$lib/api';
+	import { getTmdb } from '$lib/api/discover.js';
 	import { browseFilesystem } from '$lib/api';
 	import { sortRootFoldersForMediaType } from '$lib/utils/root-folders.js';
 	import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
@@ -158,6 +159,8 @@
 	let executeResult = $state<ExecuteResult | null>(null);
 	let executeError = $state<string | null>(null);
 	let bulkImportSummary = $state<{ importedGroups: number; failedGroups: number } | null>(null);
+	// Cache keyed by "{tmdbId}-S{season}" → map of episodeNumber → title
+	let episodeTitleCache = $state<Record<string, Record<number, string>>>({});
 	let bypassNavigationGuard = false;
 	let leaveImportModalOpen = $state(false);
 	let pendingNavigation = $state<PendingNavigation | null>(null);
@@ -664,6 +667,40 @@
 		}
 	});
 
+	// Fetch TMDB episode titles for matched TV groups and cache by tmdbId+season
+	$effect(() => {
+		if (step !== 2 && step !== 3) return;
+		for (const group of detectionGroups) {
+			if (getEffectiveMediaType(group) !== 'tv' || group.detectedFileCount > 1) continue;
+			const state = groupReviewState[group.id];
+			if (!state) continue;
+			const tmdbId = state.selectedMatch?.tmdbId;
+			const season = state.seasonNumber;
+			if (!tmdbId || season < 0) continue;
+			const cacheKey = `${tmdbId}-S${season}`;
+			if (cacheKey in episodeTitleCache) continue;
+			episodeTitleCache = { ...episodeTitleCache, [cacheKey]: {} };
+			fetchSeasonEpisodeTitles(tmdbId, season, cacheKey);
+		}
+	});
+
+	async function fetchSeasonEpisodeTitles(tmdbId: number, season: number, cacheKey: string) {
+		try {
+			const data = await getTmdb(`tv/${tmdbId}/season/${season}`);
+			if (data?.episodes && Array.isArray(data.episodes)) {
+				const titles: Record<number, string> = {};
+				for (const ep of data.episodes) {
+					if (typeof ep.episode_number === 'number' && ep.name) {
+						titles[ep.episode_number] = ep.name;
+					}
+				}
+				episodeTitleCache = { ...episodeTitleCache, [cacheKey]: titles };
+			}
+		} catch {
+			// episode titles are a nice-to-have - silently skip on error
+		}
+	}
+
 	async function loadRootFolders() {
 		loadingRootFolders = true;
 		try {
@@ -921,27 +958,13 @@
 		return typeof activeGroup.parsedSeason !== 'number';
 	}
 
-	function shouldPreserveSelectedItemEditor(nextGroupId: string): boolean {
-		if (!showSelectedItemEditor || !isMultiGroupReview || step !== 2) {
-			return false;
-		}
-
-		const nextGroup = detectionGroups.find((group) => group.id === nextGroupId);
-		if (!nextGroup) {
-			return false;
-		}
-
-		return getEffectiveMediaType(nextGroup) === 'tv';
-	}
-
 	function switchGroup(groupId: string) {
 		if (groupId === selectedGroupId) return;
-		const preserveSelectedItemEditor = shouldPreserveSelectedItemEditor(groupId);
 		persistActiveGroupState();
 		selectedGroupId = groupId;
 		loadGroupState(groupId);
-		if (isMultiGroupReview && !preserveSelectedItemEditor) {
-			showSelectedItemEditor = false;
+		if (isMultiGroupReview) {
+			showSelectedItemEditor = true;
 		}
 	}
 
@@ -1539,12 +1562,15 @@
 
 	function getGroupEpisodeInfo(
 		group: DetectionGroup
-	): { season: number; episode: number } | null {
+	): { season: number; episode: number; title?: string } | null {
 		if (getEffectiveMediaType(group) !== 'tv') return null;
 		const state = getGroupState(group);
 		if (group.detectedFileCount > 1) return null;
 		if (state.seasonNumber < 0 || state.episodeNumber < 1) return null;
-		return { season: state.seasonNumber, episode: state.episodeNumber };
+		const tmdbId = state.selectedMatch?.tmdbId;
+		const cacheKey = tmdbId ? `${tmdbId}-S${state.seasonNumber}` : null;
+		const title = cacheKey ? episodeTitleCache[cacheKey]?.[state.episodeNumber] : undefined;
+		return { season: state.seasonNumber, episode: state.episodeNumber, title };
 	}
 
 	function canImportGroup(group: DetectionGroup): boolean {
@@ -1695,7 +1721,7 @@
 			detectedGroupFilter = 'pending';
 			detectedMediaFilter = 'all';
 			importMediaFilter = 'all';
-			showSelectedItemEditor = false;
+			showSelectedItemEditor = true;
 			reviewSelectedSeriesSectionId = null;
 			reviewSelectedSeasonSectionKey = null;
 			importSelectedSeriesSectionId = null;
@@ -2134,6 +2160,7 @@
 					{importedGroupIds}
 					{skippedGroupIds}
 					{pendingGroupCount}
+					{readyGroupCount}
 					{remainingGroupCount}
 					{skippedGroupCount}
 					{skipActionsEnabled}
@@ -2160,63 +2187,39 @@
 				/>
 			{/if}
 
-			{#if isMultiGroupReview && !showSelectedItemEditor}
-				<div class="rounded-xl border border-base-300 bg-base-100 p-4 sm:p-5">
-					<div class="flex flex-wrap items-center justify-between gap-3">
-						<div class="min-w-0">
-							<div class="text-sm text-base-content/60">{m.library_import_selectedItem()}</div>
-							<div class="truncate text-lg font-semibold">{activeGroup.displayName}</div>
-							<div class="text-sm text-base-content/70">
-								{formatMediaTypeLabel(activeGroup.inferredMediaType)} • {activeGroup.detectedFileCount ===
-								1
-									? m.library_import_fileCountSingular({ count: activeGroup.detectedFileCount })
-									: m.library_import_fileCount({ count: activeGroup.detectedFileCount })}
-							</div>
-						</div>
-						<button
-							class="btn btn-outline"
-							onclick={() => (showSelectedItemEditor = true)}
-							disabled={isGroupImported(activeGroup.id)}
-						>
-							{m.library_import_configureSelectedItem()}
-						</button>
-					</div>
-				</div>
-			{:else}
-				<GroupEditorPanel
-					{activeGroup}
-					{selectedMediaType}
-					{selectedMatch}
-					bind:searchQuery
-					{matchCandidates}
-					bind:importTarget
-					bind:seasonNumber
-					bind:episodeNumber
-					bind:batchSeasonOverride
-					bind:selectedRootFolder
-					{isMediaTypeLockedByContext}
-					{isBatchTvImport}
-					isGroupImported={isGroupImported(activeGroup?.id ?? '')}
-					isGroupSkipped={isGroupSkipped(activeGroup?.id ?? '')}
-					{skipActionsEnabled}
-					{searchingMatches}
-					{routeImportContext}
-					{selectedMatchContextMismatch}
-					{parsedSourceContextMismatch}
-					{canApplyMatchSelectionToActiveSeason}
-					bind:applyMatchToSeasonOnSelect={applySelectedMatchToSeasonOnSelect}
-					{canImportGroup}
-					{canApplyActiveSeasonOverride}
-					onSwitchMediaType={switchMediaType}
-					onChooseMatch={chooseMatch}
-					onSearchInput={handleMatchSearchInput}
-					onSearch={searchTmdb}
-					onClearSearch={clearMatchSearch}
-					onSeasonNumberChange={handleSeasonNumberChange}
-					onEpisodeNumberChange={persistActiveGroupState}
-					onToggleSkip={toggleSkipActiveGroup}
-				/>
-			{/if}
+			<GroupEditorPanel
+				{activeGroup}
+				{selectedMediaType}
+				{selectedMatch}
+				bind:searchQuery
+				{matchCandidates}
+				bind:importTarget
+				bind:seasonNumber
+				bind:episodeNumber
+				bind:batchSeasonOverride
+				bind:selectedRootFolder
+				{isMediaTypeLockedByContext}
+				{isBatchTvImport}
+				isGroupImported={isGroupImported(activeGroup?.id ?? '')}
+				isGroupSkipped={isGroupSkipped(activeGroup?.id ?? '')}
+				{skipActionsEnabled}
+				{searchingMatches}
+				{routeImportContext}
+				{selectedMatchContextMismatch}
+				{parsedSourceContextMismatch}
+				{canApplyMatchSelectionToActiveSeason}
+				bind:applyMatchToSeasonOnSelect={applySelectedMatchToSeasonOnSelect}
+				{canImportGroup}
+				{canApplyActiveSeasonOverride}
+				onSwitchMediaType={switchMediaType}
+				onChooseMatch={chooseMatch}
+				onSearchInput={handleMatchSearchInput}
+				onSearch={searchTmdb}
+				onClearSearch={clearMatchSearch}
+				onSeasonNumberChange={handleSeasonNumberChange}
+				onEpisodeNumberChange={persistActiveGroupState}
+				onToggleSkip={toggleSkipActiveGroup}
+			/>
 
 			<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 				<button class="btn btn-ghost" onclick={() => goToStep(1)}>{m.action_back()}</button>

--- a/src/routes/library/import/+page.svelte
+++ b/src/routes/library/import/+page.svelte
@@ -1536,6 +1536,16 @@
 		importSelectedSeasonSectionKey = seasonKey;
 	}
 
+	function getGroupEpisodeInfo(
+		group: DetectionGroup
+	): { season: number; episode: number } | null {
+		if (getEffectiveMediaType(group) !== 'tv') return null;
+		const state = getGroupState(group);
+		if (group.detectedFileCount > 1) return null;
+		if (state.seasonNumber < 0 || state.episodeNumber < 1) return null;
+		return { season: state.seasonNumber, episode: state.episodeNumber };
+	}
+
 	function canImportGroup(group: DetectionGroup): boolean {
 		if (importedGroupIds.includes(group.id) || skippedGroupIds.includes(group.id)) {
 			return false;
@@ -2136,6 +2146,7 @@
 					{isSeasonSectionFullySkipped}
 					{getDetectedSeasonsLabel}
 					{canApplySelectedMatchToSeason}
+					{getGroupEpisodeInfo}
 					onSwitchGroup={switchGroup}
 					onSkipGroup={markGroupSkipped}
 					onUnskipGroup={unskipGroup}
@@ -2234,6 +2245,7 @@
 			{executingImport}
 			canImport={canImportGroup}
 			{getEffectiveMediaType}
+			{getGroupEpisodeInfo}
 			getSectionDestinations={getSectionDestinationOptions}
 			getSectionEligibleCount={(section) => getSectionDestinationEligibleGroups(section).length}
 			canApplyDestination={canApplySelectedDestinationToMedia}

--- a/src/routes/library/import/+page.svelte
+++ b/src/routes/library/import/+page.svelte
@@ -165,6 +165,7 @@
 	const routeImportContext = $derived.by(() => parseImportContext(page.url.searchParams));
 	const isDirectLibraryImportContext = $derived.by(() => Boolean(routeImportContext?.libraryId));
 	const isMediaTypeLockedByContext = $derived.by(() => Boolean(routeImportContext));
+	const lockedMediaType = $derived.by(() => routeImportContext?.mediaType ?? undefined);
 	const isFileOnlyContext = $derived.by(() =>
 		Boolean(
 			routeImportContext && routeImportContext.mediaType === 'movie' && routeImportContext.libraryId
@@ -2147,6 +2148,7 @@
 					{getDetectedSeasonsLabel}
 					{canApplySelectedMatchToSeason}
 					{getGroupEpisodeInfo}
+					{lockedMediaType}
 					onSwitchGroup={switchGroup}
 					onSkipGroup={markGroupSkipped}
 					onUnskipGroup={unskipGroup}
@@ -2246,6 +2248,7 @@
 			canImport={canImportGroup}
 			{getEffectiveMediaType}
 			{getGroupEpisodeInfo}
+			{lockedMediaType}
 			getSectionDestinations={getSectionDestinationOptions}
 			getSectionEligibleCount={(section) => getSectionDestinationEligibleGroups(section).length}
 			canApplyDestination={canApplySelectedDestinationToMedia}


### PR DESCRIPTION
## Summary

This PR improves the import wizard UX, fixes episode parsing bugs, and cleans up dead code.

## Related Issues

<!-- Link to related issues -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- **Episode pill on import review/confirm:** Each group now shows a `S##E##` badge (and TMDB episode title when available) so the user can verify mappings before importing
- **Compact import editor panel:** Redesigned the group editor from a two-card layout into a single inline card, reducing visual noise in the wizard
- **Locked media type context:** When the importer is launched from an existing library item, media type filters, skip-season, and apply-to-season controls are hidden since they are irrelevant
- **Match Folder season override:** TV folders whose filenames carry no parsed season now show a warning with a season input; "Match Files" is blocked until a season is provided or all files parse cleanly
- **Absolute episode matching:** Stored absolute episode number in `parsedEpisode` during disk scan; added re-parse fallback in `unmatched-file-service` and `media-matcher` so anime absolute-numbered files resolve correctly via the `episodes` table
- **Fansub/BD-BOX parser fixes:** Split the multi-season range pattern to prevent `S1 - NN` (fansub episode notation) from being misread as a season pack; added BD-BOX naming support
- **Sidebar scroll fix:** Changed sidebar `aside` to `h-[100dvh]` with `overflow-y-auto` scoped to the nav div, so the page remains scrollable while a dropdown menu is open and the footer card is fully visible on mobile
- **Dead state cleanup:** Removed unused `showSelectedItemEditor` variable and typed the TMDB season API response to resolve TypeScript errors

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow conventional commits
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- Before/after screenshots for the import wizard and Match Folder modal -->
