### PR TITLE
fix: library classification 405 and monitor-all scope in custom libraries

### DIFF
--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -293,7 +293,7 @@ export async function getLibraryClassificationSettings() {
 }
 
 export async function updateLibraryClassificationSettings(payload: LibraryClassificationUpdate) {
-	return apiPut('/api/settings/library/classification', payload);
+	return apiPost('/api/settings/library/classification', payload);
 }
 
 export async function getWorker(id: string) {

--- a/src/routes/library/tv/+page.server.ts
+++ b/src/routes/library/tv/+page.server.ts
@@ -451,12 +451,12 @@ export const load: PageServerLoad = async ({ url }) => {
 };
 
 export const actions: Actions = {
-	toggleAllMonitored: async ({ request, url }) => {
+	toggleAllMonitored: async ({ request }) => {
 		const formData = await request.formData();
 		const monitored = formData.get('monitored') === 'true';
 
 		try {
-			const requestedLibraryScope = url.searchParams.get('library')?.trim() || '';
+			const requestedLibraryScope = (formData.get('library') as string | null)?.trim() || '';
 
 			const availableLibraries = await getLibraryEntityService().listLibraries({ mediaType: 'tv' });
 			const defaultLibrary =

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -806,6 +806,7 @@
 		aria-hidden="true"
 	>
 		<input type="hidden" name="monitored" value="true" />
+		<input type="hidden" name="library" value={data.filters.library} />
 	</form>
 	<form
 		id="tv-unmonitor-all"
@@ -816,6 +817,7 @@
 		aria-hidden="true"
 	>
 		<input type="hidden" name="monitored" value="false" />
+		<input type="hidden" name="library" value={data.filters.library} />
 	</form>
 
 	<LibraryDrawer


### PR DESCRIPTION
## Summary

Two small bug fixes in library management; a wrong HTTP method causing a 405 on the enforce anime root folders toggle, and a missing form field that broke monitor-all in custom library(tv) contexts.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Fix 405 error when toggling "Enforce anime root folders"; client was sending `PUT` but the `/api/settings/library/classification` route only handles `POST`
- Pass library scope as a hidden form field on monitor-all so the action correctly targets the active custom library instead of falling back to the global scope

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
