### PR TITLE
feat: Jackett/Prowlarr integration, search enhancement, and log viewer overhaul

### DIFF
--- a/data/indexers/definitions/torznab.yaml
+++ b/data/indexers/definitions/torznab.yaml
@@ -1,7 +1,7 @@
 ---
 id: torznab
 name: Torznab
-description: Connect to any Torznab-compatible API endpoint you host or control (e.g., your own Prowlarr/Jackett instance)
+description: Connect to a self-hosted or third-party Torznab-compatible endpoint
 type: semi-private
 language: en-US
 encoding: UTF-8

--- a/messages/de.json
+++ b/messages/de.json
@@ -2564,7 +2564,7 @@
 	"settings_integrations_captcha_timing": "Zeitsteuerung",
 	"settings_integrations_configured": "Konfiguriert",
 	"settings_integrations_connectionSuccessful": "Verbindung erfolgreich",
-	"settings_integrations_deleteConfirmPrefix": "Bist du sicher, dass du",
+	"settings_integrations_deleteConfirmPrefix": "Bist du sicher, dass du ",
 	"settings_integrations_deleteConfirmSuffix": "löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.",
 	"settings_integrations_downloadClientsDesc": "Anwendungen, die das Herunterladen von Releases von Indexern verwalten.",
 	"settings_integrations_downloadClients_addButton": "Download-Client hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2565,7 +2565,7 @@
 	"settings_integrations_captcha_timing": "Timing",
 	"settings_integrations_configured": "Configured",
 	"settings_integrations_connectionSuccessful": "Connection successful",
-	"settings_integrations_deleteConfirmPrefix": "Are you sure you want to delete",
+	"settings_integrations_deleteConfirmPrefix": "Are you sure you want to delete ",
 	"settings_integrations_deleteConfirmSuffix": "? This action cannot be undone.",
 	"settings_integrations_downloadClientsDesc": "Applications that handle downloading releases from indexers.",
 	"settings_integrations_downloadClients_addButton": "Add Download Client",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2564,7 +2564,7 @@
 	"settings_integrations_captcha_timing": "Temporización",
 	"settings_integrations_configured": "Configurado",
 	"settings_integrations_connectionSuccessful": "Conexión exitosa",
-	"settings_integrations_deleteConfirmPrefix": "¿Estás seguro de que quieres eliminar",
+	"settings_integrations_deleteConfirmPrefix": "¿Estás seguro de que quieres eliminar ",
 	"settings_integrations_deleteConfirmSuffix": "? Esta acción no se puede deshacer.",
 	"settings_integrations_downloadClientsDesc": "Aplicaciones que manejan la descarga de lanzamientos desde indexadores.",
 	"settings_integrations_downloadClients_addButton": "Añadir cliente de descarga",

--- a/src/lib/components/indexers/IndexerFormRegular.svelte
+++ b/src/lib/components/indexers/IndexerFormRegular.svelte
@@ -27,6 +27,8 @@
 		hasAuthSettings: boolean;
 		definitionUrls: string[];
 		alternateUrls: string[];
+		prowlarrManaged?: boolean;
+		jackettManaged?: boolean;
 		onNameChange: (value: string) => void;
 		onUrlChange: (value: string) => void;
 		onUrlBlur: () => void;
@@ -63,6 +65,8 @@
 		hasAuthSettings,
 		definitionUrls,
 		alternateUrls,
+		prowlarrManaged = false,
+		jackettManaged = false,
 		onNameChange,
 		onUrlChange,
 		onUrlBlur,
@@ -150,23 +154,31 @@
 		<div class="form-control">
 			<label class="label py-1" for="regular-name">
 				<span class="label-text">Name</span>
-				<span class="label-text-alt text-xs {nameTooLong ? 'text-error' : 'text-base-content/60'}">
-					{name.length}/{MAX_NAME_LENGTH}
-				</span>
+				{#if !prowlarrManaged && !jackettManaged}
+					<span
+						class="label-text-alt text-xs {nameTooLong ? 'text-error' : 'text-base-content/60'}"
+					>
+						{name.length}/{MAX_NAME_LENGTH}
+					</span>
+				{/if}
 			</label>
-			<input
-				id="regular-name"
-				type="text"
-				class="input-bordered input input-sm"
-				value={name}
-				oninput={(e) => onNameChange(e.currentTarget.value)}
-				maxlength={MAX_NAME_LENGTH}
-				placeholder={definition?.name ?? 'My Indexer'}
-			/>
-			{#if nameTooLong}
-				<p class="label py-0">
-					<span class="label-text-alt text-xs text-error">Max {MAX_NAME_LENGTH} characters.</span>
-				</p>
+			{#if prowlarrManaged || jackettManaged}
+				<p class="py-1.5 text-sm font-medium">{name}</p>
+			{:else}
+				<input
+					id="regular-name"
+					type="text"
+					class="input-bordered input input-sm"
+					value={name}
+					oninput={(e) => onNameChange(e.currentTarget.value)}
+					maxlength={MAX_NAME_LENGTH}
+					placeholder={definition?.name ?? 'My Indexer'}
+				/>
+				{#if nameTooLong}
+					<p class="label py-0">
+						<span class="label-text-alt text-xs text-error">Max {MAX_NAME_LENGTH} characters.</span>
+					</p>
+				{/if}
 			{/if}
 		</div>
 
@@ -174,13 +186,15 @@
 		<div class="form-control">
 			<label class="label py-1" for="regular-url">
 				<span class="label-text">URL</span>
-				{#if alternateUrls.length > 0}
+				{#if !prowlarrManaged && !jackettManaged && alternateUrls.length > 0}
 					<span class="label-text-alt text-xs text-base-content/60">
 						+{alternateUrls.length} failover{alternateUrls.length > 1 ? 's' : ''}
 					</span>
 				{/if}
 			</label>
-			{#if definitionUrls.length > 1}
+			{#if prowlarrManaged || jackettManaged}
+				<p class="py-1.5 font-mono text-xs break-all text-base-content/70">{url}</p>
+			{:else if definitionUrls.length > 1}
 				<select
 					id="regular-url"
 					class="select-bordered select select-sm"
@@ -264,7 +278,17 @@
 	</div>
 
 	<!-- Authentication Section (collapsible, only when has settings) -->
-	{#if hasAuthSettings && definition}
+	{#if prowlarrManaged || jackettManaged}
+		<div
+			class="rounded-box flex items-center gap-3 border border-base-300 bg-base-200/60 px-4 py-3 text-sm text-base-content/70"
+		>
+			<Lock class="h-4 w-4 shrink-0" />
+			<span
+				>Authentication is managed by {prowlarrManaged ? 'Prowlarr' : 'Jackett'}. Use the sync
+				action to apply credential changes.</span
+			>
+		</div>
+	{:else if hasAuthSettings && definition}
 		{@const AuthIcon = authIcon}
 		<div class="collapse rounded-lg bg-base-200" class:collapse-open={authSettingsOpen}>
 			<button

--- a/src/lib/components/indexers/IndexerModal.svelte
+++ b/src/lib/components/indexers/IndexerModal.svelte
@@ -15,6 +15,8 @@
 		indexer?: Indexer | null;
 		definitions: IndexerDefinition[];
 		saving: boolean;
+		prowlarrBaseUrl?: string | null;
+		jackettBaseUrl?: string | null;
 		onClose: () => void;
 		onSave: (data: IndexerFormData) => void | Promise<void>;
 		onDelete?: () => void;
@@ -27,6 +29,8 @@
 		indexer = null,
 		definitions,
 		saving,
+		prowlarrBaseUrl = null,
+		jackettBaseUrl = null,
 		onClose,
 		onSave,
 		onDelete,
@@ -82,6 +86,23 @@
 		selectedDefinition?.protocol ?? indexer?.protocol ?? 'torrent'
 	);
 	const isInternalIndexer = $derived(mode === 'edit' && indexer && !selectedDefinition);
+
+	const isProwlarrManaged = $derived.by(() => {
+		if (mode !== 'edit' || !indexer || !prowlarrBaseUrl) return false;
+		const base = prowlarrBaseUrl.replace(/\/+$/, '');
+		if (!indexer.baseUrl.startsWith(base + '/')) return false;
+		const suffix = indexer.baseUrl.slice(base.length + 1).replace(/\/+$/, '');
+		return /^\d+$/.test(suffix);
+	});
+
+	const isJackettManaged = $derived.by(() => {
+		if (mode !== 'edit' || !indexer || !jackettBaseUrl) return false;
+		const base = jackettBaseUrl.replace(/\/+$/, '');
+		return (
+			indexer.baseUrl.startsWith(base + '/api/v2.0/indexers/') &&
+			indexer.baseUrl.includes('/results/torznab')
+		);
+	});
 
 	const uiHints = $derived(() => {
 		if (selectedDefinition) {
@@ -297,6 +318,44 @@
 			</div>
 		{/if}
 
+		<!-- Prowlarr-managed indexer header -->
+		{#if isProwlarrManaged && indexer}
+			<div class="mb-6 flex items-center gap-3 rounded-lg bg-primary/10 px-4 py-3">
+				<div class="rounded-lg bg-primary/20 p-2">
+					<Lock class="h-5 w-5 text-primary" />
+				</div>
+				<div>
+					<div class="flex items-center gap-2">
+						<span class="font-semibold">{indexer.name}</span>
+						<span class="badge badge-primary badge-sm">Prowlarr</span>
+						<span class="badge badge-ghost badge-sm">{indexer.protocol}</span>
+					</div>
+					<div class="text-sm text-base-content/60">
+						Name, URL, and authentication are managed by Prowlarr.
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Jackett-managed indexer header -->
+		{#if isJackettManaged && indexer}
+			<div class="mb-6 flex items-center gap-3 rounded-lg bg-secondary/10 px-4 py-3">
+				<div class="rounded-lg bg-secondary/20 p-2">
+					<Lock class="h-5 w-5 text-secondary" />
+				</div>
+				<div>
+					<div class="flex items-center gap-2">
+						<span class="font-semibold">{indexer.name}</span>
+						<span class="badge badge-secondary badge-sm">Jackett</span>
+						<span class="badge badge-ghost badge-sm">{indexer.protocol}</span>
+					</div>
+					<div class="text-sm text-base-content/60">
+						Name, URL, and authentication are managed by Jackett.
+					</div>
+				</div>
+			</div>
+		{/if}
+
 		<!-- Internal indexer header (edit mode for auto-managed indexers) -->
 		{#if isInternalIndexer && indexer}
 			<div class="mb-6 flex items-center justify-between rounded-lg bg-info/10 px-4 py-3">
@@ -374,6 +433,8 @@
 				hasAuthSettings={hasAuthSettings ?? false}
 				{definitionUrls}
 				{alternateUrls}
+				prowlarrManaged={isProwlarrManaged}
+				jackettManaged={isJackettManaged}
 				onNameChange={(v) => (name = v)}
 				onUrlChange={(v) => (url = v)}
 				onUrlBlur={() => (urlTouched = true)}
@@ -396,7 +457,9 @@
 		<!-- Actions -->
 		<div class="modal-action">
 			{#if mode === 'edit' && onDelete}
-				<button class="btn mr-auto btn-outline btn-error" onclick={onDelete}>Delete</button>
+				<button class="btn mr-auto btn-outline btn-error" onclick={onDelete}>
+					{isProwlarrManaged || isJackettManaged ? 'Remove' : 'Delete'}
+				</button>
 			{/if}
 
 			<button

--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -21,6 +21,8 @@
 		reorderMode: boolean;
 		isDragOver: boolean;
 		isDragging: boolean;
+		prowlarrBaseUrl?: string | null;
+		jackettBaseUrl?: string | null;
 		onSelect: (id: string, selected: boolean) => void;
 		onEdit: (indexer: IndexerWithStatus) => void;
 		onDelete: (indexer: IndexerWithStatus) => void;
@@ -41,6 +43,8 @@
 		reorderMode,
 		isDragOver,
 		isDragging,
+		prowlarrBaseUrl = null,
+		jackettBaseUrl = null,
 		onSelect,
 		onEdit,
 		onDelete,
@@ -52,6 +56,23 @@
 		onDrop,
 		onDragEnd
 	}: Props = $props();
+
+	function isProwlarrIndexer(): boolean {
+		if (!prowlarrBaseUrl) return false;
+		const base = prowlarrBaseUrl.replace(/\/+$/, '');
+		if (!indexer.baseUrl.startsWith(base + '/')) return false;
+		const suffix = indexer.baseUrl.slice(base.length + 1).replace(/\/+$/, '');
+		return /^\d+$/.test(suffix);
+	}
+
+	function isJackettIndexer(): boolean {
+		if (!jackettBaseUrl) return false;
+		const base = jackettBaseUrl.replace(/\/+$/, '');
+		return (
+			indexer.baseUrl.startsWith(base + '/api/v2.0/indexers/') &&
+			indexer.baseUrl.includes('/results/torznab')
+		);
+	}
 
 	function truncateUrl(url: string, maxLength: number = 30): string {
 		if (url.length <= maxLength) return url;
@@ -93,14 +114,25 @@
 			consecutiveFailures={indexer.status?.consecutiveFailures ?? 0}
 			lastFailure={indexer.status?.lastFailure}
 			disabledUntil={indexer.status?.disabledUntil}
+			jackettManaged={isJackettIndexer()}
 		/>
 	</td>
 
 	<!-- Name -->
 	<td>
-		<button class="link font-bold link-hover" onclick={() => onEdit(indexer)}>
-			{indexer.name}
-		</button>
+		<div class="flex flex-wrap items-center gap-1.5">
+			<button class="link font-bold link-hover" onclick={() => onEdit(indexer)}>
+				{indexer.name}
+			</button>
+			{#if isProwlarrIndexer()}
+				<span class="badge badge-primary badge-xs">Prowlarr</span>
+				{#if indexer.settings?.prowlarrEnabled === 'false'}
+					<span class="badge badge-warning badge-xs">Disabled in Prowlarr</span>
+				{/if}
+			{:else if isJackettIndexer()}
+				<span class="badge badge-secondary badge-xs">Jackett</span>
+			{/if}
+		</div>
 	</td>
 
 	<!-- Definition -->
@@ -148,7 +180,7 @@
 
 	<!-- URL -->
 	<td class="max-w-50">
-		<div class="tooltip" data-tip={indexer.baseUrl}>
+		<div class="tooltip block w-full" data-tip={indexer.baseUrl}>
 			<span class="block truncate text-sm text-base-content/70">
 				{truncateUrl(indexer.baseUrl)}
 			</span>

--- a/src/lib/components/indexers/IndexerStatusBadge.svelte
+++ b/src/lib/components/indexers/IndexerStatusBadge.svelte
@@ -7,9 +7,20 @@
 		consecutiveFailures?: number;
 		lastFailure?: string;
 		disabledUntil?: string;
+		jackettManaged?: boolean;
 	}
 
-	let { enabled, consecutiveFailures = 0, lastFailure, disabledUntil }: Props = $props();
+	let {
+		enabled,
+		consecutiveFailures = 0,
+		lastFailure,
+		disabledUntil,
+		jackettManaged = false
+	}: Props = $props();
+
+	const flaresolverrHint = $derived(
+		jackettManaged ? ' If FlareSolverr is involved, click Test to reset.' : ''
+	);
 
 	const hasFailures = $derived(consecutiveFailures > 0);
 	const isAutoDisabled = $derived(!!disabledUntil && new Date(disabledUntil) > new Date());
@@ -29,7 +40,8 @@
 				text: m.settings_indexers_status_unhealthy(),
 				class: 'badge-error',
 				icon: AlertTriangle,
-				tooltip: m.settings_indexers_tooltip_unhealthy({ until, consecutiveFailures })
+				tooltip:
+					m.settings_indexers_tooltip_unhealthy({ until, consecutiveFailures }) + flaresolverrHint
 			};
 		}
 		if (hasFailures) {
@@ -38,7 +50,9 @@
 				text: m.settings_indexers_status_degraded(),
 				class: 'badge-warning',
 				icon: AlertTriangle,
-				tooltip: m.settings_indexers_tooltip_degraded({ consecutiveFailures, failureTime })
+				tooltip:
+					m.settings_indexers_tooltip_degraded({ consecutiveFailures, failureTime }) +
+					flaresolverrHint
 			};
 		}
 		return {

--- a/src/lib/components/indexers/IndexerTable.svelte
+++ b/src/lib/components/indexers/IndexerTable.svelte
@@ -24,6 +24,8 @@
 		canReorder: boolean;
 		testingIds: Set<string>;
 		togglingIds: Set<string>;
+		prowlarrBaseUrl?: string | null;
+		jackettBaseUrl?: string | null;
 		onSelect: (id: string, selected: boolean) => void;
 		onSelectAll: (selected: boolean) => void;
 		onSort: (column: IndexerSort['column']) => void;
@@ -42,6 +44,8 @@
 		canReorder,
 		testingIds,
 		togglingIds,
+		prowlarrBaseUrl = null,
+		jackettBaseUrl = null,
 		onSelect,
 		onSelectAll,
 		onSort,
@@ -62,6 +66,23 @@
 	const reorderDisabledReason = $derived(
 		canReorder ? '' : 'Clear filters to reorder all indexers by priority'
 	);
+
+	function isProwlarrIndexer(indexer: IndexerWithStatus): boolean {
+		if (!prowlarrBaseUrl) return false;
+		const base = prowlarrBaseUrl.replace(/\/+$/, '');
+		if (!indexer.baseUrl.startsWith(base + '/')) return false;
+		const suffix = indexer.baseUrl.slice(base.length + 1).replace(/\/+$/, '');
+		return /^\d+$/.test(suffix);
+	}
+
+	function isJackettIndexer(indexer: IndexerWithStatus): boolean {
+		if (!jackettBaseUrl) return false;
+		const base = jackettBaseUrl.replace(/\/+$/, '');
+		return (
+			indexer.baseUrl.startsWith(base + '/api/v2.0/indexers/') &&
+			indexer.baseUrl.includes('/results/torznab')
+		);
+	}
 
 	function isSortedBy(column: IndexerSort['column']): boolean {
 		return sort.column === column;
@@ -236,10 +257,21 @@
 									consecutiveFailures={indexer.status?.consecutiveFailures ?? 0}
 									lastFailure={indexer.status?.lastFailure}
 									disabledUntil={indexer.status?.disabledUntil}
+									jackettManaged={isJackettIndexer(indexer)}
 								/>
 							</div>
-							<div class="truncate text-xs text-base-content/60">
-								{indexer.definitionName ?? indexer.definitionId}
+							<div class="mt-0.5 flex flex-wrap items-center gap-1">
+								<span class="text-xs text-base-content/60">
+									{indexer.definitionName ?? indexer.definitionId}
+								</span>
+								{#if isProwlarrIndexer(indexer)}
+									<span class="badge badge-primary badge-xs">Prowlarr</span>
+									{#if indexer.settings?.prowlarrEnabled === 'false'}
+										<span class="badge badge-warning badge-xs">Disabled in Prowlarr</span>
+									{/if}
+								{:else if isJackettIndexer(indexer)}
+									<span class="badge badge-secondary badge-xs">Jackett</span>
+								{/if}
 							</div>
 						</div>
 					</div>
@@ -460,6 +492,8 @@
 						{reorderMode}
 						isDragOver={dragOverIndex === index}
 						isDragging={draggedIndex === index}
+						{prowlarrBaseUrl}
+						{jackettBaseUrl}
 						{onSelect}
 						{onEdit}
 						{onDelete}

--- a/src/lib/components/indexers/JackettImportModal.svelte
+++ b/src/lib/components/indexers/JackettImportModal.svelte
@@ -1,0 +1,813 @@
+<script lang="ts">
+	import {
+		X,
+		Download,
+		Loader2,
+		CheckCircle,
+		XCircle,
+		AlertCircle,
+		WifiOff,
+		RefreshCw,
+		Settings,
+		Trash2,
+		ArrowLeft
+	} from 'lucide-svelte';
+	import { untrack } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
+	import { createIndexer, ApiError } from '$lib/api';
+	import { getResponseErrorMessage } from '$lib/utils/http';
+	import { invalidateAll } from '$app/navigation';
+
+	interface JackettIndexer {
+		id: string;
+		name: string;
+		type: string;
+		baseUrl: string;
+		alreadyImported: boolean;
+	}
+
+	interface StoredConnection {
+		url: string;
+		autoSync: boolean;
+		syncIntervalHours: number;
+		syncAddNew: boolean;
+		lastSyncAt: string | null;
+		lastSyncResult: SyncResult | null;
+		lastSyncError: string | null;
+	}
+
+	interface SyncResult {
+		updated: number;
+		removed: number;
+		added: number;
+		failed: number;
+		errors: string[];
+	}
+
+	interface Props {
+		open: boolean;
+		storedConnection: StoredConnection | null;
+		onClose: () => void;
+	}
+
+	let { open, storedConnection, onClose }: Props = $props();
+
+	type Step = 'manage' | 'connect' | 'selectIndexers' | 'done';
+
+	let step = $state<Step>('connect');
+	let jackettUrl = $state('');
+	let apiKey = $state('');
+	let adminPassword = $state('');
+	let autoSync = $state(false);
+	let syncIntervalHours = $state(24);
+	let syncAddNew = $state(false);
+	let connection = $state<StoredConnection | null>(null);
+
+	$effect(() => {
+		if (open) {
+			const conn = untrack(() => storedConnection);
+			connection = conn;
+			step = conn ? 'manage' : 'connect';
+			jackettUrl = conn?.url ?? '';
+			apiKey = '';
+			adminPassword = '';
+			autoSync = conn?.autoSync ?? false;
+			syncIntervalHours = conn?.syncIntervalHours ?? 24;
+			syncAddNew = conn?.syncAddNew ?? false;
+			connectError = '';
+			syncing = false;
+			syncError = '';
+			importing = false;
+			doneResult = null;
+			confirmingDelete = false;
+			indexers = [];
+			selected.clear();
+		}
+	});
+
+	let connecting = $state(false);
+	let connectError = $state('');
+
+	let indexers = $state<JackettIndexer[]>([]);
+	let selected = new SvelteSet<string>();
+	let importing = $state(false);
+	let browsingIndexers = $state(false);
+
+	let syncing = $state(false);
+	let syncError = $state('');
+
+	let doneResult = $state<{ type: 'import' | 'sync'; result: SyncResult } | null>(null);
+	let confirmingDelete = $state(false);
+
+	let savingSettings = $state(false);
+	let saveSettingsTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function scheduleSettingsSave() {
+		if (!connection) return;
+		if (saveSettingsTimer) clearTimeout(saveSettingsTimer);
+		saveSettingsTimer = setTimeout(async () => {
+			if (!connection) return;
+			savingSettings = true;
+			try {
+				const res = await fetch('/api/indexers/jackett/connection', {
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ url: connection.url, autoSync, syncIntervalHours, syncAddNew })
+				});
+				if (res.ok) {
+					await invalidateAll();
+				}
+			} finally {
+				savingSettings = false;
+			}
+		}, 400);
+	}
+
+	function handleClose() {
+		onClose();
+	}
+
+	async function handleConnect() {
+		connectError = '';
+		connecting = true;
+		try {
+			const res = await fetch('/api/indexers/jackett/connection', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					url: jackettUrl,
+					apiKey,
+					adminPassword: adminPassword || undefined,
+					autoSync,
+					syncIntervalHours,
+					syncAddNew
+				})
+			});
+			const data = await res.json();
+			if (!res.ok) {
+				connectError = data.error ?? 'Failed to connect to Jackett.';
+				return;
+			}
+
+			const indexerRes = await fetch('/api/indexers/jackett', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ url: jackettUrl, apiKey })
+			});
+			const indexerData = await indexerRes.json();
+			if (!indexerRes.ok) {
+				connectError = indexerData.error ?? 'Failed to fetch indexers.';
+				return;
+			}
+
+			indexers = indexerData.indexers as JackettIndexer[];
+			selected.clear();
+			for (const i of indexers) {
+				if (!i.alreadyImported) selected.add(i.id);
+			}
+			connection = {
+				url: jackettUrl,
+				autoSync,
+				syncIntervalHours,
+				syncAddNew,
+				lastSyncAt: null,
+				lastSyncResult: null,
+				lastSyncError: null
+			};
+			step = 'selectIndexers';
+		} catch {
+			connectError = 'Unable to reach Jackett. Check the URL and try again.';
+		} finally {
+			connecting = false;
+		}
+	}
+
+	async function handleImport() {
+		importing = true;
+		const toImport = indexers.filter((i) => selected.has(i.id));
+		const result: SyncResult = { updated: 0, added: 0, removed: 0, failed: 0, errors: [] };
+
+		for (const indexer of toImport) {
+			try {
+				await createIndexer({
+					name: indexer.name,
+					definitionId: 'torznab',
+					baseUrl: indexer.baseUrl,
+					alternateUrls: [],
+					enabled: true,
+					priority: 25,
+					settings: { apikey: apiKey },
+					enableAutomaticSearch: true,
+					enableInteractiveSearch: true,
+					minimumSeeders: 1,
+					seedRatio: null,
+					seedTime: null,
+					packSeedTime: null,
+					rejectDeadTorrents: true
+				});
+				result.added += 1;
+			} catch (e) {
+				const error =
+					e instanceof ApiError
+						? getResponseErrorMessage(e.response, 'Import failed')
+						: e instanceof Error
+							? e.message
+							: 'Unknown error';
+				result.failed += 1;
+				result.errors.push(`${indexer.name}: ${String(error)}`);
+			}
+		}
+
+		importing = false;
+		doneResult = { type: 'import', result };
+		step = 'done';
+		await invalidateAll();
+	}
+
+	async function browseAndImport() {
+		browsingIndexers = true;
+		connectError = '';
+		try {
+			const res = await fetch('/api/indexers/jackett/indexers');
+			const data = await res.json();
+			if (!res.ok) {
+				connectError = data.error ?? 'Failed to fetch indexers.';
+				return;
+			}
+			indexers = data.indexers as JackettIndexer[];
+			selected.clear();
+			for (const i of indexers) {
+				if (!i.alreadyImported) selected.add(i.id);
+			}
+			step = 'selectIndexers';
+		} catch {
+			connectError = 'Unable to reach Jackett.';
+		} finally {
+			browsingIndexers = false;
+		}
+	}
+
+	async function handleSyncNow() {
+		syncing = true;
+		syncError = '';
+		try {
+			const res = await fetch('/api/indexers/jackett/sync', { method: 'POST' });
+			const data = await res.json();
+			if (!res.ok) {
+				syncError = data.error ?? 'Sync failed.';
+				return;
+			}
+			await refreshConnection();
+			doneResult = { type: 'sync', result: data.result as SyncResult };
+			step = 'done';
+			await invalidateAll();
+		} catch {
+			syncError = 'Sync failed. Check that Jackett is still accessible.';
+		} finally {
+			syncing = false;
+		}
+	}
+
+	async function handleDeleteConnection() {
+		try {
+			await fetch('/api/indexers/jackett/connection', { method: 'DELETE' });
+			connection = null;
+			step = 'connect';
+			jackettUrl = '';
+			apiKey = '';
+			autoSync = false;
+			syncIntervalHours = 24;
+			confirmingDelete = false;
+			await invalidateAll();
+		} catch {
+			// ignore
+		}
+	}
+
+	async function refreshConnection() {
+		try {
+			const res = await fetch('/api/indexers/jackett/connection');
+			if (res.ok) {
+				const data = await res.json();
+				connection = data.connection as StoredConnection | null;
+			}
+		} catch {
+			// ignore
+		}
+	}
+
+	function formatRelativeTime(isoString: string | null): string {
+		if (!isoString) return 'Never';
+		const diffMs = Date.now() - new Date(isoString).getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		if (diffMins < 1) return 'Just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		const diffHours = Math.floor(diffMins / 60);
+		if (diffHours < 24) return `${diffHours}h ago`;
+		return `${Math.floor(diffHours / 24)}d ago`;
+	}
+
+	function toggleAll(checked: boolean) {
+		selected.clear();
+		if (checked) {
+			for (const i of indexers) {
+				if (!i.alreadyImported) selected.add(i.id);
+			}
+		}
+	}
+
+	function toggleOne(id: string, checked: boolean) {
+		if (checked) selected.add(id);
+		else selected.delete(id);
+	}
+
+	const selectableIds = $derived(indexers.filter((i) => !i.alreadyImported).map((i) => i.id));
+	const allSelected = $derived(
+		selectableIds.length > 0 && selectableIds.every((id) => selected.has(id))
+	);
+	const someSelected = $derived(selected.size > 0 && !allSelected);
+
+	const stepTitle = $derived(
+		step === 'manage'
+			? 'Jackett Connection'
+			: step === 'selectIndexers'
+				? 'Select Indexers'
+				: step === 'done'
+					? 'Done'
+					: connection
+						? 'Change Connection'
+						: 'Connect to Jackett'
+	);
+</script>
+
+<ModalWrapper {open} onClose={handleClose} maxWidth="lg" flexContent>
+	<!-- Header -->
+	<div class="flex shrink-0 items-center justify-between border-b border-base-300 px-6 py-4">
+		<div class="flex items-center gap-2">
+			{#if step === 'selectIndexers'}
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-square -ml-1"
+					onclick={() => (step = connection ? 'manage' : 'connect')}
+					aria-label="Back"
+				>
+					<ArrowLeft class="h-4 w-4" />
+				</button>
+			{/if}
+			<Download class="h-5 w-5 text-primary" />
+			<h2 class="text-lg font-semibold">{stepTitle}</h2>
+		</div>
+		<button type="button" class="btn btn-ghost btn-sm btn-square" onclick={handleClose}>
+			<X class="h-4 w-4" />
+		</button>
+	</div>
+
+	<!-- Step: Connect / Change Connection -->
+	{#if step === 'connect'}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<p class="text-sm text-base-content/70">
+				{connection
+					? 'Enter new connection details. Existing imported indexers will not be affected.'
+					: 'Enter your Jackett URL and API key. Each indexer will be imported as a separate Torznab entry.'}
+			</p>
+			<div class="form-control">
+				<label class="label" for="jackett-url">
+					<span class="label-text">Jackett URL</span>
+				</label>
+				<input
+					id="jackett-url"
+					type="url"
+					class="input input-bordered w-full"
+					placeholder="http://localhost:9117"
+					bind:value={jackettUrl}
+					disabled={connecting}
+				/>
+			</div>
+			<div class="form-control">
+				<label class="label" for="jackett-key">
+					<span class="label-text">API Key</span>
+				</label>
+				<input
+					id="jackett-key"
+					type="password"
+					class="input input-bordered w-full font-mono"
+					placeholder="Your Jackett API key"
+					bind:value={apiKey}
+					disabled={connecting}
+					onkeydown={(e) => e.key === 'Enter' && jackettUrl && apiKey && handleConnect()}
+				/>
+				<p class="mt-1 text-xs text-base-content/60">
+					Found in Jackett under the dashboard - API Key field at the top right
+				</p>
+			</div>
+			<div class="form-control">
+				<label class="label" for="jackett-admin-password">
+					<span class="label-text"
+						>Admin Password <span class="text-base-content/50">(optional)</span></span
+					>
+				</label>
+				<input
+					id="jackett-admin-password"
+					type="password"
+					class="input input-bordered w-full"
+					placeholder="Leave blank if no password is set"
+					bind:value={adminPassword}
+					disabled={connecting}
+				/>
+				<p class="mt-1 text-xs text-base-content/60">
+					Only required if you set one in Jackett under Config → Admin password
+				</p>
+			</div>
+			<div class="divider my-2 text-xs text-base-content/50">Auto-sync</div>
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Automatic sync</p>
+					<p class="text-xs text-base-content/60">
+						Update existing indexers and remove deleted ones on a schedule
+					</p>
+				</div>
+				<input type="checkbox" class="toggle toggle-primary toggle-sm" bind:checked={autoSync} />
+			</div>
+			{#if autoSync}
+				<div class="form-control">
+					<label class="label py-1" for="sync-interval">
+						<span class="label-text text-sm">Sync interval</span>
+					</label>
+					<select
+						id="sync-interval"
+						class="select select-bordered select-sm"
+						bind:value={syncIntervalHours}
+					>
+						<option value={6}>Every 6 hours</option>
+						<option value={12}>Every 12 hours</option>
+						<option value={24}>Daily (recommended)</option>
+						<option value={48}>Every 2 days</option>
+						<option value={168}>Weekly</option>
+					</select>
+				</div>
+			{/if}
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Import new indexers during sync</p>
+					<p class="text-xs text-base-content/60">
+						Automatically add Jackett indexers you haven't imported yet
+					</p>
+				</div>
+				<input type="checkbox" class="toggle toggle-primary toggle-sm" bind:checked={syncAddNew} />
+			</div>
+			{#if connectError}
+				<div class="alert alert-error py-2 text-sm">{connectError}</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+			<button type="button" class="btn btn-ghost btn-sm" onclick={handleClose}>Cancel</button>
+			<button
+				type="button"
+				class="btn btn-primary btn-sm"
+				onclick={handleConnect}
+				disabled={!jackettUrl || !apiKey || connecting}
+			>
+				{#if connecting}
+					<Loader2 class="h-4 w-4 animate-spin" />
+					Connecting...
+				{:else}
+					Connect
+				{/if}
+			</button>
+		</div>
+
+		<!-- Step: Manage existing connection -->
+	{:else if step === 'manage'}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<div
+				class="rounded-box space-y-2 p-4 {connection?.lastSyncError
+					? 'border border-warning/30 bg-warning/5'
+					: 'bg-base-200/60'}"
+			>
+				<div class="flex items-start justify-between gap-4">
+					<div class="min-w-0">
+						<p class="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+							Connected to
+						</p>
+						<p class="mt-0.5 truncate text-sm font-medium">{connection?.url}</p>
+					</div>
+					{#if connection?.lastSyncError}
+						<WifiOff class="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+					{:else}
+						<CheckCircle class="mt-0.5 h-5 w-5 shrink-0 text-success" />
+					{/if}
+				</div>
+				{#if connection?.lastSyncError}
+					<p class="text-xs text-warning">{connection.lastSyncError}</p>
+				{/if}
+				<div class="flex flex-wrap items-center gap-x-4 gap-y-1 pt-1 text-xs text-base-content/60">
+					<span>Last synced: {formatRelativeTime(connection?.lastSyncAt ?? null)}</span>
+					{#if connection?.lastSyncResult && !connection?.lastSyncError}
+						{@const r = connection.lastSyncResult}
+						{#if r.failed > 0}
+							<span class="flex items-center gap-1 text-warning">
+								<AlertCircle class="h-3.5 w-3.5" />
+								{r.updated} updated · {r.removed} removed{r.added > 0 ? ` · ${r.added} added` : ''} ·
+								{r.failed} failed
+							</span>
+						{:else}
+							<span
+								>{r.updated} updated · {r.removed} removed{r.added > 0
+									? ` · ${r.added} added`
+									: ''}</span
+							>
+						{/if}
+					{/if}
+				</div>
+			</div>
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Sync now</p>
+					<p class="text-xs text-base-content/60">Update existing indexers, remove deleted ones</p>
+				</div>
+				<button
+					type="button"
+					class="btn btn-primary btn-sm gap-1.5"
+					onclick={handleSyncNow}
+					disabled={syncing}
+				>
+					{#if syncing}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Syncing...
+					{:else}
+						<RefreshCw class="h-4 w-4" />
+						Sync
+					{/if}
+				</button>
+			</div>
+
+			{#if syncError}
+				<div class="alert alert-error py-2 text-sm">{syncError}</div>
+			{/if}
+
+			<div class="divider my-1 text-xs text-base-content/50">Auto-sync settings</div>
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Automatic sync</p>
+					<p class="text-xs text-base-content/60">Keep indexers in sync automatically</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary toggle-sm"
+					checked={autoSync}
+					onchange={(e) => {
+						autoSync = (e.currentTarget as HTMLInputElement).checked;
+						scheduleSettingsSave();
+					}}
+				/>
+			</div>
+			{#if autoSync}
+				<div class="form-control">
+					<label class="label py-1" for="manage-sync-interval">
+						<span class="label-text text-sm">Sync interval</span>
+					</label>
+					<select
+						id="manage-sync-interval"
+						class="select select-bordered select-sm"
+						value={syncIntervalHours}
+						onchange={(e) => {
+							syncIntervalHours = Number((e.currentTarget as HTMLSelectElement).value);
+							scheduleSettingsSave();
+						}}
+					>
+						<option value={6}>Every 6 hours</option>
+						<option value={12}>Every 12 hours</option>
+						<option value={24}>Daily (recommended)</option>
+						<option value={48}>Every 2 days</option>
+						<option value={168}>Weekly</option>
+					</select>
+				</div>
+			{/if}
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Import new indexers during sync</p>
+					<p class="text-xs text-base-content/60">
+						Automatically add Jackett indexers you haven't imported yet
+					</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary toggle-sm"
+					checked={syncAddNew}
+					onchange={(e) => {
+						syncAddNew = (e.currentTarget as HTMLInputElement).checked;
+						scheduleSettingsSave();
+					}}
+				/>
+			</div>
+
+			{#if connectError}
+				<div class="alert alert-error py-2 text-sm">{connectError}</div>
+			{/if}
+
+			<div class="divider my-1"></div>
+
+			{#if confirmingDelete}
+				<div class="rounded-box space-y-2 border border-error/30 bg-error/5 p-3">
+					<p class="text-sm font-medium text-error">Delete this connection?</p>
+					<p class="text-xs text-base-content/70">
+						Already imported indexers will remain in Cinephage. Only the saved connection and
+						auto-sync will be removed.
+					</p>
+					<div class="flex gap-2 pt-1">
+						<button type="button" class="btn btn-error btn-xs" onclick={handleDeleteConnection}>
+							<Trash2 class="h-3.5 w-3.5" />
+							Yes, delete
+						</button>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs"
+							onclick={() => (confirmingDelete = false)}>Cancel</button
+						>
+					</div>
+				</div>
+			{:else}
+				<div class="flex items-center justify-between">
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm gap-1.5 text-base-content/60"
+						onclick={() => {
+							jackettUrl = connection?.url ?? '';
+							apiKey = '';
+							connectError = '';
+							step = 'connect';
+						}}
+					>
+						<Settings class="h-4 w-4" />
+						Change connection
+					</button>
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm gap-1.5 text-error/70"
+						onclick={() => (confirmingDelete = true)}
+					>
+						<Trash2 class="h-4 w-4" />
+						Delete connection
+					</button>
+				</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm gap-1.5"
+				disabled={browsingIndexers}
+				onclick={browseAndImport}
+			>
+				{#if browsingIndexers}
+					<Loader2 class="h-4 w-4 animate-spin" />
+					Loading...
+				{:else}
+					<Download class="h-4 w-4" />
+					Browse &amp; import
+				{/if}
+			</button>
+			<button type="button" class="btn btn-primary btn-sm" onclick={handleClose}>
+				{#if savingSettings}
+					<Loader2 class="h-4 w-4 animate-spin" />
+				{/if}
+				Close
+			</button>
+		</div>
+
+		<!-- Step: Browse / select indexers -->
+	{:else if step === 'selectIndexers'}
+		{#if indexers.length === 0}
+			<div class="flex flex-col items-center justify-center gap-3 p-10">
+				<Loader2 class="h-6 w-6 animate-spin text-base-content/40" />
+				<p class="text-sm text-base-content/60">Loading indexers from Jackett...</p>
+			</div>
+		{:else}
+			<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+				<div class="shrink-0 border-b border-base-300 px-6 py-3">
+					<p class="text-sm text-base-content/70">
+						{indexers.length} indexer{indexers.length !== 1 ? 's' : ''} found.
+						{selected.size} selected for import.
+					</p>
+				</div>
+				<div class="flex-1 overflow-y-auto">
+					<div class="flex items-center gap-3 border-b border-base-300 bg-base-200/40 px-4 py-2.5">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							checked={allSelected}
+							indeterminate={someSelected}
+							onchange={(e) => toggleAll((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="text-sm font-medium">Select all</span>
+					</div>
+					{#each indexers as indexer (indexer.id)}
+						<label
+							class="flex cursor-pointer items-center gap-3 border-b border-base-300/40 px-4 py-3 last:border-0 hover:bg-base-200/40 {indexer.alreadyImported
+								? 'opacity-50'
+								: ''}"
+						>
+							<input
+								type="checkbox"
+								class="checkbox checkbox-sm shrink-0"
+								checked={selected.has(indexer.id)}
+								disabled={indexer.alreadyImported}
+								onchange={(e) => toggleOne(indexer.id, (e.target as HTMLInputElement).checked)}
+							/>
+							<div class="min-w-0 flex-1">
+								<div class="flex flex-wrap items-center gap-1.5">
+									<span class="text-sm font-medium">{indexer.name}</span>
+									{#if indexer.alreadyImported}
+										<span class="badge badge-ghost badge-xs">already added</span>
+									{/if}
+								</div>
+								<div class="mt-0.5 text-xs text-base-content/50">
+									Torznab · {indexer.type}
+								</div>
+							</div>
+						</label>
+					{/each}
+				</div>
+			</div>
+			<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm"
+					onclick={() => (step = connection ? 'manage' : 'connect')}
+				>
+					Back
+				</button>
+				<button
+					type="button"
+					class="btn btn-primary btn-sm"
+					onclick={handleImport}
+					disabled={selected.size === 0 || importing}
+				>
+					{#if importing}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Importing...
+					{:else}
+						Import {selected.size} indexer{selected.size !== 1 ? 's' : ''}
+					{/if}
+				</button>
+			</div>
+		{/if}
+
+		<!-- Step: Done -->
+	{:else if step === 'done' && doneResult}
+		{@const { result } = doneResult}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<div class="flex items-start gap-2">
+				{#if result.failed === 0}
+					<CheckCircle class="mt-0.5 h-5 w-5 shrink-0 text-success" />
+					<div>
+						<p class="text-sm font-medium">
+							{doneResult.type === 'sync' ? 'Sync complete' : 'Import complete'}
+						</p>
+						<p class="mt-0.5 text-sm text-base-content/70">
+							{#if doneResult.type === 'sync'}
+								{result.updated} updated · {result.removed} removed{result.added > 0
+									? ` · ${result.added} added`
+									: ''}
+							{:else}
+								Imported {result.added} indexer{result.added !== 1 ? 's' : ''}
+							{/if}
+						</p>
+					</div>
+				{:else if result.updated === 0 && result.added === 0 && result.removed === 0}
+					<XCircle class="mt-0.5 h-5 w-5 shrink-0 text-error" />
+					<p class="text-sm font-medium">
+						All {result.failed} operation{result.failed !== 1 ? 's' : ''} failed.
+					</p>
+				{:else}
+					<AlertCircle class="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+					<div>
+						<p class="text-sm font-medium">Completed with errors</p>
+						<p class="mt-0.5 text-sm text-base-content/70">
+							{result.updated} updated · {result.removed} removed{result.added > 0
+								? ` · ${result.added} added`
+								: ''} · {result.failed} failed
+						</p>
+					</div>
+				{/if}
+			</div>
+			{#if result.errors.length > 0}
+				<div class="space-y-1.5">
+					{#each result.errors as error (error)}
+						<div class="flex items-start gap-2 text-sm text-error">
+							<XCircle class="mt-0.5 h-4 w-4 shrink-0" />
+							<span>{error}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-end border-t border-base-300 px-6 py-4">
+			<button type="button" class="btn btn-primary btn-sm" onclick={handleClose}>Done</button>
+		</div>
+	{/if}
+</ModalWrapper>

--- a/src/lib/components/indexers/ProwlarrImportModal.svelte
+++ b/src/lib/components/indexers/ProwlarrImportModal.svelte
@@ -1,0 +1,803 @@
+<script lang="ts">
+	import {
+		X,
+		Download,
+		Loader2,
+		CheckCircle,
+		XCircle,
+		AlertCircle,
+		WifiOff,
+		RefreshCw,
+		Settings,
+		Trash2,
+		ArrowLeft
+	} from 'lucide-svelte';
+	import { untrack } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
+	import { createIndexer, ApiError } from '$lib/api';
+	import { getResponseErrorMessage } from '$lib/utils/http';
+	import { invalidateAll } from '$app/navigation';
+
+	interface ProwlarrIndexer {
+		id: number;
+		name: string;
+		enabled: boolean;
+		protocol: 'torrent' | 'usenet';
+		definitionId: 'torznab' | 'newznab';
+		baseUrl: string;
+		privacy: string;
+		alreadyImported: boolean;
+	}
+
+	interface StoredConnection {
+		url: string;
+		autoSync: boolean;
+		syncIntervalHours: number;
+		syncAddNew: boolean;
+		lastSyncAt: string | null;
+		lastSyncResult: SyncResult | null;
+		lastSyncError: string | null;
+	}
+
+	interface SyncResult {
+		updated: number;
+		removed: number;
+		added: number;
+		failed: number;
+		errors: string[];
+	}
+
+	interface Props {
+		open: boolean;
+		storedConnection: StoredConnection | null;
+		onClose: () => void;
+	}
+
+	let { open, storedConnection, onClose }: Props = $props();
+
+	type Step = 'manage' | 'connect' | 'selectIndexers' | 'done';
+
+	let step = $state<Step>('connect');
+	let prowlarrUrl = $state('');
+	let apiKey = $state('');
+	let autoSync = $state(false);
+	let syncIntervalHours = $state(24);
+	let syncAddNew = $state(false);
+	let connection = $state<StoredConnection | null>(null);
+
+	// Re-initialize state only when the modal transitions to open.
+	// storedConnection is read via untrack so mid-session invalidateAll() calls
+	// don't reset in-progress toggle changes.
+	$effect(() => {
+		if (open) {
+			const conn = untrack(() => storedConnection);
+			connection = conn;
+			step = conn ? 'manage' : 'connect';
+			prowlarrUrl = conn?.url ?? '';
+			apiKey = '';
+			autoSync = conn?.autoSync ?? false;
+			syncIntervalHours = conn?.syncIntervalHours ?? 24;
+			syncAddNew = conn?.syncAddNew ?? false;
+			connectError = '';
+			syncing = false;
+			syncError = '';
+			importing = false;
+			doneResult = null;
+			confirmingDelete = false;
+			indexers = [];
+			selected.clear();
+		}
+	});
+
+	let connecting = $state(false);
+	let connectError = $state('');
+
+	let indexers = $state<ProwlarrIndexer[]>([]);
+	let selected = new SvelteSet<number>();
+	let importing = $state(false);
+
+	let browsingIndexers = $state(false);
+
+	let syncing = $state(false);
+	let syncError = $state('');
+
+	let doneResult = $state<{ type: 'import' | 'sync'; result: SyncResult } | null>(null);
+	let confirmingDelete = $state(false);
+
+	let savingSettings = $state(false);
+	let saveSettingsTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function scheduleSettingsSave() {
+		if (!connection) return;
+		if (saveSettingsTimer) clearTimeout(saveSettingsTimer);
+		saveSettingsTimer = setTimeout(async () => {
+			if (!connection) return;
+			savingSettings = true;
+			try {
+				const res = await fetch('/api/indexers/prowlarr/connection', {
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ url: connection.url, autoSync, syncIntervalHours, syncAddNew })
+				});
+				if (res.ok) {
+					await invalidateAll();
+				}
+			} finally {
+				savingSettings = false;
+			}
+		}, 400);
+	}
+
+	function isDuplicate(indexer: ProwlarrIndexer): boolean {
+		return indexer.alreadyImported;
+	}
+
+	function handleClose() {
+		onClose();
+	}
+
+	async function handleConnect() {
+		connectError = '';
+		connecting = true;
+		try {
+			const res = await fetch('/api/indexers/prowlarr/connection', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ url: prowlarrUrl, apiKey, autoSync, syncIntervalHours, syncAddNew })
+			});
+			const data = await res.json();
+			if (!res.ok) {
+				connectError = data.error ?? 'Failed to connect to Prowlarr.';
+				return;
+			}
+
+			// Fetch indexers for initial browse/import
+			const indexerRes = await fetch('/api/indexers/prowlarr', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ url: prowlarrUrl, apiKey })
+			});
+			const indexerData = await indexerRes.json();
+			if (!indexerRes.ok) {
+				connectError = indexerData.error ?? 'Failed to fetch indexers.';
+				return;
+			}
+
+			indexers = indexerData.indexers as ProwlarrIndexer[];
+			selected.clear();
+			for (const i of indexers) {
+				if (i.enabled && !isDuplicate(i)) selected.add(i.id);
+			}
+			connection = {
+				url: prowlarrUrl,
+				autoSync,
+				syncIntervalHours,
+				syncAddNew,
+				lastSyncAt: null,
+				lastSyncResult: null,
+				lastSyncError: null
+			};
+			step = 'selectIndexers';
+		} catch {
+			connectError = 'Unable to reach Prowlarr. Check the URL and try again.';
+		} finally {
+			connecting = false;
+		}
+	}
+
+	async function handleImport() {
+		importing = true;
+		const toImport = indexers.filter((i) => selected.has(i.id));
+		const result: SyncResult = { updated: 0, added: 0, removed: 0, failed: 0, errors: [] };
+
+		for (const indexer of toImport) {
+			try {
+				await createIndexer({
+					name: indexer.name,
+					definitionId: indexer.definitionId,
+					baseUrl: indexer.baseUrl,
+					alternateUrls: [],
+					enabled: indexer.enabled,
+					priority: 25,
+					settings: { apikey: apiKey, prowlarrEnabled: String(indexer.enabled) },
+					enableAutomaticSearch: true,
+					enableInteractiveSearch: true,
+					minimumSeeders: 1,
+					seedRatio: null,
+					seedTime: null,
+					packSeedTime: null,
+					rejectDeadTorrents: true
+				});
+				result.added += 1;
+			} catch (e) {
+				const error =
+					e instanceof ApiError
+						? getResponseErrorMessage(e.response, 'Import failed')
+						: e instanceof Error
+							? e.message
+							: 'Unknown error';
+				result.failed += 1;
+				result.errors.push(`${indexer.name}: ${String(error)}`);
+			}
+		}
+
+		importing = false;
+		doneResult = { type: 'import', result };
+		step = 'done';
+		await invalidateAll();
+	}
+
+	async function browseAndImport() {
+		browsingIndexers = true;
+		connectError = '';
+		try {
+			const res = await fetch('/api/indexers/prowlarr/indexers');
+			const data = await res.json();
+			if (!res.ok) {
+				connectError = data.error ?? 'Failed to fetch indexers.';
+				return;
+			}
+			indexers = data.indexers as ProwlarrIndexer[];
+			selected.clear();
+			for (const i of indexers) {
+				if (i.enabled && !isDuplicate(i)) selected.add(i.id);
+			}
+			step = 'selectIndexers';
+		} catch {
+			connectError = 'Unable to reach Prowlarr.';
+		} finally {
+			browsingIndexers = false;
+		}
+	}
+
+	async function handleSyncNow() {
+		syncing = true;
+		syncError = '';
+		try {
+			const res = await fetch('/api/indexers/prowlarr/sync', { method: 'POST' });
+			const data = await res.json();
+			if (!res.ok) {
+				syncError = data.error ?? 'Sync failed.';
+				return;
+			}
+			// Refresh connection metadata from server
+			await refreshConnection();
+			doneResult = { type: 'sync', result: data.result as SyncResult };
+			step = 'done';
+			await invalidateAll();
+		} catch {
+			syncError = 'Sync failed. Check that Prowlarr is still accessible.';
+		} finally {
+			syncing = false;
+		}
+	}
+
+	async function handleDeleteConnection() {
+		try {
+			await fetch('/api/indexers/prowlarr/connection', { method: 'DELETE' });
+			connection = null;
+			step = 'connect';
+			prowlarrUrl = '';
+			apiKey = '';
+			autoSync = false;
+			syncIntervalHours = 24;
+			confirmingDelete = false;
+			await invalidateAll();
+		} catch {
+			// ignore
+		}
+	}
+
+	async function refreshConnection() {
+		try {
+			const res = await fetch('/api/indexers/prowlarr/connection');
+			if (res.ok) {
+				const data = await res.json();
+				connection = data.connection as StoredConnection | null;
+			}
+		} catch {
+			// ignore
+		}
+	}
+
+	function formatRelativeTime(isoString: string | null): string {
+		if (!isoString) return 'Never';
+		const diffMs = Date.now() - new Date(isoString).getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		if (diffMins < 1) return 'Just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		const diffHours = Math.floor(diffMins / 60);
+		if (diffHours < 24) return `${diffHours}h ago`;
+		return `${Math.floor(diffHours / 24)}d ago`;
+	}
+
+	function toggleAll(checked: boolean) {
+		selected.clear();
+		if (checked) {
+			for (const i of indexers) {
+				if (!isDuplicate(i)) selected.add(i.id);
+			}
+		}
+	}
+
+	function toggleOne(id: number, checked: boolean) {
+		if (checked) selected.add(id);
+		else selected.delete(id);
+	}
+
+	const selectableIds = $derived(indexers.filter((i) => !isDuplicate(i)).map((i) => i.id));
+	const allSelected = $derived(
+		selectableIds.length > 0 && selectableIds.every((id) => selected.has(id))
+	);
+	const someSelected = $derived(selected.size > 0 && !allSelected);
+
+	const stepTitle = $derived(
+		step === 'manage'
+			? 'Prowlarr Connection'
+			: step === 'selectIndexers'
+				? 'Select Indexers'
+				: step === 'done'
+					? 'Done'
+					: connection
+						? 'Change Connection'
+						: 'Connect to Prowlarr'
+	);
+</script>
+
+<ModalWrapper {open} onClose={handleClose} maxWidth="lg" flexContent>
+	<!-- Header -->
+	<div class="flex shrink-0 items-center justify-between border-b border-base-300 px-6 py-4">
+		<div class="flex items-center gap-2">
+			{#if step === 'selectIndexers'}
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-square -ml-1"
+					onclick={() => (step = connection ? 'manage' : 'connect')}
+					aria-label="Back"
+				>
+					<ArrowLeft class="h-4 w-4" />
+				</button>
+			{/if}
+			<Download class="h-5 w-5 text-primary" />
+			<h2 class="text-lg font-semibold">{stepTitle}</h2>
+		</div>
+		<button type="button" class="btn btn-ghost btn-sm btn-square" onclick={handleClose}>
+			<X class="h-4 w-4" />
+		</button>
+	</div>
+
+	<!-- Step: Connect / Change Connection -->
+	{#if step === 'connect'}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<p class="text-sm text-base-content/70">
+				{connection
+					? 'Enter new connection details. Existing imported indexers will not be affected.'
+					: 'Enter your Prowlarr URL and API key. Each indexer will be imported as a separate Torznab or Newznab entry.'}
+			</p>
+			<div class="form-control">
+				<label class="label" for="prowlarr-url">
+					<span class="label-text">Prowlarr URL</span>
+				</label>
+				<input
+					id="prowlarr-url"
+					type="url"
+					class="input input-bordered w-full"
+					placeholder="http://localhost:9696"
+					bind:value={prowlarrUrl}
+					disabled={connecting}
+				/>
+			</div>
+			<div class="form-control">
+				<label class="label" for="prowlarr-key">
+					<span class="label-text">API Key</span>
+				</label>
+				<input
+					id="prowlarr-key"
+					type="password"
+					class="input input-bordered w-full font-mono"
+					placeholder="Your Prowlarr API key"
+					bind:value={apiKey}
+					disabled={connecting}
+					onkeydown={(e) => e.key === 'Enter' && prowlarrUrl && apiKey && handleConnect()}
+				/>
+				<p class="mt-1 text-xs text-base-content/60">
+					Found in Prowlarr under Settings → General → Security
+				</p>
+			</div>
+			<div class="divider my-2 text-xs text-base-content/50">Auto-sync</div>
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Automatic sync</p>
+					<p class="text-xs text-base-content/60">
+						Update existing indexers and remove deleted ones on a schedule
+					</p>
+				</div>
+				<input type="checkbox" class="toggle toggle-primary toggle-sm" bind:checked={autoSync} />
+			</div>
+			{#if autoSync}
+				<div class="form-control">
+					<label class="label py-1" for="sync-interval">
+						<span class="label-text text-sm">Sync interval</span>
+					</label>
+					<select
+						id="sync-interval"
+						class="select select-bordered select-sm"
+						bind:value={syncIntervalHours}
+					>
+						<option value={6}>Every 6 hours</option>
+						<option value={12}>Every 12 hours</option>
+						<option value={24}>Daily (recommended)</option>
+						<option value={48}>Every 2 days</option>
+						<option value={168}>Weekly</option>
+					</select>
+				</div>
+			{/if}
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Import new indexers during sync</p>
+					<p class="text-xs text-base-content/60">
+						Automatically add Prowlarr indexers you haven't imported yet
+					</p>
+				</div>
+				<input type="checkbox" class="toggle toggle-primary toggle-sm" bind:checked={syncAddNew} />
+			</div>
+			{#if connectError}
+				<div class="alert alert-error py-2 text-sm">{connectError}</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+			<button type="button" class="btn btn-ghost btn-sm" onclick={handleClose}>Cancel</button>
+			<button
+				type="button"
+				class="btn btn-primary btn-sm"
+				onclick={handleConnect}
+				disabled={!prowlarrUrl || !apiKey || connecting}
+			>
+				{#if connecting}
+					<Loader2 class="h-4 w-4 animate-spin" />
+					Connecting...
+				{:else}
+					Connect
+				{/if}
+			</button>
+		</div>
+
+		<!-- Step: Manage existing connection -->
+	{:else if step === 'manage'}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<div
+				class="rounded-box space-y-2 p-4 {connection?.lastSyncError
+					? 'border border-warning/30 bg-warning/5'
+					: 'bg-base-200/60'}"
+			>
+				<div class="flex items-start justify-between gap-4">
+					<div class="min-w-0">
+						<p class="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+							Connected to
+						</p>
+						<p class="mt-0.5 truncate text-sm font-medium">{connection?.url}</p>
+					</div>
+					{#if connection?.lastSyncError}
+						<WifiOff class="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+					{:else}
+						<CheckCircle class="mt-0.5 h-5 w-5 shrink-0 text-success" />
+					{/if}
+				</div>
+				{#if connection?.lastSyncError}
+					<p class="text-xs text-warning">{connection.lastSyncError}</p>
+				{/if}
+				<div class="flex flex-wrap items-center gap-x-4 gap-y-1 pt-1 text-xs text-base-content/60">
+					<span>Last synced: {formatRelativeTime(connection?.lastSyncAt ?? null)}</span>
+					{#if connection?.lastSyncResult && !connection?.lastSyncError}
+						{@const r = connection.lastSyncResult}
+						{#if r.failed > 0}
+							<span class="flex items-center gap-1 text-warning">
+								<AlertCircle class="h-3.5 w-3.5" />
+								{r.updated} updated · {r.removed} removed{r.added > 0 ? ` · ${r.added} added` : ''} ·
+								{r.failed} failed
+							</span>
+						{:else}
+							<span
+								>{r.updated} updated · {r.removed} removed{r.added > 0
+									? ` · ${r.added} added`
+									: ''}</span
+							>
+						{/if}
+					{/if}
+				</div>
+			</div>
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Sync now</p>
+					<p class="text-xs text-base-content/60">Update existing indexers, remove deleted ones</p>
+				</div>
+				<button
+					type="button"
+					class="btn btn-primary btn-sm gap-1.5"
+					onclick={handleSyncNow}
+					disabled={syncing}
+				>
+					{#if syncing}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Syncing...
+					{:else}
+						<RefreshCw class="h-4 w-4" />
+						Sync
+					{/if}
+				</button>
+			</div>
+
+			{#if syncError}
+				<div class="alert alert-error py-2 text-sm">{syncError}</div>
+			{/if}
+
+			<div class="divider my-1 text-xs text-base-content/50">Auto-sync settings</div>
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Automatic sync</p>
+					<p class="text-xs text-base-content/60">Keep indexers in sync automatically</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary toggle-sm"
+					checked={autoSync}
+					onchange={(e) => {
+						autoSync = (e.currentTarget as HTMLInputElement).checked;
+						scheduleSettingsSave();
+					}}
+				/>
+			</div>
+			{#if autoSync}
+				<div class="form-control">
+					<label class="label py-1" for="manage-sync-interval">
+						<span class="label-text text-sm">Sync interval</span>
+					</label>
+					<select
+						id="manage-sync-interval"
+						class="select select-bordered select-sm"
+						value={syncIntervalHours}
+						onchange={(e) => {
+							syncIntervalHours = Number((e.currentTarget as HTMLSelectElement).value);
+							scheduleSettingsSave();
+						}}
+					>
+						<option value={6}>Every 6 hours</option>
+						<option value={12}>Every 12 hours</option>
+						<option value={24}>Daily (recommended)</option>
+						<option value={48}>Every 2 days</option>
+						<option value={168}>Weekly</option>
+					</select>
+				</div>
+			{/if}
+
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="text-sm font-medium">Import new indexers during sync</p>
+					<p class="text-xs text-base-content/60">
+						Automatically add Prowlarr indexers you haven't imported yet
+					</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary toggle-sm"
+					checked={syncAddNew}
+					onchange={(e) => {
+						syncAddNew = (e.currentTarget as HTMLInputElement).checked;
+						scheduleSettingsSave();
+					}}
+				/>
+			</div>
+
+			{#if connectError}
+				<div class="alert alert-error py-2 text-sm">{connectError}</div>
+			{/if}
+
+			<div class="divider my-1"></div>
+
+			{#if confirmingDelete}
+				<div class="rounded-box space-y-2 border border-error/30 bg-error/5 p-3">
+					<p class="text-sm font-medium text-error">Delete this connection?</p>
+					<p class="text-xs text-base-content/70">
+						Already imported indexers will remain in Cinephage. Only the saved connection and
+						auto-sync will be removed.
+					</p>
+					<div class="flex gap-2 pt-1">
+						<button type="button" class="btn btn-error btn-xs" onclick={handleDeleteConnection}>
+							<Trash2 class="h-3.5 w-3.5" />
+							Yes, delete
+						</button>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs"
+							onclick={() => (confirmingDelete = false)}>Cancel</button
+						>
+					</div>
+				</div>
+			{:else}
+				<div class="flex items-center justify-between">
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm gap-1.5 text-base-content/60"
+						onclick={() => {
+							prowlarrUrl = connection?.url ?? '';
+							apiKey = '';
+							connectError = '';
+							step = 'connect';
+						}}
+					>
+						<Settings class="h-4 w-4" />
+						Change connection
+					</button>
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm gap-1.5 text-error/70"
+						onclick={() => (confirmingDelete = true)}
+					>
+						<Trash2 class="h-4 w-4" />
+						Delete connection
+					</button>
+				</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm gap-1.5"
+				disabled={browsingIndexers}
+				onclick={browseAndImport}
+			>
+				{#if browsingIndexers}
+					<Loader2 class="h-4 w-4 animate-spin" />
+					Loading...
+				{:else}
+					<Download class="h-4 w-4" />
+					Browse &amp; import
+				{/if}
+			</button>
+			<button type="button" class="btn btn-primary btn-sm" onclick={handleClose}>
+				{#if savingSettings}
+					<Loader2 class="h-4 w-4 animate-spin" />
+				{/if}
+				Close
+			</button>
+		</div>
+
+		<!-- Step: Browse / select indexers for manual import -->
+	{:else if step === 'selectIndexers'}
+		{#if indexers.length === 0}
+			<div class="flex flex-col items-center justify-center gap-3 p-10">
+				<Loader2 class="h-6 w-6 animate-spin text-base-content/40" />
+				<p class="text-sm text-base-content/60">Loading indexers from Prowlarr...</p>
+			</div>
+		{:else}
+			<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+				<div class="shrink-0 border-b border-base-300 px-6 py-3">
+					<p class="text-sm text-base-content/70">
+						{indexers.length} indexer{indexers.length !== 1 ? 's' : ''} found.
+						{selected.size} selected for import.
+					</p>
+				</div>
+				<div class="flex-1 overflow-y-auto">
+					<div class="flex items-center gap-3 border-b border-base-300 bg-base-200/40 px-4 py-2.5">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							checked={allSelected}
+							indeterminate={someSelected}
+							onchange={(e) => toggleAll((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="text-sm font-medium">Select all</span>
+					</div>
+					{#each indexers as indexer (indexer.id)}
+						{@const duplicate = isDuplicate(indexer)}
+						<label
+							class="flex cursor-pointer items-center gap-3 border-b border-base-300/40 px-4 py-3 last:border-0 hover:bg-base-200/40 {duplicate
+								? 'opacity-50'
+								: ''}"
+						>
+							<input
+								type="checkbox"
+								class="checkbox checkbox-sm shrink-0"
+								checked={selected.has(indexer.id)}
+								disabled={duplicate}
+								onchange={(e) => toggleOne(indexer.id, (e.target as HTMLInputElement).checked)}
+							/>
+							<div class="min-w-0 flex-1">
+								<div class="flex flex-wrap items-center gap-1.5">
+									<span class="text-sm font-medium">{indexer.name}</span>
+									{#if duplicate}
+										<span class="badge badge-ghost badge-xs">already added</span>
+									{/if}
+									{#if !indexer.enabled}
+										<span class="badge badge-warning badge-xs">disabled in Prowlarr</span>
+									{/if}
+								</div>
+								<div class="mt-0.5 text-xs text-base-content/50">
+									{indexer.protocol === 'torrent' ? 'Torznab' : 'Newznab'} · {indexer.privacy}
+								</div>
+							</div>
+						</label>
+					{/each}
+				</div>
+			</div>
+			<div class="flex shrink-0 justify-between gap-2 border-t border-base-300 px-6 py-4">
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm"
+					onclick={() => (step = connection ? 'manage' : 'connect')}
+				>
+					Back
+				</button>
+				<button
+					type="button"
+					class="btn btn-primary btn-sm"
+					onclick={handleImport}
+					disabled={selected.size === 0 || importing}
+				>
+					{#if importing}
+						<Loader2 class="h-4 w-4 animate-spin" />
+						Importing...
+					{:else}
+						Import {selected.size} indexer{selected.size !== 1 ? 's' : ''}
+					{/if}
+				</button>
+			</div>
+		{/if}
+
+		<!-- Step: Done -->
+	{:else if step === 'done' && doneResult}
+		{@const { result } = doneResult}
+		<div class="flex-1 space-y-4 overflow-y-auto p-6">
+			<div class="flex items-start gap-2">
+				{#if result.failed === 0}
+					<CheckCircle class="mt-0.5 h-5 w-5 shrink-0 text-success" />
+					<div>
+						<p class="text-sm font-medium">
+							{doneResult.type === 'sync' ? 'Sync complete' : 'Import complete'}
+						</p>
+						<p class="mt-0.5 text-sm text-base-content/70">
+							{#if doneResult.type === 'sync'}
+								{result.updated} updated · {result.removed} removed{result.added > 0
+									? ` · ${result.added} added`
+									: ''}
+							{:else}
+								Imported {result.added} indexer{result.added !== 1 ? 's' : ''}
+							{/if}
+						</p>
+					</div>
+				{:else if result.updated === 0 && result.added === 0 && result.removed === 0}
+					<XCircle class="mt-0.5 h-5 w-5 shrink-0 text-error" />
+					<p class="text-sm font-medium">
+						All {result.failed} operation{result.failed !== 1 ? 's' : ''} failed.
+					</p>
+				{:else}
+					<AlertCircle class="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+					<div>
+						<p class="text-sm font-medium">Completed with errors</p>
+						<p class="mt-0.5 text-sm text-base-content/70">
+							{result.updated} updated · {result.removed} removed{result.added > 0
+								? ` · ${result.added} added`
+								: ''} · {result.failed} failed
+						</p>
+					</div>
+				{/if}
+			</div>
+			{#if result.errors.length > 0}
+				<div class="space-y-1.5">
+					{#each result.errors as error (error)}
+						<div class="flex items-start gap-2 text-sm text-error">
+							<XCircle class="mt-0.5 h-4 w-4 shrink-0" />
+							<span>{error}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+		<div class="flex shrink-0 justify-end border-t border-base-300 px-6 py-4">
+			<button type="button" class="btn btn-primary btn-sm" onclick={handleClose}>Done</button>
+		</div>
+	{/if}
+</ModalWrapper>

--- a/src/lib/components/search/InteractiveSearchModal.svelte
+++ b/src/lib/components/search/InteractiveSearchModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
+	import { setContext } from 'svelte';
 	import ModalWrapper from '$lib/components/ui/modal/ModalWrapper.svelte';
 	import SearchHeader from './SearchHeader.svelte';
 	import SearchStats from './SearchStats.svelte';
@@ -105,6 +106,50 @@
 	let usenetStreamingState = $state<
 		'unknown' | 'available' | 'noConfiguredServers' | 'noEnabledServers' | 'unavailable'
 	>('unknown');
+
+	// Indexer source lookup: maps Cinephage indexer UUID → 'prowlarr' | 'jackett'.
+	// Populated lazily on first open by fetching the indexers list and connection URLs.
+	const indexerSourceCtx = $state<{ map: Map<string, 'prowlarr' | 'jackett'> }>({ map: new Map() });
+	setContext('indexerSources', indexerSourceCtx);
+	let indexerSourceLoaded = $state(false);
+
+	$effect(() => {
+		if (!open || indexerSourceLoaded) return;
+		indexerSourceLoaded = true;
+		Promise.all([
+			fetch('/api/indexers').then((r) => (r.ok ? r.json() : [])),
+			fetch('/api/indexers/prowlarr/connection').then((r) =>
+				r.ok ? r.json() : { connection: null }
+			),
+			fetch('/api/indexers/jackett/connection').then((r) =>
+				r.ok ? r.json() : { connection: null }
+			)
+		])
+			.then(([allIndexers, prowlarrData, jackettData]) => {
+				const prowlarrBase = prowlarrData.connection?.url?.replace(/\/+$/, '') ?? null;
+				const jackettBase = jackettData.connection?.url?.replace(/\/+$/, '') ?? null;
+				const map = new SvelteMap<string, 'prowlarr' | 'jackett'>();
+				for (const idx of allIndexers as { id: string; baseUrl: string }[]) {
+					const url = idx.baseUrl;
+					if (prowlarrBase && url.startsWith(prowlarrBase + '/')) {
+						const suffix = url.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
+						if (/^\d+$/.test(suffix)) {
+							map.set(idx.id, 'prowlarr');
+							continue;
+						}
+					}
+					if (
+						jackettBase &&
+						url.startsWith(jackettBase + '/api/v2.0/indexers/') &&
+						url.includes('/results/torznab')
+					) {
+						map.set(idx.id, 'jackett');
+					}
+				}
+				indexerSourceCtx.map = map;
+			})
+			.catch(() => {});
+	});
 
 	let sortBy = $state<'score' | 'seeders' | 'size' | 'age'>('score');
 	let sortDir = $state<'asc' | 'desc'>('desc');

--- a/src/lib/components/search/SearchResultRow.svelte
+++ b/src/lib/components/search/SearchResultRow.svelte
@@ -14,6 +14,7 @@
 		ArrowDownCircle,
 		Ban
 	} from 'lucide-svelte';
+	import { getContext } from 'svelte';
 	import { formatBytes } from '$lib/utils/format';
 	import type { ScoreComponents } from '$lib/server/quality/types.js';
 	import * as m from '$lib/paraglide/messages.js';
@@ -112,6 +113,11 @@
 
 	let expanded = $state(false);
 
+	const indexerSourceCtx = getContext<{ map: Map<string, 'prowlarr' | 'jackett'> } | undefined>(
+		'indexerSources'
+	);
+	const indexerSource = $derived(indexerSourceCtx?.map.get(release.indexerId) ?? null);
+
 	function formatAge(date: string | Date): string {
 		const publishDate = typeof date === 'string' ? new Date(date) : date;
 		const now = new Date();
@@ -182,8 +188,8 @@
 		const hasSeederData = release.seeders !== undefined || release.leechers !== undefined;
 		if (!hasSeederData) return null;
 		return {
-			seeders: release.seeders !== undefined ? String(release.seeders) : '—',
-			leechers: release.leechers !== undefined ? String(release.leechers) : '—'
+			seeders: release.seeders !== undefined ? String(release.seeders) : '-',
+			leechers: release.leechers !== undefined ? String(release.leechers) : '-'
 		};
 	}
 </script>
@@ -231,6 +237,11 @@
 			<div class="flex items-center gap-1.5">
 				<span class="h-2 w-2 rounded-full {getProtocolColor()}"></span>
 				<span class="text-base-content/60">{release.indexerName}</span>
+				{#if indexerSource === 'prowlarr'}
+					<span class="badge badge-primary badge-xs">Prowlarr</span>
+				{:else if indexerSource === 'jackett'}
+					<span class="badge badge-secondary badge-xs">Jackett</span>
+				{/if}
 			</div>
 
 			<!-- Size -->
@@ -447,7 +458,14 @@
 					<dl class="space-y-1.5 text-sm">
 						<div class="flex justify-between">
 							<dt class="text-base-content/60">{m.search_labelIndexer()}</dt>
-							<dd class="font-medium">{release.indexerName}</dd>
+							<dd class="flex items-center gap-1.5 font-medium">
+								{release.indexerName}
+								{#if indexerSource === 'prowlarr'}
+									<span class="badge badge-primary badge-xs">Prowlarr</span>
+								{:else if indexerSource === 'jackett'}
+									<span class="badge badge-secondary badge-xs">Jackett</span>
+								{/if}
+							</dd>
 						</div>
 						{#if release.infoHash}
 							<div class="flex justify-between">

--- a/src/lib/components/search/SearchStats.svelte
+++ b/src/lib/components/search/SearchStats.svelte
@@ -8,10 +8,15 @@
 		Download,
 		XCircle
 	} from 'lucide-svelte';
+	import { getContext } from 'svelte';
 
 	type SearchMode = 'all' | 'multiSeasonPack';
 
 	import type { Release } from './SearchResultRow.svelte';
+
+	const indexerSourceCtx = getContext<{ map: Map<string, 'prowlarr' | 'jackett'> } | undefined>(
+		'indexerSources'
+	);
 
 	interface IndexerResult {
 		name: string;
@@ -234,6 +239,11 @@
 								{:else}
 									{result.name}: {result.displayCount}
 								{/if}
+								{#if indexerSourceCtx?.map.get(result.indexerId) === 'prowlarr'}
+									<span class="badge badge-primary badge-xs opacity-80">P</span>
+								{:else if indexerSourceCtx?.map.get(result.indexerId) === 'jackett'}
+									<span class="badge badge-secondary badge-xs opacity-80">J</span>
+								{/if}
 								{#if result.error}
 									<span class="tooltip" data-tip={result.error}>
 										<AlertCircle size={12} />
@@ -256,6 +266,11 @@
 							>
 								<XCircle size={12} />
 								{rejected.indexerName}
+								{#if indexerSourceCtx?.map.get(rejected.indexerId) === 'prowlarr'}
+									<span class="badge badge-primary badge-xs opacity-80">P</span>
+								{:else if indexerSourceCtx?.map.get(rejected.indexerId) === 'jackett'}
+									<span class="badge badge-secondary badge-xs opacity-80">J</span>
+								{/if}
 							</div>
 						{/each}
 					</div>

--- a/src/lib/server/indexers/jackett/JackettConnectionService.ts
+++ b/src/lib/server/indexers/jackett/JackettConnectionService.ts
@@ -1,0 +1,360 @@
+import { db } from '$lib/server/db';
+import { settings as settingsTable } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'indexers' as const });
+
+const SETTINGS_KEY = 'jackett_connection';
+const JACKETT_INDEXERS_PATH = '/api/v2.0/indexers';
+const TORZNAB_SUFFIX = '/results/torznab';
+
+export interface JackettConnection {
+	url: string;
+	/** Stored server-side only; never sent to the client */
+	apiKey: string;
+	/** Optional admin password; stored server-side only, never sent to the client */
+	adminPassword?: string;
+	autoSync: boolean;
+	syncIntervalHours: number;
+	/**
+	 * When true, sync also imports indexers that exist in Jackett but
+	 * have not been imported yet.
+	 */
+	syncAddNew: boolean;
+	lastSyncAt: string | null;
+	lastSyncResult: SyncResult | null;
+	/** Set when a sync attempt fails entirely (e.g. Jackett unreachable). Cleared on success. */
+	lastSyncError: string | null;
+}
+
+export interface SyncResult {
+	updated: number;
+	removed: number;
+	added: number;
+	failed: number;
+	errors: string[];
+}
+
+export interface JackettApiIndexer {
+	id: string;
+	name: string;
+	type: string;
+	language: string;
+	configured?: boolean;
+}
+
+export async function getJackettConnection(): Promise<JackettConnection | null> {
+	const row = await db.query.settings.findFirst({
+		where: eq(settingsTable.key, SETTINGS_KEY)
+	});
+	if (!row) return null;
+	try {
+		const conn = JSON.parse(row.value) as JackettConnection;
+		if (conn.syncAddNew === undefined) conn.syncAddNew = false;
+		if (conn.lastSyncError === undefined) conn.lastSyncError = null;
+		return conn;
+	} catch {
+		return null;
+	}
+}
+
+export async function saveJackettConnection(conn: JackettConnection): Promise<void> {
+	await db
+		.insert(settingsTable)
+		.values({ key: SETTINGS_KEY, value: JSON.stringify(conn) })
+		.onConflictDoUpdate({ target: settingsTable.key, set: { value: JSON.stringify(conn) } });
+}
+
+export async function deleteJackettConnection(): Promise<void> {
+	await db.delete(settingsTable).where(eq(settingsTable.key, SETTINGS_KEY));
+}
+
+export function normalizeJackettUrl(url: string): string {
+	return url.replace(/\/+$/, '');
+}
+
+/** Build the Torznab feed URL for a given Jackett indexer ID. */
+export function jackettIndexerUrl(jackettBase: string, indexerId: string): string {
+	return `${jackettBase}${JACKETT_INDEXERS_PATH}/${indexerId}${TORZNAB_SUFFIX}`;
+}
+
+/** Returns true when baseUrl is a Torznab feed served by this Jackett instance. */
+export function isIndexerFromJackett(baseUrl: string, jackettBase: string): boolean {
+	const base = jackettBase.replace(/\/+$/, '');
+	const normalized = baseUrl.replace(/\/+$/, '');
+	const prefix = `${base}${JACKETT_INDEXERS_PATH}/`;
+	return normalized.startsWith(prefix) && normalized.includes(TORZNAB_SUFFIX);
+}
+
+/** Extract the Jackett indexer ID from a stored Cinephage baseUrl. */
+export function extractJackettIndexerId(baseUrl: string, jackettBase: string): string | null {
+	const base = jackettBase.replace(/\/+$/, '');
+	const prefix = `${base}${JACKETT_INDEXERS_PATH}/`;
+	const normalized = baseUrl.replace(/\/+$/, '');
+	if (!normalized.startsWith(prefix)) return null;
+	const rest = normalized.slice(prefix.length);
+	const slash = rest.indexOf('/');
+	return slash > -1 ? rest.slice(0, slash) : rest;
+}
+
+type HeadersExt = Headers & { getSetCookie?(): string[] };
+
+function extractCookiePairs(h: Headers): string[] {
+	const ext = h as HeadersExt;
+	const lines = ext.getSetCookie ? ext.getSetCookie() : [h.get('set-cookie') ?? ''].filter(Boolean);
+	return lines.map((c) => c.split(';')[0].trim()).filter(Boolean);
+}
+
+/**
+ * Login to Jackett by POSTing to /UI/Dashboard with form-encoded password.
+ * Returns the session cookie string on success, or null if login failed.
+ *
+ * No-password installs: pass empty string; Jackett accepts it.
+ * Password-protected installs: pass the admin password.
+ */
+async function loginToJackett(base: string, adminPassword = ''): Promise<string | null> {
+	try {
+		const res = await fetch(`${base}/UI/Dashboard`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({ password: adminPassword }).toString(),
+			redirect: 'manual',
+			signal: AbortSignal.timeout(10000)
+		});
+
+		const cookies = extractCookiePairs(res.headers);
+		logger.debug(
+			{ status: res.status, cookies, location: res.headers.get('location') },
+			'[Jackett] POST /UI/Dashboard response'
+		);
+
+		// Success: 302 redirect (to dashboard) with session cookie in Set-Cookie.
+		if (res.status >= 300 && res.status < 400 && cookies.length > 0) {
+			return cookies.join('; ');
+		}
+
+		return null;
+	} catch (err) {
+		logger.debug({ err }, '[Jackett] POST /UI/Dashboard failed');
+		return null;
+	}
+}
+
+async function doJackettListRequest(url: string, cookie: string | null): Promise<Response> {
+	const headers: Record<string, string> = { Accept: 'application/json' };
+	if (cookie) headers['Cookie'] = cookie;
+	return fetch(url, { headers, redirect: 'manual', signal: AbortSignal.timeout(10000) });
+}
+
+async function parseJackettListResponse(res: Response): Promise<JackettApiIndexer[]> {
+	const contentType = res.headers.get('content-type') ?? '';
+	if (contentType.includes('text/html')) {
+		throw new Error(
+			'Jackett returned an HTML page instead of JSON. ' +
+				'If you have an admin password set, disable it under Jackett Config → Admin password.'
+		);
+	}
+	let data: unknown;
+	try {
+		data = await res.json();
+	} catch {
+		throw new Error(`Jackett returned non-JSON response (content-type: ${contentType || 'none'})`);
+	}
+	if (!Array.isArray(data)) {
+		throw new Error('Unexpected response format from Jackett (expected array)');
+	}
+	return (data as JackettApiIndexer[]).filter((i) => i.configured !== false);
+}
+
+export async function fetchJackettIndexers(
+	jackettUrl: string,
+	apiKey: string,
+	adminPassword = ''
+): Promise<JackettApiIndexer[]> {
+	const base = normalizeJackettUrl(jackettUrl);
+	const encodedKey = encodeURIComponent(apiKey);
+
+	// Recent Jackett builds bypass the login redirect when the URL has a trailing
+	// slash. Try that first; if it returns 200 we are done without any cookie dance.
+	const trailingSlashUrl = `${base}${JACKETT_INDEXERS_PATH}/?apikey=${encodedKey}`;
+	const trailingRes = await doJackettListRequest(trailingSlashUrl, null);
+	logger.debug(
+		{ status: trailingRes.status, location: trailingRes.headers.get('location') },
+		'[Jackett] trailing-slash probe'
+	);
+
+	if (trailingRes.ok) {
+		return parseJackettListResponse(trailingRes);
+	}
+
+	// Trailing-slash did not work; do the login dance and retry.
+	const cookie = await loginToJackett(base, adminPassword);
+	logger.debug({ hasCookie: Boolean(cookie) }, '[Jackett] session cookie result');
+
+	const listUrl = `${base}${JACKETT_INDEXERS_PATH}?apikey=${encodedKey}`;
+	const res = await doJackettListRequest(listUrl, cookie);
+
+	if (res.status >= 300 && res.status < 400) {
+		throw new Error(
+			adminPassword
+				? 'Jackett rejected the admin password. Check it matches Jackett Config → Admin password.'
+				: 'Jackett requires login. If you have set an admin password in Jackett, enter it in the Admin Password field when connecting.'
+		);
+	}
+	if (res.status === 401 || res.status === 403) {
+		throw new Error('Authentication failed. Check your Jackett API key.');
+	}
+	if (!res.ok) {
+		let body = '';
+		try {
+			body = await res.text();
+		} catch {
+			// ignore
+		}
+		const snippet = body.slice(0, 200).replace(/\s+/g, ' ').trim();
+		const lower = snippet.toLowerCase();
+		if (lower.includes('cookies required')) {
+			throw new Error(
+				'Jackett requires a session cookie that could not be established. ' +
+					'If you have an admin password set in Jackett, disable it under Config → Admin password.'
+			);
+		}
+		throw new Error(
+			`Jackett returned HTTP ${res.status} ${res.statusText}${snippet ? ` - ${snippet}` : ''}`
+		);
+	}
+
+	return parseJackettListResponse(res);
+}
+
+export async function syncJackettIndexers(): Promise<SyncResult> {
+	const conn = await getJackettConnection();
+	if (!conn) {
+		throw new Error('No Jackett connection configured');
+	}
+
+	const jackettBase = normalizeJackettUrl(conn.url);
+	const result: SyncResult = { updated: 0, removed: 0, added: 0, failed: 0, errors: [] };
+
+	let jackettIndexers: JackettApiIndexer[];
+	try {
+		jackettIndexers = await fetchJackettIndexers(conn.url, conn.apiKey, conn.adminPassword ?? '');
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		conn.lastSyncAt = new Date().toISOString();
+		conn.lastSyncError = errorMsg;
+		await saveJackettConnection(conn);
+		throw new Error(`Failed to fetch indexers from Jackett: ${errorMsg}`);
+	}
+
+	const jackettById = new Map(jackettIndexers.map((i) => [i.id, i]));
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+
+	const managedIndexers = existingIndexers.filter((i) =>
+		isIndexerFromJackett(i.baseUrl, jackettBase)
+	);
+
+	for (const indexer of managedIndexers) {
+		const indexerId = extractJackettIndexerId(indexer.baseUrl, jackettBase);
+		const ji = indexerId ? jackettById.get(indexerId) : undefined;
+
+		if (!ji) {
+			// Removed from Jackett; remove from Cinephage
+			try {
+				await manager.deleteIndexer(indexer.id);
+				result.removed += 1;
+				logger.info(
+					{ indexerName: indexer.name, jackettId: indexerId },
+					'[Jackett] Removed indexer deleted in Jackett'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(
+					`Remove ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+			continue;
+		}
+
+		// Still exists in Jackett; sync name and API key
+		const updates: Record<string, unknown> = {};
+		if (ji.name !== indexer.name) updates.name = ji.name;
+
+		const existingSettings = indexer.settings as Record<string, unknown> | null;
+		const currentKey = existingSettings?.apikey;
+		if (currentKey !== conn.apiKey) {
+			updates.settings = { ...(existingSettings ?? {}), apikey: conn.apiKey };
+		}
+
+		if (Object.keys(updates).length > 0) {
+			try {
+				await manager.updateIndexer(indexer.id, updates);
+				result.updated += 1;
+				logger.info(
+					{ indexerName: ji.name, jackettId: indexerId, updates: Object.keys(updates) },
+					'[Jackett] Updated indexer'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(
+					`Update ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+	}
+
+	if (conn.syncAddNew) {
+		const managedUrls = new Set(managedIndexers.map((i) => normalizeJackettUrl(i.baseUrl)));
+
+		for (const ji of jackettIndexers) {
+			const baseUrl = jackettIndexerUrl(jackettBase, ji.id);
+			if (managedUrls.has(baseUrl)) continue;
+
+			try {
+				await manager.createIndexer({
+					name: ji.name,
+					definitionId: 'torznab',
+					baseUrl,
+					alternateUrls: [],
+					enabled: true,
+					priority: 25,
+					settings: { apikey: conn.apiKey },
+					enableAutomaticSearch: true,
+					enableInteractiveSearch: true,
+					minimumSeeders: 1,
+					seedRatio: null,
+					seedTime: null,
+					packSeedTime: null
+				});
+				result.added += 1;
+				logger.info(
+					{ indexerName: ji.name, jackettId: ji.id },
+					'[Jackett] Auto-imported new indexer'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(`Add ${ji.name}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	}
+
+	conn.lastSyncAt = new Date().toISOString();
+	conn.lastSyncResult = result;
+	conn.lastSyncError = null;
+	await saveJackettConnection(conn);
+
+	logger.info(
+		{
+			updated: result.updated,
+			removed: result.removed,
+			added: result.added,
+			failed: result.failed
+		},
+		'[Jackett] Sync complete'
+	);
+	return result;
+}

--- a/src/lib/server/indexers/jackett/JackettSyncScheduler.ts
+++ b/src/lib/server/indexers/jackett/JackettSyncScheduler.ts
@@ -1,0 +1,107 @@
+import type { BackgroundService, ServiceStatus } from '$lib/server/services/background-service.js';
+import { getJackettConnection, syncJackettIndexers } from './JackettConnectionService.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'indexers' as const });
+
+const POLL_INTERVAL_MS = 30 * 1000;
+const STARTUP_GRACE_MS = 3 * 60 * 1000;
+
+export class JackettSyncScheduler implements BackgroundService {
+	private static instance: JackettSyncScheduler | null = null;
+
+	readonly name = 'JackettSyncScheduler';
+	private _status: ServiceStatus = 'pending';
+	private _error: Error | undefined;
+
+	private timer: NodeJS.Timeout | null = null;
+	private startupTime: Date | null = null;
+	private running = false;
+
+	private constructor() {}
+
+	static getInstance(): JackettSyncScheduler {
+		if (!JackettSyncScheduler.instance) {
+			JackettSyncScheduler.instance = new JackettSyncScheduler();
+		}
+		return JackettSyncScheduler.instance;
+	}
+
+	get status(): ServiceStatus {
+		return this._status;
+	}
+
+	get error(): Error | undefined {
+		return this._error;
+	}
+
+	start(): void {
+		if (this._status === 'starting' || this._status === 'ready') return;
+		this._status = 'starting';
+		this.startupTime = new Date();
+
+		setImmediate(() => {
+			this.timer = setInterval(() => {
+				this.poll().catch((err) => {
+					logger.error({ err }, '[JackettSync] Poll error');
+				});
+			}, POLL_INTERVAL_MS);
+			this._status = 'ready';
+			logger.info('[JackettSync] Scheduler started');
+		});
+	}
+
+	async stop(): Promise<void> {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		this._status = 'pending';
+		this.startupTime = null;
+		logger.info('[JackettSync] Scheduler stopped');
+	}
+
+	private async poll(): Promise<void> {
+		if (this.running) return;
+
+		if (this.startupTime) {
+			const elapsed = Date.now() - this.startupTime.getTime();
+			if (elapsed < STARTUP_GRACE_MS) return;
+		}
+
+		const conn = await getJackettConnection();
+		if (!conn?.autoSync) return;
+
+		if (!conn.lastSyncAt) {
+			await this.runSync();
+			return;
+		}
+
+		const intervalMs = conn.syncIntervalHours * 60 * 60 * 1000;
+		const elapsed = Date.now() - new Date(conn.lastSyncAt).getTime();
+		if (elapsed >= intervalMs) {
+			await this.runSync();
+		}
+	}
+
+	private async runSync(): Promise<void> {
+		if (this.running) return;
+		this.running = true;
+		try {
+			logger.info('[JackettSync] Running scheduled sync');
+			const result = await syncJackettIndexers();
+			logger.info(
+				{ added: result.added, removed: result.removed, failed: result.failed },
+				'[JackettSync] Scheduled sync complete'
+			);
+		} catch (err) {
+			logger.error({ err }, '[JackettSync] Scheduled sync failed');
+		} finally {
+			this.running = false;
+		}
+	}
+}
+
+export function getJackettSyncScheduler(): JackettSyncScheduler {
+	return JackettSyncScheduler.getInstance();
+}

--- a/src/lib/server/indexers/loader/YamlIndexerFactory.ts
+++ b/src/lib/server/indexers/loader/YamlIndexerFactory.ts
@@ -95,17 +95,27 @@ export class YamlIndexerFactory implements IIndexerFactory {
 
 		// For Newznab/Torznab, fetch live capabilities from the indexer's caps endpoint.
 		// This allows us to filter out unsupported search params (e.g., tmdbid if not supported).
+		// For torznab, auto-discover the correct endpoint first so bare host URLs work.
 		let liveCapabilities;
 		if (NEWZNAB_DEFINITIONS.includes(config.definitionId)) {
 			try {
 				const provider = getNewznabCapabilitiesProvider();
 				const rawApiKey = cleanSettings?.apikey;
-				const apiKey = typeof rawApiKey === 'string' ? rawApiKey : undefined;
-				liveCapabilities = await provider.getCapabilities(config.baseUrl, apiKey?.trim());
+				const apiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : undefined;
+
+				let resolvedBaseUrl = config.baseUrl;
+				if (config.definitionId === 'torznab') {
+					resolvedBaseUrl = await provider.resolveTorznabBaseUrl(config.baseUrl, apiKey);
+					if (resolvedBaseUrl !== config.baseUrl) {
+						record.baseUrl = resolvedBaseUrl;
+					}
+				}
+
+				liveCapabilities = await provider.getCapabilities(resolvedBaseUrl, apiKey);
 				log.info(
 					{
 						indexerId: config.id,
-						baseUrl: config.baseUrl,
+						baseUrl: resolvedBaseUrl,
 						movieSearch: liveCapabilities.searching.movieSearch.supportedParams,
 						tvSearch: liveCapabilities.searching.tvSearch.supportedParams
 					},

--- a/src/lib/server/indexers/newznab/NewznabCapabilitiesProvider.ts
+++ b/src/lib/server/indexers/newznab/NewznabCapabilitiesProvider.ts
@@ -63,6 +63,9 @@ export class NewznabCapabilitiesProvider {
 	/** In-memory cache: baseUrl -> cached capabilities */
 	private cache: Map<string, CachedCapabilities> = new Map();
 
+	/** Resolved torznab URL cache: raw URL -> discovered endpoint URL */
+	private resolvedUrlCache: Map<string, string> = new Map();
+
 	/**
 	 * Get capabilities for a Newznab indexer.
 	 * Returns cached capabilities if available and not expired.
@@ -124,11 +127,65 @@ export class NewznabCapabilitiesProvider {
 	}
 
 	/**
+	 * Resolve the actual Torznab endpoint URL for a given raw base URL.
+	 * If the URL already ends with /api it is returned as-is.
+	 * Otherwise, candidate paths are probed in order:
+	 *   1. {path}/torznab/all/api  (Jackett all-indexers aggregated)
+	 *   2. {path}/api              (Prowlarr per-indexer and generic torznab)
+	 * The first responding endpoint is cached and returned.
+	 * Falls back to appending /api without caching if no candidate responds.
+	 *
+	 * Note: Prowlarr has no aggregate multi-indexer endpoint. Each Prowlarr indexer
+	 * must be added separately using its numeric ID (e.g. http://host:9696/23).
+	 */
+	async resolveTorznabBaseUrl(rawUrl: string, apiKey?: string): Promise<string> {
+		const cacheKey = `resolved:${this.getCacheKey(rawUrl, apiKey)}`;
+		const cached = this.resolvedUrlCache.get(cacheKey);
+		if (cached) return cached;
+
+		const url = new URL(rawUrl);
+		const normalizedPath = url.pathname.replace(/\/+$/, '');
+		const lowerPath = normalizedPath.toLowerCase();
+
+		// A valid torznab endpoint always ends with /api ; anything else needs discovery.
+		if (lowerPath.endsWith('/api')) {
+			this.resolvedUrlCache.set(cacheKey, rawUrl);
+			return rawUrl;
+		}
+
+		// Jackett all-indexers: /torznab/all/api?apikey={key}
+		// Prowlarr per-indexer and generic: /api (appended to whatever path the user provided)
+		const candidates: string[] = [
+			`${normalizedPath}/torznab/all/api`,
+			`${normalizedPath}/api`
+		];
+
+		for (const candidatePath of candidates) {
+			const candidate = new URL(rawUrl);
+			candidate.pathname = candidatePath;
+			logger.debug({ url: candidate.toString() }, '[Torznab] Probing candidate endpoint');
+			if (await this.probeTorznabEndpoint(candidate, apiKey)) {
+				const resolved = candidate.toString();
+				this.resolvedUrlCache.set(cacheKey, resolved);
+				logger.info({ rawUrl, resolved }, '[Torznab] Auto-discovered endpoint');
+				return resolved;
+			}
+		}
+
+		// No candidate responded; fall back to /api without caching so we re-probe next time
+		const fallback = new URL(rawUrl);
+		fallback.pathname = normalizedPath ? `${normalizedPath}/api` : '/api';
+		logger.warn({ rawUrl }, '[Torznab] Could not auto-discover endpoint, falling back to /api');
+		return fallback.toString();
+	}
+
+	/**
 	 * Clear cached capabilities for an indexer.
 	 */
 	clearCache(baseUrl: string, apiKey?: string): void {
 		const cacheKey = this.getCacheKey(baseUrl, apiKey);
 		this.cache.delete(cacheKey);
+		this.resolvedUrlCache.delete(`resolved:${cacheKey}`);
 		logger.debug({ baseUrl }, '[Newznab] Cache cleared');
 	}
 
@@ -137,7 +194,50 @@ export class NewznabCapabilitiesProvider {
 	 */
 	clearAllCache(): void {
 		this.cache.clear();
+		this.resolvedUrlCache.clear();
 		logger.debug('[Newznab] All cache cleared');
+	}
+
+	/**
+	 * Probe a candidate torznab URL by requesting ?t=caps and checking for a valid XML caps response.
+	 */
+	private async probeTorznabEndpoint(url: URL, apiKey?: string): Promise<boolean> {
+		const probe = new URL(url.toString());
+		probe.searchParams.set('t', 'caps');
+		const normalizedApiKey = apiKey?.trim();
+		if (normalizedApiKey) {
+			probe.searchParams.set('apikey', normalizedApiKey);
+		}
+		const probeUrl = probe.toString().replace(/apikey=[^&]+/, 'apikey=***');
+		try {
+			const response = await fetch(probe.toString(), {
+				headers: { Accept: 'application/xml, text/xml, */*' },
+				signal: AbortSignal.timeout(5000)
+			});
+			const ct = (response.headers.get('content-type') ?? '').toLowerCase();
+			if (!response.ok) {
+				logger.debug({ url: probeUrl, status: response.status }, '[Torznab] Probe: non-OK status');
+				return false;
+			}
+			if (ct.includes('text/html')) {
+				logger.debug({ url: probeUrl, ct }, '[Torznab] Probe: HTML response');
+				return false;
+			}
+			const text = await response.text();
+			// Case-insensitive: .NET apps (Prowlarr) may return <Caps> instead of <caps>
+			const hasCaps = text.toLowerCase().includes('<caps');
+			logger.debug(
+				{ url: probeUrl, ct, status: response.status, hasCaps, preview: text.slice(0, 120) },
+				'[Torznab] Probe: response'
+			);
+			return hasCaps;
+		} catch (err) {
+			logger.debug(
+				{ url: probeUrl, err: err instanceof Error ? err.message : String(err) },
+				'[Torznab] Probe: fetch error'
+			);
+			return false;
+		}
 	}
 
 	/**
@@ -148,10 +248,10 @@ export class NewznabCapabilitiesProvider {
 		const url = new URL(baseUrl);
 		const normalizedPath = url.pathname.replace(/\/+$/, '');
 		const lowerPath = normalizedPath.toLowerCase();
-		// Torznab-style endpoints can be full paths ending in /torznab.
-		// For plain indexer host URLs, append /api to match Newznab conventions.
-		const isTorznabEndpoint =
-			lowerPath.endsWith('/torznab') || lowerPath.includes('/results/torznab');
+		// Append /api for host-only URLs (newznab convention).
+		// Skip only if the path already ends with /api, or if it's a bare /torznab path
+		// (e.g. Prowlarr per-indexer direct endpoint that exposes the torznab root).
+		const isTorznabEndpoint = lowerPath.endsWith('/torznab');
 		if (!isTorznabEndpoint && !lowerPath.endsWith('/api')) {
 			url.pathname = normalizedPath ? `${normalizedPath}/api` : '/api';
 		}
@@ -187,6 +287,11 @@ export class NewznabCapabilitiesProvider {
 				'Indexer returned HTML instead of XML from the caps endpoint'
 			);
 		}
+		if (contentType.includes('application/json') || contentType.includes('text/json')) {
+			throw new CapabilitiesFetchError(
+				'Indexer returned JSON instead of XML from the caps endpoint'
+			);
+		}
 
 		const xml = await response.text();
 		if (!xml.trim()) {
@@ -201,14 +306,15 @@ export class NewznabCapabilitiesProvider {
 	private parseCapabilities(xml: string): NewznabCapabilities {
 		const $ = cheerio.load(xml, { xmlMode: true });
 
-		if ($('caps').length === 0) {
+		// Case-insensitive: Prowlarr/.NET may return <Caps> instead of <caps>
+		if ($('caps').length === 0 && $('Caps').length === 0) {
 			throw new CapabilitiesFetchError(
 				'Invalid capabilities response: missing <caps> root element'
 			);
 		}
 
 		// Check for error response
-		const errorEl = $('error');
+		const errorEl = $('error, Error');
 		if (errorEl.length > 0) {
 			const code = errorEl.attr('code') || 'unknown';
 			const desc = errorEl.attr('description') || 'Unknown error';

--- a/src/lib/server/indexers/newznab/NewznabCapabilitiesProvider.ts
+++ b/src/lib/server/indexers/newznab/NewznabCapabilitiesProvider.ts
@@ -155,10 +155,7 @@ export class NewznabCapabilitiesProvider {
 
 		// Jackett all-indexers: /torznab/all/api?apikey={key}
 		// Prowlarr per-indexer and generic: /api (appended to whatever path the user provided)
-		const candidates: string[] = [
-			`${normalizedPath}/torznab/all/api`,
-			`${normalizedPath}/api`
-		];
+		const candidates: string[] = [`${normalizedPath}/torznab/all/api`, `${normalizedPath}/api`];
 
 		for (const candidatePath of candidates) {
 			const candidate = new URL(rawUrl);

--- a/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
@@ -1,0 +1,299 @@
+import { db } from '$lib/server/db';
+import { settings as settingsTable } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
+import { getPersistentStatusTracker } from '$lib/server/indexers/status';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'indexers' as const });
+
+const SETTINGS_KEY = 'prowlarr_connection';
+
+export interface ProwlarrConnection {
+	url: string;
+	/** Stored server-side only — never sent to the client */
+	apiKey: string;
+	autoSync: boolean;
+	syncIntervalHours: number;
+	/**
+	 * When true, sync will also import indexers that exist in Prowlarr but
+	 * have not been imported yet. When false (default), sync only touches
+	 * indexers the user has already explicitly imported.
+	 */
+	syncAddNew: boolean;
+	lastSyncAt: string | null;
+	lastSyncResult: SyncResult | null;
+	/** Set when a sync attempt fails entirely (e.g. Prowlarr unreachable). Cleared on success. */
+	lastSyncError: string | null;
+}
+
+export interface SyncResult {
+	updated: number;
+	removed: number;
+	added: number;
+	failed: number;
+	errors: string[];
+}
+
+export interface ProwlarrApiIndexer {
+	id: number;
+	name: string;
+	enable: boolean;
+	protocol: string;
+	privacy?: string;
+}
+
+export interface ProwlarrApiIndexerStatus {
+	indexerId: number;
+	disabledTill: string | null;
+	mostRecentFailure: string | null;
+}
+
+export async function getProwlarrConnection(): Promise<ProwlarrConnection | null> {
+	const row = await db.query.settings.findFirst({
+		where: eq(settingsTable.key, SETTINGS_KEY)
+	});
+	if (!row) return null;
+	try {
+		const conn = JSON.parse(row.value) as ProwlarrConnection;
+		if (conn.syncAddNew === undefined) conn.syncAddNew = false;
+		if (conn.lastSyncError === undefined) conn.lastSyncError = null;
+		return conn;
+	} catch {
+		return null;
+	}
+}
+
+export async function saveProwlarrConnection(conn: ProwlarrConnection): Promise<void> {
+	await db
+		.insert(settingsTable)
+		.values({ key: SETTINGS_KEY, value: JSON.stringify(conn) })
+		.onConflictDoUpdate({ target: settingsTable.key, set: { value: JSON.stringify(conn) } });
+}
+
+export async function deleteProwlarrConnection(): Promise<void> {
+	await db.delete(settingsTable).where(eq(settingsTable.key, SETTINGS_KEY));
+}
+
+export function normalizeProwlarrUrl(url: string): string {
+	return url.replace(/\/+$/, '');
+}
+
+function isIndexerFromConnection(baseUrl: string, prowlarrBase: string): boolean {
+	if (!baseUrl.startsWith(prowlarrBase + '/')) return false;
+	const suffix = baseUrl.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
+	return /^\d+$/.test(suffix);
+}
+
+export async function fetchProwlarrIndexers(
+	prowlarrUrl: string,
+	apiKey: string
+): Promise<ProwlarrApiIndexer[]> {
+	const base = normalizeProwlarrUrl(prowlarrUrl);
+	const res = await fetch(`${base}/api/v1/indexer`, {
+		headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
+		signal: AbortSignal.timeout(10000)
+	});
+
+	if (res.status === 401 || res.status === 403) {
+		throw new Error('Authentication failed. Check your Prowlarr API key.');
+	}
+	if (!res.ok) {
+		throw new Error(`Prowlarr returned HTTP ${res.status}`);
+	}
+
+	const data: unknown = await res.json();
+	if (!Array.isArray(data)) {
+		throw new Error('Unexpected response format from Prowlarr');
+	}
+	return data as ProwlarrApiIndexer[];
+}
+
+export async function fetchProwlarrIndexerStatus(
+	prowlarrUrl: string,
+	apiKey: string
+): Promise<ProwlarrApiIndexerStatus[]> {
+	const base = normalizeProwlarrUrl(prowlarrUrl);
+	const res = await fetch(`${base}/api/v1/indexerstatus`, {
+		headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
+		signal: AbortSignal.timeout(10000)
+	});
+	if (!res.ok) return [];
+	const data: unknown = await res.json();
+	if (!Array.isArray(data)) return [];
+	return data as ProwlarrApiIndexerStatus[];
+}
+
+export async function syncProwlarrIndexers(): Promise<SyncResult> {
+	const conn = await getProwlarrConnection();
+	if (!conn) {
+		throw new Error('No Prowlarr connection configured');
+	}
+
+	const prowlarrBase = normalizeProwlarrUrl(conn.url);
+	const result: SyncResult = { updated: 0, removed: 0, added: 0, failed: 0, errors: [] };
+
+	let prowlarrIndexers: ProwlarrApiIndexer[];
+	try {
+		prowlarrIndexers = await fetchProwlarrIndexers(conn.url, conn.apiKey);
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		conn.lastSyncAt = new Date().toISOString();
+		conn.lastSyncError = errorMsg;
+		await saveProwlarrConnection(conn);
+		throw new Error(`Failed to fetch indexers from Prowlarr: ${errorMsg}`);
+	}
+
+	const prowlarrById = new Map(prowlarrIndexers.map((i) => [i.id, i]));
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+
+	// Partition: which existing Cinephage indexers came from this Prowlarr instance
+	const managedIndexers = existingIndexers.filter((i) =>
+		isIndexerFromConnection(i.baseUrl, prowlarrBase)
+	);
+
+	for (const indexer of managedIndexers) {
+		const suffix = indexer.baseUrl.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
+		const prowlarrId = parseInt(suffix, 10);
+		const pi = prowlarrById.get(prowlarrId);
+
+		if (!pi) {
+			// Deleted in Prowlarr — remove from Cinephage
+			try {
+				await manager.deleteIndexer(indexer.id);
+				result.removed += 1;
+				logger.info(
+					{ indexerName: indexer.name, prowlarrId },
+					'[Prowlarr] Removed indexer deleted in Prowlarr'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(
+					`Remove ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+			continue;
+		}
+
+		// Still exists in Prowlarr — sync name, enabled state, API key, and prowlarrEnabled
+		const updates: Record<string, unknown> = {};
+		if (pi.name !== indexer.name) updates.name = pi.name;
+		if (pi.enable !== indexer.enabled) updates.enabled = pi.enable;
+
+		const existingSettings = indexer.settings as Record<string, unknown> | null;
+		const currentKey = existingSettings?.apikey;
+		const currentProwlarrEnabled = existingSettings?.prowlarrEnabled;
+		if (currentKey !== conn.apiKey || currentProwlarrEnabled !== pi.enable) {
+			updates.settings = {
+				...(existingSettings ?? {}),
+				apikey: conn.apiKey,
+				prowlarrEnabled: pi.enable
+			};
+		}
+
+		if (Object.keys(updates).length > 0) {
+			try {
+				await manager.updateIndexer(indexer.id, updates);
+				result.updated += 1;
+				logger.info(
+					{ indexerName: pi.name, prowlarrId, updates: Object.keys(updates) },
+					'[Prowlarr] Updated indexer'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(
+					`Update ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+	}
+
+	// Add new indexers only when the user has opted in
+	if (conn.syncAddNew) {
+		const managedBaseUrls = new Set(managedIndexers.map((i) => normalizeProwlarrUrl(i.baseUrl)));
+
+		for (const pi of prowlarrIndexers) {
+			const baseUrl = `${prowlarrBase}/${pi.id}`;
+			if (managedBaseUrls.has(baseUrl)) continue;
+
+			const protocol = pi.protocol === 'usenet' ? 'usenet' : 'torrent';
+			const definitionId = protocol === 'usenet' ? 'newznab' : 'torznab';
+
+			try {
+				await manager.createIndexer({
+					name: pi.name,
+					definitionId,
+					baseUrl,
+					alternateUrls: [],
+					enabled: pi.enable === true,
+					priority: 25,
+					settings: { apikey: conn.apiKey, prowlarrEnabled: pi.enable },
+					enableAutomaticSearch: true,
+					enableInteractiveSearch: true,
+					minimumSeeders: 1,
+					seedRatio: null,
+					seedTime: null,
+					packSeedTime: null
+				});
+				result.added += 1;
+				logger.info(
+					{ indexerName: pi.name, prowlarrId: pi.id },
+					'[Prowlarr] Auto-imported new indexer'
+				);
+			} catch (err) {
+				result.failed += 1;
+				result.errors.push(`Add ${pi.name}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	}
+
+	// Health passthrough: update Cinephage status tracker from Prowlarr's indexer health data.
+	// This avoids Cinephage making its own test requests to Prowlarr-proxied URLs (which
+	// triggers rate limiting on the underlying indexers).
+	try {
+		const statusTracker = getPersistentStatusTracker();
+		const prowlarrStatuses = await fetchProwlarrIndexerStatus(conn.url, conn.apiKey);
+		const failedByProwlarrId = new Map(prowlarrStatuses.map((s) => [s.indexerId, s]));
+
+		// Re-fetch managed indexers (some may have been removed above)
+		const currentIndexers = await manager.getIndexers();
+		const stillManaged = currentIndexers.filter((i) =>
+			isIndexerFromConnection(i.baseUrl, prowlarrBase)
+		);
+
+		for (const indexer of stillManaged) {
+			const suffix = indexer.baseUrl.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
+			const prowlarrId = parseInt(suffix, 10);
+			const failureInfo = failedByProwlarrId.get(prowlarrId);
+
+			if (failureInfo) {
+				await statusTracker.recordFailure(
+					indexer.id,
+					failureInfo.mostRecentFailure ?? 'Reported unhealthy by Prowlarr'
+				);
+			} else {
+				await statusTracker.recordSuccess(indexer.id);
+			}
+		}
+	} catch {
+		// Health passthrough is best-effort — don't fail the sync if it errors
+	}
+
+	conn.lastSyncAt = new Date().toISOString();
+	conn.lastSyncResult = result;
+	conn.lastSyncError = null;
+	await saveProwlarrConnection(conn);
+
+	logger.info(
+		{
+			updated: result.updated,
+			removed: result.removed,
+			added: result.added,
+			failed: result.failed
+		},
+		'[Prowlarr] Sync complete'
+	);
+	return result;
+}

--- a/src/lib/server/indexers/prowlarr/ProwlarrSyncScheduler.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrSyncScheduler.ts
@@ -1,0 +1,112 @@
+import type { BackgroundService, ServiceStatus } from '$lib/server/services/background-service.js';
+import { getProwlarrConnection, syncProwlarrIndexers } from './ProwlarrConnectionService.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'indexers' as const });
+
+/** Poll every 30 seconds to check if sync is due */
+const POLL_INTERVAL_MS = 30 * 1000;
+
+/** Grace period before first poll after startup */
+const STARTUP_GRACE_MS = 3 * 60 * 1000;
+
+export class ProwlarrSyncScheduler implements BackgroundService {
+	private static instance: ProwlarrSyncScheduler | null = null;
+
+	readonly name = 'ProwlarrSyncScheduler';
+	private _status: ServiceStatus = 'pending';
+	private _error: Error | undefined;
+
+	private timer: NodeJS.Timeout | null = null;
+	private startupTime: Date | null = null;
+	private running = false;
+
+	private constructor() {}
+
+	static getInstance(): ProwlarrSyncScheduler {
+		if (!ProwlarrSyncScheduler.instance) {
+			ProwlarrSyncScheduler.instance = new ProwlarrSyncScheduler();
+		}
+		return ProwlarrSyncScheduler.instance;
+	}
+
+	get status(): ServiceStatus {
+		return this._status;
+	}
+
+	get error(): Error | undefined {
+		return this._error;
+	}
+
+	start(): void {
+		if (this._status === 'starting' || this._status === 'ready') return;
+		this._status = 'starting';
+		this.startupTime = new Date();
+
+		setImmediate(() => {
+			this.timer = setInterval(() => {
+				this.poll().catch((err) => {
+					logger.error({ err }, '[ProwlarrSync] Poll error');
+				});
+			}, POLL_INTERVAL_MS);
+			this._status = 'ready';
+			logger.info('[ProwlarrSync] Scheduler started');
+		});
+	}
+
+	async stop(): Promise<void> {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		this._status = 'pending';
+		this.startupTime = null;
+		logger.info('[ProwlarrSync] Scheduler stopped');
+	}
+
+	private async poll(): Promise<void> {
+		if (this.running) return;
+
+		// Startup grace period
+		if (this.startupTime) {
+			const elapsed = Date.now() - this.startupTime.getTime();
+			if (elapsed < STARTUP_GRACE_MS) return;
+		}
+
+		const conn = await getProwlarrConnection();
+		if (!conn?.autoSync) return;
+
+		if (!conn.lastSyncAt) {
+			// Never synced — run immediately
+			await this.runSync();
+			return;
+		}
+
+		const intervalMs = conn.syncIntervalHours * 60 * 60 * 1000;
+		const elapsed = Date.now() - new Date(conn.lastSyncAt).getTime();
+		if (elapsed >= intervalMs) {
+			await this.runSync();
+		}
+	}
+
+	private async runSync(): Promise<void> {
+		if (this.running) return;
+		this.running = true;
+		try {
+			logger.info('[ProwlarrSync] Running scheduled sync');
+			const result = await syncProwlarrIndexers();
+			logger.info(
+				{ added: result.added, removed: result.removed, failed: result.failed },
+				'[ProwlarrSync] Scheduled sync complete'
+			);
+		} catch (err) {
+			logger.error({ err }, '[ProwlarrSync] Scheduled sync failed');
+		} finally {
+			this.running = false;
+		}
+	}
+}
+
+export function getProwlarrSyncScheduler(): ProwlarrSyncScheduler {
+	return ProwlarrSyncScheduler.getInstance();
+}

--- a/src/lib/server/indexers/ratelimit/HostConcurrencyLimiter.ts
+++ b/src/lib/server/indexers/ratelimit/HostConcurrencyLimiter.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-host concurrency limiter.
+ *
+ * Limits how many requests to the same host can be in-flight simultaneously.
+ * This prevents thundering-herd bursts when many indexers share a host
+ * (e.g., 20 Prowlarr indexers all firing at once).
+ *
+ * Unlike rate limiting (N requests per time window), this is a semaphore:
+ * at most N requests can be awaiting a response from the same host at any instant.
+ */
+
+const DEFAULT_MAX_CONCURRENT = 5;
+
+/**
+ * Extract a host key from a URL, including port so that different services
+ * on the same machine are not treated as the same host.
+ */
+function concurrencyKey(url: string): string {
+	try {
+		const parsed = new URL(url);
+		const host = parsed.hostname.toLowerCase();
+		return parsed.port ? `${host}:${parsed.port}` : host;
+	} catch {
+		return url.toLowerCase();
+	}
+}
+
+export class HostConcurrencyLimiter {
+	private inFlight: Map<string, number> = new Map();
+	private queues: Map<string, Array<(acquired: boolean) => void>> = new Map();
+	private maxConcurrent: number;
+
+	constructor(maxConcurrent = DEFAULT_MAX_CONCURRENT) {
+		this.maxConcurrent = maxConcurrent;
+	}
+
+	/**
+	 * Acquire a concurrency slot for the given URL's host.
+	 *
+	 * Returns true when the slot is acquired (proceed with the request).
+	 * Returns false if timeoutMs elapses before a slot becomes available.
+	 * If timeoutMs is omitted, waits indefinitely.
+	 */
+	async acquire(url: string, timeoutMs?: number): Promise<boolean> {
+		const key = concurrencyKey(url);
+		const current = this.inFlight.get(key) ?? 0;
+
+		if (current < this.maxConcurrent) {
+			this.inFlight.set(key, current + 1);
+			return true;
+		}
+
+		// No slot available — queue and wait
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+
+			const onSlot = (acquired: boolean) => {
+				if (settled) return;
+				settled = true;
+				if (acquired) {
+					const n = this.inFlight.get(key) ?? 0;
+					this.inFlight.set(key, n + 1);
+				}
+				resolve(acquired);
+			};
+
+			const queue = this.queues.get(key) ?? [];
+			queue.push(onSlot);
+			this.queues.set(key, queue);
+
+			if (timeoutMs !== undefined) {
+				setTimeout(() => {
+					if (!settled) {
+						settled = true;
+						const q = this.queues.get(key);
+						if (q) {
+							const idx = q.indexOf(onSlot);
+							if (idx > -1) q.splice(idx, 1);
+						}
+						resolve(false);
+					}
+				}, timeoutMs);
+			}
+		});
+	}
+
+	/**
+	 * Release a concurrency slot for the given URL's host.
+	 * Must be called in a finally block after every successful acquire.
+	 */
+	release(url: string): void {
+		const key = concurrencyKey(url);
+		const current = this.inFlight.get(key) ?? 0;
+		this.inFlight.set(key, Math.max(0, current - 1));
+
+		const queue = this.queues.get(key);
+		if (queue?.length) {
+			const next = queue.shift();
+			if (next) next(true);
+		}
+	}
+
+	getInFlight(url: string): number {
+		return this.inFlight.get(concurrencyKey(url)) ?? 0;
+	}
+}
+
+let concurrencyLimiterInstance: HostConcurrencyLimiter | null = null;
+
+export function getHostConcurrencyLimiter(): HostConcurrencyLimiter {
+	if (!concurrencyLimiterInstance) {
+		concurrencyLimiterInstance = new HostConcurrencyLimiter();
+	}
+	return concurrencyLimiterInstance;
+}
+
+export function resetHostConcurrencyLimiter(): void {
+	concurrencyLimiterInstance = null;
+}

--- a/src/lib/server/indexers/ratelimit/HostRateLimiter.ts
+++ b/src/lib/server/indexers/ratelimit/HostRateLimiter.ts
@@ -22,41 +22,64 @@ const DEFAULT_HOST_RATE_LIMIT: RateLimitConfig = {
 };
 
 /**
- * Extract hostname from URL.
+ * Extract host identifier from URL, including port when present.
+ * Including the port ensures that two different services on the same
+ * machine (e.g., Prowlarr on :9696 and Jackett on :9117) get separate buckets.
  */
 function extractHost(url: string): string {
 	try {
-		return new URL(url).hostname.toLowerCase();
+		const parsed = new URL(url);
+		const host = parsed.hostname.toLowerCase();
+		return parsed.port ? `${host}:${parsed.port}` : host;
 	} catch {
-		// Fallback for invalid URLs
 		return url.toLowerCase();
 	}
 }
 
 /**
- * Get base domain from hostname (e.g., "api.example.com" -> "example.com")
- * This groups subdomains together.
+ * Get base domain from a host string (optionally including port).
+ *
+ * For IP addresses and localhost the full host:port is returned as-is so
+ * rate limit buckets map precisely to one service rather than accidentally
+ * grouping unrelated IPs that share the same last two octets.
+ *
+ * For named hosts the registered domain is returned, grouping subdomains
+ * (e.g., "api.example.com:443" -> "example.com:443").
  */
-function getBaseDomain(hostname: string): string {
-	const parts = hostname.split('.');
+function getBaseDomain(hostWithPort: string): string {
+	// Separate port suffix (e.g., "example.com:8080" -> host="example.com", suffix=":8080")
+	// Safe for IPv4 — IPv6 would be "[::1]:port" which we don't currently handle.
+	let host = hostWithPort;
+	let portSuffix = '';
+	const lastColon = hostWithPort.lastIndexOf(':');
+	if (lastColon > -1) {
+		const afterColon = hostWithPort.slice(lastColon + 1);
+		if (/^\d+$/.test(afterColon)) {
+			host = hostWithPort.slice(0, lastColon);
+			portSuffix = hostWithPort.slice(lastColon);
+		}
+	}
 
-	// Handle special cases like .co.uk, .com.au, etc.
+	// IP addresses and localhost — return full host:port, no stripping
+	if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host === 'localhost' || host === '127.0.0.1') {
+		return hostWithPort;
+	}
+
+	const parts = host.split('.');
 	const multiPartTLDs = ['co.uk', 'com.au', 'co.nz', 'org.uk', 'net.au'];
 
 	if (parts.length >= 3) {
 		const lastTwo = parts.slice(-2).join('.');
 		if (multiPartTLDs.includes(lastTwo)) {
-			// e.g., "www.example.co.uk" -> "example.co.uk"
-			return parts.slice(-3).join('.');
+			return parts.slice(-3).join('.') + portSuffix;
 		}
 	}
 
-	// Standard case: "api.example.com" -> "example.com"
 	if (parts.length >= 2) {
-		return parts.slice(-2).join('.');
+		return parts.slice(-2).join('.') + portSuffix;
 	}
 
-	return hostname;
+	return hostWithPort;
 }
 
 /**
@@ -243,6 +266,41 @@ export class HostRateLimiter {
 				reason: `host ${host}`
 			};
 		}
+	}
+
+	/**
+	 * Atomically check both rate limits and record the request if it can proceed.
+	 *
+	 * No await occurs between the check and the record, so concurrent callers in
+	 * the same JS event-loop tick each see the updated count from previous callers.
+	 * This prevents the thundering-herd bug where all parallel callers see count=0
+	 * when recording is deferred to after the response.
+	 *
+	 * When canProceed is false the request has NOT been recorded — the caller must
+	 * wait the returned waitTimeMs and then record manually before dispatching.
+	 */
+	checkAndRecord(
+		indexerId: string,
+		url: string,
+		indexerLimiter: RateLimiter
+	): { canProceed: boolean; waitTimeMs: number; reason: string } {
+		const hostLimiter = this.getLimiterForUrl(url);
+
+		// Synchronous — no await between check and record
+		if (indexerLimiter.canProceed() && hostLimiter.canProceed()) {
+			indexerLimiter.recordRequest();
+			hostLimiter.recordRequest();
+			return { canProceed: true, waitTimeMs: 0, reason: 'none' };
+		}
+
+		const indexerWait = indexerLimiter.getWaitTime();
+		const hostWait = hostLimiter.getWaitTime();
+
+		if (indexerWait >= hostWait) {
+			return { canProceed: false, waitTimeMs: indexerWait, reason: `indexer ${indexerId}` };
+		}
+		const host = extractHost(url);
+		return { canProceed: false, waitTimeMs: hostWait, reason: `host ${host}` };
 	}
 
 	private getHostKey(hostname: string): string {

--- a/src/lib/server/indexers/runtime/RequestBuilder.ts
+++ b/src/lib/server/indexers/runtime/RequestBuilder.ts
@@ -730,6 +730,21 @@ export class RequestBuilder {
 		}
 
 		try {
+			// Torznab paths are always empty strings — the base URL IS the endpoint.
+			// Jackett URLs like http://host/torznab/all must end with /api, but users often omit it.
+			// Apply the same normalization that the caps-fetch does so searches hit the right endpoint.
+			if (this.definition.id === 'torznab' && !path) {
+				const base = new URL(this.baseUrl);
+				const normalizedPath = base.pathname.replace(/\/+$/, '');
+				const lowerPath = normalizedPath.toLowerCase();
+				const isTorznabEndpoint =
+					lowerPath.endsWith('/torznab') || lowerPath.includes('/results/torznab');
+				if (!isTorznabEndpoint && !lowerPath.endsWith('/api')) {
+					base.pathname = normalizedPath ? `${normalizedPath}/api` : '/api';
+				}
+				return base.toString();
+			}
+
 			// Newznab endpoints are commonly hosted under a sub-path (e.g., /newznab).
 			// Keep that base path when definition paths are absolute like "/api".
 			if (this.definition.id === 'newznab' && path.startsWith('/')) {

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -128,9 +128,18 @@ function containsCyrillic(value: string): boolean {
 	return CYRILLIC_REGEX.test(value);
 }
 
+const RUSSIAN_TRACKER_NAMES = ['rutracker', 'kinozal', 'rutor', 'nnmclub', 'nnm-club', 'rustorka'];
+
 function prefersNativeCyrillicTitles(indexer: IIndexer): boolean {
 	const name = indexer.name.toLowerCase();
-	return name.includes('rutracker') || name.includes('kinozal');
+	if (RUSSIAN_TRACKER_NAMES.some((t) => name.includes(t))) return true;
+	// .ru TLD is a reliable catch-all for Russian trackers not covered by name matching
+	try {
+		const hostname = new URL(indexer.baseUrl).hostname.toLowerCase();
+		return hostname.endsWith('.ru') || hostname.includes('.ru.');
+	} catch {
+		return false;
+	}
 }
 
 const NON_VIDEO_ARTIFACT_TITLE_PATTERNS: RegExp[] = [

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -34,6 +34,10 @@ import {
 import { getPersistentStatusTracker, type PersistentStatusTracker } from '../status';
 import { getRateLimitRegistry, type RateLimitRegistry } from '../ratelimit';
 import { getHostRateLimiter, type HostRateLimiter } from '../ratelimit/HostRateLimiter';
+import {
+	getHostConcurrencyLimiter,
+	type HostConcurrencyLimiter
+} from '../ratelimit/HostConcurrencyLimiter';
 import { ReleaseDeduplicator } from './ReleaseDeduplicator';
 import { ReleaseRanker } from './ReleaseRanker';
 import { ReleaseCache } from './ReleaseCache';
@@ -226,6 +230,7 @@ export class SearchOrchestrator {
 	private rutrackerAutomaticSearchLane: Promise<void> = Promise.resolve();
 	private rateLimitRegistry: RateLimitRegistry;
 	private hostRateLimiter: HostRateLimiter;
+	private hostConcurrencyLimiter: HostConcurrencyLimiter;
 	private deduplicator: ReleaseDeduplicator;
 	private ranker: ReleaseRanker;
 	private cache: ReleaseCache;
@@ -243,6 +248,7 @@ export class SearchOrchestrator {
 		this.statusTracker = getPersistentStatusTracker();
 		this.rateLimitRegistry = getRateLimitRegistry();
 		this.hostRateLimiter = getHostRateLimiter();
+		this.hostConcurrencyLimiter = getHostConcurrencyLimiter();
 		this.deduplicator = new ReleaseDeduplicator();
 		this.ranker = new ReleaseRanker();
 		this.cache = new ReleaseCache();
@@ -909,36 +915,49 @@ export class SearchOrchestrator {
 		const startTime = Date.now();
 
 		try {
-			// Check both indexer rate limit AND host rate limit
 			const limiter = this.rateLimitRegistry.get(indexer.id);
-			const hostCheck = this.hostRateLimiter.checkRateLimits(indexer.id, indexer.baseUrl, limiter);
 
-			if (!hostCheck.canProceed) {
-				const waitTime = hostCheck.waitTimeMs;
+			// Atomically check and record rate limits — concurrent callers each see
+			// the updated count, preventing all-zero thundering-herd reads.
+			const rateCheck = this.hostRateLimiter.checkAndRecord(indexer.id, indexer.baseUrl, limiter);
+
+			if (!rateCheck.canProceed) {
 				logger.debug(
-					{
-						indexer: indexer.name,
-						reason: hostCheck.reason,
-						waitTimeMs: waitTime
-					},
+					{ indexer: indexer.name, reason: rateCheck.reason, waitTimeMs: rateCheck.waitTimeMs },
 					'Rate limited'
 				);
 
-				// Wait or skip based on wait time
-				if (waitTime > timeout) {
+				if (rateCheck.waitTimeMs > timeout) {
 					return {
 						indexerId: indexer.id,
 						indexerName: indexer.name,
 						results: [],
 						searchTimeMs: Date.now() - startTime,
-						error: `Rate limited: ${hostCheck.reason} (wait: ${waitTime}ms)`
+						error: `Rate limited: ${rateCheck.reason} (wait: ${rateCheck.waitTimeMs}ms)`
 					};
 				}
 
-				await this.delay(waitTime);
+				await this.delay(rateCheck.waitTimeMs);
+				// Record after waiting, now that the window has advanced
+				limiter.recordRequest();
+				this.hostRateLimiter.recordRequest(indexer.baseUrl);
 			}
 
-			// Execute search with timeout
+			// Acquire a concurrency slot — limits simultaneous in-flight requests to
+			// the same host (e.g., many Prowlarr indexers sharing one instance).
+			const remainingMs = timeout - (Date.now() - startTime);
+			const acquired = await this.hostConcurrencyLimiter.acquire(indexer.baseUrl, remainingMs);
+			if (!acquired) {
+				return {
+					indexerId: indexer.id,
+					indexerName: indexer.name,
+					results: [],
+					searchTimeMs: Date.now() - startTime,
+					error: 'Concurrency limit: too many requests in-flight to this host'
+				};
+			}
+
+			// Execute search with timeout; release concurrency slot when done (success or error)
 			const searchPromise = useTieredSearch
 				? this.executeWithTiering(indexer, criteria)
 				: this.executeSimple(indexer, criteria);
@@ -946,11 +965,8 @@ export class SearchOrchestrator {
 			const { releases, searchMethod } = await Promise.race([
 				searchPromise,
 				this.createTimeoutPromise(timeout)
-			]);
+			]).finally(() => this.hostConcurrencyLimiter.release(indexer.baseUrl));
 
-			// Record success for both indexer and host rate limits
-			limiter.recordRequest();
-			this.hostRateLimiter.recordRequest(indexer.baseUrl);
 			await this.statusTracker.recordSuccess(indexer.id, Date.now() - startTime);
 
 			// Attach indexer priority to each release for Radarr-style deduplication
@@ -1240,6 +1256,14 @@ export class SearchOrchestrator {
 		const BATCH_SIZE = 3;
 
 		for (let i = 0; i < variantCriteria.length; i += BATCH_SIZE) {
+			// Early exit: results from a previous batch mean the primary query
+			// already matched - skip remaining variants to avoid redundant requests.
+			// This prevents FlareSolverr-backed indexers from being overwhelmed
+			// by follow-up queries that can't finish within the per-indexer timeout.
+			if (allReleases.length > 0) {
+				break;
+			}
+
 			const batch = variantCriteria.slice(i, i + BATCH_SIZE);
 			const settled = await Promise.allSettled(batch.map((vc) => indexer.search(vc)));
 

--- a/src/lib/server/logging/log-history.ts
+++ b/src/lib/server/logging/log-history.ts
@@ -253,6 +253,8 @@ async function getMatchingEntryPage(
 	const entries: CapturedLogEntry[] = [];
 	const offset = Math.max(0, options.offset ?? 0);
 	const limit = Math.max(1, options.limit ?? 100);
+	// Collect one extra entry to detect whether more exist without a full scan.
+	const collectLimit = options.stopWhenLimitReached ? limit + 1 : limit;
 	let parseErrors = 0;
 	let total = 0;
 
@@ -267,12 +269,12 @@ async function getMatchingEntryPage(
 			}
 			if (!parsed.entry) return;
 			if (matchesHistoryFilters(parsed.entry, filters)) {
-				if (total >= offset && entries.length < limit) {
+				if (total >= offset && entries.length < collectLimit) {
 					entries.push(parsed.entry);
 				}
 				total += 1;
 
-				if (options.stopWhenLimitReached && entries.length >= limit) {
+				if (options.stopWhenLimitReached && entries.length >= collectLimit) {
 					reachedLimit = true;
 					return false;
 				}
@@ -291,10 +293,11 @@ async function getMatchingEntryPage(
 		);
 	}
 
+	const hasMore = entries.length > limit || total > offset + entries.length;
 	return {
-		entries,
+		entries: entries.slice(0, limit),
 		total,
-		hasMore: total > offset + entries.length
+		hasMore
 	};
 }
 
@@ -368,7 +371,7 @@ class LogHistoryService {
 		const result = await getMatchingEntryPage(query, {
 			offset,
 			limit: pageSize,
-			stopWhenLimitReached: offset === 0
+			stopWhenLimitReached: true
 		});
 
 		return {

--- a/src/lib/server/services/AlternateTitleService.ts
+++ b/src/lib/server/services/AlternateTitleService.ts
@@ -18,6 +18,75 @@ import { tmdb } from '$lib/server/tmdb.js';
 import { logger } from '$lib/logging/index.js';
 
 /**
+ * Maps ISO 639-1 language codes to the ISO 3166-1 country codes where that
+ * language is the primary language. Used to rank TMDB alternate titles by
+ * relevance when a preferred language is known.
+ *
+ * TMDB alternate titles only carry country codes (not language codes), so
+ * this mapping is the best proxy available without a TMDB API change.
+ */
+const LANGUAGE_COUNTRIES: Record<string, Set<string>> = {
+	en: new Set(['US', 'GB', 'AU', 'CA', 'NZ', 'IE', 'ZA']),
+	fr: new Set(['FR', 'BE', 'CH', 'CA', 'LU', 'MC']),
+	de: new Set(['DE', 'AT', 'CH', 'LI', 'LU']),
+	es: new Set([
+		'ES',
+		'MX',
+		'AR',
+		'CO',
+		'CL',
+		'PE',
+		'VE',
+		'EC',
+		'BO',
+		'PY',
+		'UY',
+		'CR',
+		'GT',
+		'HN',
+		'NI',
+		'PA',
+		'SV',
+		'DO',
+		'CU',
+		'PR'
+	]),
+	pt: new Set(['PT', 'BR', 'AO', 'MZ']),
+	it: new Set(['IT', 'SM', 'VA', 'CH']),
+	ru: new Set(['RU', 'BY', 'KZ', 'KG']),
+	ja: new Set(['JP']),
+	ko: new Set(['KR']),
+	zh: new Set(['CN', 'TW', 'HK', 'MO', 'SG']),
+	nl: new Set(['NL', 'BE', 'SR']),
+	pl: new Set(['PL']),
+	sv: new Set(['SE']),
+	no: new Set(['NO']),
+	da: new Set(['DK']),
+	fi: new Set(['FI']),
+	tr: new Set(['TR']),
+	ar: new Set([
+		'SA',
+		'AE',
+		'EG',
+		'DZ',
+		'MA',
+		'TN',
+		'LY',
+		'IQ',
+		'SY',
+		'JO',
+		'LB',
+		'KW',
+		'QA',
+		'BH',
+		'OM',
+		'YE'
+	]),
+	hi: new Set(['IN']),
+	th: new Set(['TH'])
+};
+
+/**
  * Normalize a title for matching (like Radarr's CleanTitle)
  * Removes special characters, accents, and normalizes whitespace
  */
@@ -66,12 +135,21 @@ function pushUniqueSearchTitle(
 }
 
 /**
- * Get all search titles for a movie (primary + original + alternates)
- * Returns deduplicated list with primary/original title text preserved for searching.
- * Deduplication is still done using normalized titles for stable matching.
+ * Get all search titles for a movie (primary + original + alternates).
+ *
+ * Order of precedence:
+ * 1. Display title (user's preferred language)
+ * 2. Original title (if different - covers non-English originals)
+ * 3. TMDB alternates from countries matching the preferred language
+ * 4. Remaining TMDB alternates (last-resort fallback for regional trackers)
+ *
+ * The early-exit in SearchOrchestrator means later entries are only tried
+ * when the primary titles return nothing, so the ordering matters more than the count.
  */
-export async function getMovieSearchTitles(movieId: string): Promise<string[]> {
-	// Get the movie's primary and original titles
+export async function getMovieSearchTitles(
+	movieId: string,
+	preferredLanguage?: string
+): Promise<string[]> {
 	const movie = await db.query.movies.findFirst({
 		where: eq(movies.id, movieId),
 		columns: { title: true, originalTitle: true }
@@ -82,33 +160,44 @@ export async function getMovieSearchTitles(movieId: string): Promise<string[]> {
 	const titles: string[] = [];
 	const seen = new Set<string>();
 
-	// Prefer original/native title first for tracker search ordering.
+	// Display title first - user's preferred language, most likely to match standard trackers.
+	pushUniqueSearchTitle(titles, seen, movie.title);
+	// Original title second - needed for non-English films on origin-language trackers.
 	if (movie.originalTitle && movie.originalTitle !== movie.title) {
 		pushUniqueSearchTitle(titles, seen, movie.originalTitle);
 	}
-	pushUniqueSearchTitle(titles, seen, movie.title);
 
-	// Get alternate titles from database, preserving their original text for searching.
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'movie'), eq(alternateTitles.mediaId, movieId)),
-		columns: { title: true }
+		columns: { title: true, country: true }
 	});
 
-	for (const alt of alternates) {
+	// Split alternates: preferred-language countries first, others as fallback.
+	const preferredCountries = preferredLanguage
+		? (LANGUAGE_COUNTRIES[preferredLanguage.toLowerCase()] ?? null)
+		: null;
+	const [langAlts, otherAlts] = preferredCountries
+		? [
+				alternates.filter((a) => a.country && preferredCountries.has(a.country)),
+				alternates.filter((a) => !a.country || !preferredCountries.has(a.country))
+			]
+		: [alternates, []];
+
+	for (const alt of [...langAlts, ...otherAlts]) {
 		pushUniqueSearchTitle(titles, seen, alt.title);
 	}
 
-	// Limit to prevent excessive searches
 	return titles.slice(0, 5);
 }
 
 /**
- * Get all search titles for a series (primary + original + alternates)
- * Returns deduplicated list with primary/original title text preserved for searching.
- * Deduplication is still done using normalized titles for stable matching.
+ * Get all search titles for a series (primary + original + alternates).
+ * Same ordering strategy as getMovieSearchTitles.
  */
-export async function getSeriesSearchTitles(seriesId: string): Promise<string[]> {
-	// Get the series' primary and original titles
+export async function getSeriesSearchTitles(
+	seriesId: string,
+	preferredLanguage?: string
+): Promise<string[]> {
 	const show = await db.query.series.findFirst({
 		where: eq(series.id, seriesId),
 		columns: { title: true, originalTitle: true }
@@ -119,23 +208,32 @@ export async function getSeriesSearchTitles(seriesId: string): Promise<string[]>
 	const titles: string[] = [];
 	const seen = new Set<string>();
 
-	// Prefer original/native title first for tracker search ordering.
+	// Display title first - user's preferred language, most likely to match standard trackers.
+	pushUniqueSearchTitle(titles, seen, show.title);
+	// Original title second - needed for non-English shows on origin-language trackers.
 	if (show.originalTitle && show.originalTitle !== show.title) {
 		pushUniqueSearchTitle(titles, seen, show.originalTitle);
 	}
-	pushUniqueSearchTitle(titles, seen, show.title);
 
-	// Get alternate titles from database, preserving their original text for searching.
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'series'), eq(alternateTitles.mediaId, seriesId)),
-		columns: { title: true }
+		columns: { title: true, country: true }
 	});
 
-	for (const alt of alternates) {
+	const preferredCountries = preferredLanguage
+		? (LANGUAGE_COUNTRIES[preferredLanguage.toLowerCase()] ?? null)
+		: null;
+	const [langAlts, otherAlts] = preferredCountries
+		? [
+				alternates.filter((a) => a.country && preferredCountries.has(a.country)),
+				alternates.filter((a) => !a.country || !preferredCountries.has(a.country))
+			]
+		: [alternates, []];
+
+	for (const alt of [...langAlts, ...otherAlts]) {
 		pushUniqueSearchTitle(titles, seen, alt.title);
 	}
 
-	// Limit to prevent excessive searches
 	return titles.slice(0, 5);
 }
 

--- a/src/lib/server/services/initializer.ts
+++ b/src/lib/server/services/initializer.ts
@@ -19,6 +19,8 @@ import { getMediaBrowserNotifier } from '$lib/server/notifications/mediabrowser'
 import { getMediaServerStatsSyncService } from '$lib/server/mediaServerStats/MediaServerStatsSyncService.js';
 import { getEpgScheduler } from '$lib/server/livetv/epg';
 import { getLiveTvAccountManager } from '$lib/server/livetv/LiveTvAccountManager';
+import { getProwlarrSyncScheduler } from '$lib/server/indexers/prowlarr/ProwlarrSyncScheduler.js';
+import { getJackettSyncScheduler } from '$lib/server/indexers/jackett/JackettSyncScheduler.js';
 import { getLiveTvChannelService } from '$lib/server/livetv/LiveTvChannelService';
 import { getLiveTvStreamService } from '$lib/server/livetv/streaming/LiveTvStreamService';
 import { getStalkerPortalManager } from '$lib/server/livetv/stalker/StalkerPortalManager';
@@ -134,6 +136,12 @@ async function initializeServices(): Promise<void> {
 
 			const epgScheduler = getEpgScheduler();
 			serviceManager.register(epgScheduler);
+
+			const prowlarrSyncScheduler = getProwlarrSyncScheduler();
+			serviceManager.register(prowlarrSyncScheduler);
+
+			const jackettSyncScheduler = getJackettSyncScheduler();
+			serviceManager.register(jackettSyncScheduler);
 
 			serviceManager.startAll();
 

--- a/src/lib/sse/create-sse.svelte.ts
+++ b/src/lib/sse/create-sse.svelte.ts
@@ -280,6 +280,7 @@ export function createSSE<T = Record<string, unknown>>(
 			lastUrl = resolvedUrl;
 			reconnectCount = 0;
 			isManuallyClosed = false;
+			closeConnection(); // force-close before reconnect so the open-connection guard in connect() doesn't skip it
 			connect(resolvedUrl);
 		}
 	});

--- a/src/routes/api/indexers/jackett/+server.ts
+++ b/src/routes/api/indexers/jackett/+server.ts
@@ -1,0 +1,89 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { z } from 'zod';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
+import {
+	normalizeJackettUrl,
+	fetchJackettIndexers,
+	jackettIndexerUrl,
+	isIndexerFromJackett
+} from '$lib/server/indexers/jackett/JackettConnectionService.js';
+
+const requestSchema = z.object({
+	url: z.string().url('Jackett URL must be a valid URL'),
+	apiKey: z.string().min(1, 'API key is required')
+});
+
+export interface JackettImportIndexer {
+	id: string;
+	name: string;
+	type: string;
+	baseUrl: string;
+	alreadyImported: boolean;
+}
+
+/** POST: verify connection and return indexer list with alreadyImported flags. */
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	let body: unknown;
+	try {
+		body = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const result = requestSchema.safeParse(body);
+	if (!result.success) {
+		return json({ error: result.error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+	}
+
+	const { url: rawUrl, apiKey } = result.data;
+	const jackettBase = normalizeJackettUrl(rawUrl);
+
+	let rawIndexers;
+	try {
+		rawIndexers = await fetchJackettIndexers(jackettBase, apiKey);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isTimeout = message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+		return json(
+			{
+				error: isTimeout
+					? 'Connection timed out. Check that Jackett is running and the URL is correct.'
+					: message.includes('Authentication')
+						? message
+						: 'Unable to reach Jackett. Check the URL and ensure Jackett is accessible.'
+			},
+			{ status: 502 }
+		);
+	}
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+
+	const indexers: JackettImportIndexer[] = [];
+	for (const raw of rawIndexers) {
+		const baseUrl = jackettIndexerUrl(jackettBase, raw.id);
+		const existing = existingIndexers.find(
+			(e) =>
+				isIndexerFromJackett(e.baseUrl, jackettBase) && e.baseUrl.replace(/\/+$/, '') === baseUrl
+		);
+		if (existing && existing.name !== raw.name) {
+			await manager.updateIndexer(existing.id, { name: raw.name });
+		}
+		indexers.push({
+			id: raw.id,
+			name: raw.name,
+			type: raw.type ?? 'unknown',
+			baseUrl,
+			alreadyImported: Boolean(existing)
+		});
+	}
+
+	indexers.sort((a, b) => a.name.localeCompare(b.name));
+
+	return json({ indexers });
+};

--- a/src/routes/api/indexers/jackett/connection/+server.ts
+++ b/src/routes/api/indexers/jackett/connection/+server.ts
@@ -1,0 +1,135 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import {
+	getJackettConnection,
+	saveJackettConnection,
+	deleteJackettConnection,
+	fetchJackettIndexers,
+	normalizeJackettUrl
+} from '$lib/server/indexers/jackett/JackettConnectionService.js';
+import { z } from 'zod';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'indexers' as const });
+
+const connectionSchema = z.object({
+	url: z.string().url('Must be a valid URL'),
+	apiKey: z.string().optional(),
+	adminPassword: z.string().optional(),
+	autoSync: z.boolean().default(false),
+	syncIntervalHours: z.number().int().min(1).max(168).default(24),
+	syncAddNew: z.boolean().default(false)
+});
+
+/** GET: return current connection. The API key is never included in the response. */
+export const GET: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const conn = await getJackettConnection();
+	if (!conn) return json({ connection: null });
+
+	return json({
+		connection: {
+			url: conn.url,
+			autoSync: conn.autoSync,
+			syncIntervalHours: conn.syncIntervalHours,
+			syncAddNew: conn.syncAddNew,
+			lastSyncAt: conn.lastSyncAt,
+			lastSyncResult: conn.lastSyncResult,
+			lastSyncError: conn.lastSyncError
+		}
+	});
+};
+
+/**
+ * PUT: save or update connection.
+ * If apiKey is provided and non-empty, connectivity is verified.
+ * If omitted, the stored API key is reused (settings-only update).
+ */
+export const PUT: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	let body: unknown;
+	try {
+		body = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const result = connectionSchema.safeParse(body);
+	if (!result.success) {
+		return json({ error: result.error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+	}
+
+	const {
+		url: rawUrl,
+		apiKey: providedKey,
+		adminPassword: providedAdminPassword,
+		autoSync,
+		syncIntervalHours,
+		syncAddNew
+	} = result.data;
+	const url = normalizeJackettUrl(rawUrl);
+
+	const existing = await getJackettConnection();
+	const newKey = providedKey?.trim();
+
+	// Admin password: use provided value if non-empty, otherwise keep existing stored value.
+	const adminPassword =
+		providedAdminPassword !== undefined && providedAdminPassword !== ''
+			? providedAdminPassword
+			: (existing?.adminPassword ?? '');
+
+	let apiKey: string;
+	if (newKey) {
+		apiKey = newKey;
+		try {
+			await fetchJackettIndexers(url, apiKey, adminPassword);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : null;
+			logger.error({ err, url }, '[Jackett] Connection verification failed');
+			const isTimeout =
+				message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+			const detail = cause ? ` (${cause})` : '';
+			return json(
+				{
+					error: isTimeout
+						? `Connection timed out. Check the URL and ensure Jackett is accessible.${detail}`
+						: `Unable to reach Jackett: ${message}${detail}`
+				},
+				{ status: 502 }
+			);
+		}
+	} else if (existing?.apiKey) {
+		apiKey = existing.apiKey;
+	} else {
+		return json({ error: 'API key is required.' }, { status: 400 });
+	}
+
+	await saveJackettConnection({
+		url,
+		apiKey,
+		adminPassword: adminPassword || undefined,
+		autoSync,
+		syncIntervalHours,
+		syncAddNew,
+		lastSyncAt: existing?.url === url ? (existing.lastSyncAt ?? null) : null,
+		lastSyncResult: existing?.url === url ? (existing.lastSyncResult ?? null) : null,
+		lastSyncError: existing?.url === url ? (existing.lastSyncError ?? null) : null
+	});
+
+	return json({ success: true });
+};
+
+/** DELETE: remove connection. Already-imported indexers are not affected. */
+export const DELETE: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	await deleteJackettConnection();
+	return json({ success: true });
+};

--- a/src/routes/api/indexers/jackett/indexers/+server.ts
+++ b/src/routes/api/indexers/jackett/indexers/+server.ts
@@ -1,0 +1,71 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import {
+	getJackettConnection,
+	fetchJackettIndexers,
+	normalizeJackettUrl,
+	jackettIndexerUrl,
+	isIndexerFromJackett
+} from '$lib/server/indexers/jackett/JackettConnectionService.js';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
+
+/**
+ * GET: fetch indexers from the stored Jackett connection.
+ * The API key is never sent to the client.
+ * Each indexer includes `alreadyImported: boolean` based on live Cinephage indexers.
+ */
+export const GET: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const conn = await getJackettConnection();
+	if (!conn) {
+		return json({ error: 'No Jackett connection configured.' }, { status: 400 });
+	}
+
+	const base = normalizeJackettUrl(conn.url);
+
+	let rawIndexers;
+	try {
+		rawIndexers = await fetchJackettIndexers(base, conn.apiKey);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isTimeout = message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+		return json(
+			{
+				error: isTimeout
+					? 'Connection timed out. Check that Jackett is still running.'
+					: message.includes('Authentication')
+						? message
+						: 'Unable to reach Jackett. Check that it is still accessible.'
+			},
+			{ status: 502 }
+		);
+	}
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+
+	const indexers = [];
+	for (const raw of rawIndexers) {
+		const baseUrl = jackettIndexerUrl(base, raw.id);
+		const existing = existingIndexers.find(
+			(e) => isIndexerFromJackett(e.baseUrl, base) && e.baseUrl.replace(/\/+$/, '') === baseUrl
+		);
+		if (existing && existing.name !== raw.name) {
+			await manager.updateIndexer(existing.id, { name: raw.name });
+		}
+		indexers.push({
+			id: raw.id,
+			name: raw.name,
+			type: raw.type ?? 'unknown',
+			baseUrl,
+			alreadyImported: Boolean(existing)
+		});
+	}
+
+	indexers.sort((a, b) => a.name.localeCompare(b.name));
+
+	return json({ indexers });
+};

--- a/src/routes/api/indexers/jackett/sync/+server.ts
+++ b/src/routes/api/indexers/jackett/sync/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { syncJackettIndexers } from '$lib/server/indexers/jackett/JackettConnectionService.js';
+
+/** POST: trigger an immediate Jackett sync */
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	try {
+		const result = await syncJackettIndexers();
+		return json({ success: true, result });
+	} catch (err) {
+		return json({ error: err instanceof Error ? err.message : 'Sync failed' }, { status: 500 });
+	}
+};

--- a/src/routes/api/indexers/prowlarr/+server.ts
+++ b/src/routes/api/indexers/prowlarr/+server.ts
@@ -1,0 +1,136 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { z } from 'zod';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
+import { normalizeProwlarrUrl } from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
+
+const requestSchema = z.object({
+	url: z.string().url('Prowlarr URL must be a valid URL'),
+	apiKey: z.string().min(1, 'API key is required')
+});
+
+interface ProwlarrApiIndexer {
+	id: number;
+	name: string;
+	enable: boolean;
+	protocol: string;
+	privacy?: string;
+}
+
+export interface ProwlarrImportIndexer {
+	id: number;
+	name: string;
+	enabled: boolean;
+	protocol: 'torrent' | 'usenet';
+	definitionId: 'torznab' | 'newznab';
+	baseUrl: string;
+	privacy: string;
+	alreadyImported: boolean;
+}
+
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	let body: unknown;
+	try {
+		body = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const result = requestSchema.safeParse(body);
+	if (!result.success) {
+		return json({ error: result.error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+	}
+
+	const { url: rawUrl, apiKey } = result.data;
+
+	// Normalize: strip trailing slash
+	const prowlarrUrl = rawUrl.replace(/\/+$/, '');
+
+	let apiResponse: Response;
+	try {
+		apiResponse = await fetch(`${prowlarrUrl}/api/v1/indexer`, {
+			headers: {
+				'X-Api-Key': apiKey,
+				Accept: 'application/json'
+			},
+			signal: AbortSignal.timeout(10000)
+		});
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isTimeout = message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+		return json(
+			{
+				error: isTimeout
+					? 'Connection timed out. Check that Prowlarr is running and the URL is correct.'
+					: 'Unable to reach Prowlarr. Check the URL and ensure Prowlarr is accessible.'
+			},
+			{ status: 502 }
+		);
+	}
+
+	if (apiResponse.status === 401 || apiResponse.status === 403) {
+		return json({ error: 'Authentication failed. Check your Prowlarr API key.' }, { status: 401 });
+	}
+
+	if (!apiResponse.ok) {
+		return json(
+			{ error: `Prowlarr returned an unexpected error (HTTP ${apiResponse.status}).` },
+			{ status: 502 }
+		);
+	}
+
+	let rawIndexers: unknown;
+	try {
+		rawIndexers = await apiResponse.json();
+	} catch {
+		return json({ error: 'Prowlarr returned an invalid response.' }, { status: 502 });
+	}
+
+	if (!Array.isArray(rawIndexers)) {
+		return json({ error: 'Unexpected response format from Prowlarr.' }, { status: 502 });
+	}
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+	const existingByBaseUrl = new Map(
+		existingIndexers.map((i) => [normalizeProwlarrUrl(i.baseUrl), i])
+	);
+
+	const indexers: ProwlarrImportIndexer[] = [];
+
+	for (const raw of rawIndexers as ProwlarrApiIndexer[]) {
+		if (typeof raw.id !== 'number' || typeof raw.name !== 'string') continue;
+
+		const protocol = raw.protocol === 'usenet' ? 'usenet' : 'torrent';
+		const definitionId = protocol === 'usenet' ? 'newznab' : 'torznab';
+		const baseUrl = `${prowlarrUrl}/${raw.id}`;
+		const existing = existingByBaseUrl.get(baseUrl);
+
+		if (existing && existing.name !== raw.name) {
+			await manager.updateIndexer(existing.id, { name: raw.name });
+		}
+
+		indexers.push({
+			id: raw.id,
+			name: raw.name,
+			enabled: raw.enable === true,
+			protocol,
+			definitionId,
+			baseUrl,
+			privacy: typeof raw.privacy === 'string' ? raw.privacy : 'unknown',
+			alreadyImported: Boolean(existing)
+		});
+	}
+
+	// Sort: enabled first, then by name
+	indexers.sort((a, b) => {
+		if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+		return a.name.localeCompare(b.name);
+	});
+
+	return json({ indexers });
+};

--- a/src/routes/api/indexers/prowlarr/connection/+server.ts
+++ b/src/routes/api/indexers/prowlarr/connection/+server.ts
@@ -1,0 +1,125 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import {
+	getProwlarrConnection,
+	saveProwlarrConnection,
+	deleteProwlarrConnection,
+	fetchProwlarrIndexers,
+	normalizeProwlarrUrl
+} from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
+import { z } from 'zod';
+
+/**
+ * When apiKey is omitted or empty, the stored key is preserved.
+ * This lets "Save settings" (auto-sync toggle, interval) work without
+ * requiring the user to re-enter their API key.
+ */
+const connectionSchema = z.object({
+	url: z.string().url('Must be a valid URL'),
+	apiKey: z.string().optional(),
+	autoSync: z.boolean().default(false),
+	syncIntervalHours: z.number().int().min(1).max(168).default(24),
+	syncAddNew: z.boolean().default(false)
+});
+
+/** GET - return current connection. The API key is never included in the response. */
+export const GET: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const conn = await getProwlarrConnection();
+	if (!conn) return json({ connection: null });
+
+	return json({
+		connection: {
+			url: conn.url,
+			autoSync: conn.autoSync,
+			syncIntervalHours: conn.syncIntervalHours,
+			syncAddNew: conn.syncAddNew,
+			lastSyncAt: conn.lastSyncAt,
+			lastSyncResult: conn.lastSyncResult,
+			lastSyncError: conn.lastSyncError
+		}
+	});
+};
+
+/**
+ * PUT - save or update connection.
+ * If apiKey is provided and non-empty, connectivity is verified with it.
+ * If omitted, the stored API key is reused (settings-only update).
+ */
+export const PUT: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	let body: unknown;
+	try {
+		body = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const result = connectionSchema.safeParse(body);
+	if (!result.success) {
+		return json({ error: result.error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+	}
+
+	const { url: rawUrl, apiKey: providedKey, autoSync, syncIntervalHours, syncAddNew } = result.data;
+	const url = normalizeProwlarrUrl(rawUrl);
+
+	const existing = await getProwlarrConnection();
+	const newKey = providedKey?.trim();
+
+	// Determine which API key to use
+	let apiKey: string;
+	if (newKey) {
+		// New key provided; verify it works
+		apiKey = newKey;
+		try {
+			await fetchProwlarrIndexers(url, apiKey);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			const isTimeout =
+				message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+			return json(
+				{
+					error: isTimeout
+						? 'Connection timed out. Check the URL and ensure Prowlarr is accessible.'
+						: message.includes('Authentication')
+							? message
+							: 'Unable to reach Prowlarr. Check the URL and ensure Prowlarr is running.'
+				},
+				{ status: 502 }
+			);
+		}
+	} else if (existing?.apiKey) {
+		// No new key - reuse the stored one
+		apiKey = existing.apiKey;
+	} else {
+		return json({ error: 'API key is required.' }, { status: 400 });
+	}
+
+	await saveProwlarrConnection({
+		url,
+		apiKey,
+		autoSync,
+		syncIntervalHours,
+		syncAddNew,
+		// Preserve sync history when the URL hasn't changed
+		lastSyncAt: existing?.url === url ? (existing.lastSyncAt ?? null) : null,
+		lastSyncResult: existing?.url === url ? (existing.lastSyncResult ?? null) : null,
+		lastSyncError: existing?.url === url ? (existing.lastSyncError ?? null) : null
+	});
+
+	return json({ success: true });
+};
+
+/** DELETE - remove connection. Already-imported indexers are not affected. */
+export const DELETE: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	await deleteProwlarrConnection();
+	return json({ success: true });
+};

--- a/src/routes/api/indexers/prowlarr/indexers/+server.ts
+++ b/src/routes/api/indexers/prowlarr/indexers/+server.ts
@@ -1,0 +1,79 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import {
+	getProwlarrConnection,
+	fetchProwlarrIndexers,
+	normalizeProwlarrUrl
+} from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
+import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
+
+/**
+ * GET - fetch indexers from Prowlarr using the stored connection's API key.
+ * The API key is never sent to the client.
+ * Each indexer includes `alreadyImported: boolean` based on the live Cinephage indexer list.
+ */
+export const GET: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const conn = await getProwlarrConnection();
+	if (!conn) {
+		return json({ error: 'No Prowlarr connection configured.' }, { status: 400 });
+	}
+
+	const base = normalizeProwlarrUrl(conn.url);
+
+	let rawIndexers;
+	try {
+		rawIndexers = await fetchProwlarrIndexers(base, conn.apiKey);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isTimeout = message.toLowerCase().includes('timeout') || message.includes('TimeoutError');
+		return json(
+			{
+				error: isTimeout
+					? 'Connection timed out. Check that Prowlarr is still running.'
+					: message.includes('Authentication')
+						? message
+						: 'Unable to reach Prowlarr. Check that it is still accessible.'
+			},
+			{ status: 502 }
+		);
+	}
+
+	const manager = await getIndexerManager();
+	const existingIndexers = await manager.getIndexers();
+	const existingByBaseUrl = new Map(
+		existingIndexers.map((i) => [normalizeProwlarrUrl(i.baseUrl), i])
+	);
+
+	const indexers = [];
+	for (const raw of rawIndexers) {
+		const protocol = raw.protocol === 'usenet' ? 'usenet' : 'torrent';
+		const baseUrl = `${base}/${raw.id}`;
+		const existing = existingByBaseUrl.get(baseUrl);
+
+		if (existing && existing.name !== raw.name) {
+			await manager.updateIndexer(existing.id, { name: raw.name });
+		}
+
+		indexers.push({
+			id: raw.id,
+			name: raw.name,
+			enabled: raw.enable === true,
+			protocol,
+			definitionId: protocol === 'usenet' ? 'newznab' : 'torznab',
+			baseUrl,
+			privacy: typeof raw.privacy === 'string' ? raw.privacy : 'unknown',
+			alreadyImported: Boolean(existing)
+		});
+	}
+
+	indexers.sort((a, b) => {
+		if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+		return a.name.localeCompare(b.name);
+	});
+
+	return json({ indexers });
+};

--- a/src/routes/api/indexers/prowlarr/sync/+server.ts
+++ b/src/routes/api/indexers/prowlarr/sync/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { syncProwlarrIndexers } from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
+
+/** POST - trigger an immediate Prowlarr sync */
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	try {
+		const result = await syncProwlarrIndexers();
+		return json({ success: true, result });
+	} catch (err) {
+		return json({ error: err instanceof Error ? err.message : 'Sync failed' }, { status: 500 });
+	}
+};

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -197,11 +197,13 @@ export const POST: RequestHandler = async (event) => {
 			definition.settings
 		);
 
-		// Torznab validation uses the canonical caps endpoint.
-		// API key is optional and only included when provided.
+		// Torznab validation: auto-discover the correct endpoint if the user entered a bare host URL,
+		// then validate the resolved URL's caps endpoint.
 		if (validated.definitionId === 'torznab') {
 			const provider = getNewznabCapabilitiesProvider();
-			await provider.validateCapabilitiesEndpoint(validated.baseUrl, extractApiKey(settings));
+			const apiKey = extractApiKey(settings);
+			const resolvedUrl = await provider.resolveTorznabBaseUrl(validated.baseUrl, apiKey);
+			await provider.validateCapabilitiesEndpoint(resolvedUrl, apiKey);
 		}
 
 		await manager.testIndexer(

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -5,6 +5,11 @@ import { getNewznabCapabilitiesProvider } from '$lib/server/indexers/newznab/New
 import { indexerTestSchema } from '$lib/validation/schemas';
 import { mergeBlankSensitiveIndexerSettings } from '$lib/server/indexers/settingsSecrets';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import {
+	getJackettConnection,
+	isIndexerFromJackett,
+	normalizeJackettUrl
+} from '$lib/server/indexers/jackett/JackettConnectionService.js';
 
 function redactSensitiveDetails(message: string): string {
 	return message
@@ -186,6 +191,26 @@ export const POST: RequestHandler = async (event) => {
 			);
 		}
 		existingSettings = existing.settings;
+
+		// For Jackett-sourced indexers, make a warm-up search against Jackett's Torznab
+		// endpoint before running the Cinephage test. Jackett maintains an internal circuit
+		// breaker per indexer; if FlareSolverr previously failed, Jackett marks the indexer
+		// as broken and all subsequent searches return errors. A direct Torznab search request
+		// gives Jackett a chance to retry FlareSolverr and reset its own circuit breaker.
+		// Without this, the Cinephage test would keep failing even after FlareSolverr recovers,
+		// requiring the user to manually test in Jackett first.
+		try {
+			const jackettConn = await getJackettConnection();
+			if (jackettConn) {
+				const jackettBase = normalizeJackettUrl(jackettConn.url);
+				if (isIndexerFromJackett(existing.baseUrl, jackettBase)) {
+					const warmupUrl = `${existing.baseUrl}?apikey=${encodeURIComponent(jackettConn.apiKey)}&t=search&q=test`;
+					await fetch(warmupUrl, { signal: AbortSignal.timeout(15000) });
+				}
+			}
+		} catch {
+			// Warm-up failure is expected when Jackett/FlareSolverr is down; proceed anyway.
+		}
 	}
 
 	try {

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -19,6 +19,19 @@ import {
 } from '$lib/server/services/AlternateTitleService';
 
 /**
+ * Per-indexer search timeout for interactive searches.
+ * Interactive searches wait longer because the user is actively waiting and
+ * proxied indexers (Prowlarr, Jackett) add upstream latency on top of the
+ * network round trip to the remote tracker.
+ * Matches INDEXER_SEARCH_TIMEOUT_MS env var if set, otherwise defaults to 45 s.
+ */
+const INTERACTIVE_SEARCH_TIMEOUT_MS = (() => {
+	const raw = process.env.INDEXER_SEARCH_TIMEOUT_MS;
+	const parsed = raw ? parseInt(raw, 10) : NaN;
+	return parsed > 0 ? parsed : 45_000;
+})();
+
+/**
  * Redact sensitive URLs from release objects before returning in API responses.
  * This prevents API keys from being exposed to clients.
  */
@@ -270,7 +283,7 @@ export const GET: RequestHandler = async ({ url }) => {
 			searchSource: 'interactive',
 			enrichment: enrichmentOpts,
 			protocolFilter,
-			timeout: 20000
+			timeout: INTERACTIVE_SEARCH_TIMEOUT_MS
 		});
 
 		return json({
@@ -322,7 +335,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	// Standard search without enrichment (interactive)
 	const searchResult = await manager.search(criteria, {
 		searchSource: 'interactive',
-		timeout: 20000
+		timeout: INTERACTIVE_SEARCH_TIMEOUT_MS
 	});
 
 	return json({

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -182,10 +182,10 @@ export const GET: RequestHandler = async ({ url }) => {
 					columns: { id: true }
 				});
 				if (movie) {
-					searchTitles = await getMovieSearchTitles(movie.id);
+					searchTitles = await getMovieSearchTitles(movie.id, effectiveLanguage);
 					if (searchTitles.length <= 1) {
 						fetchAndStoreMovieAlternateTitles(movie.id, tmdbId).catch(() => {});
-						searchTitles = await getMovieSearchTitles(movie.id);
+						searchTitles = await getMovieSearchTitles(movie.id, effectiveLanguage);
 					}
 				}
 			} else {
@@ -194,10 +194,10 @@ export const GET: RequestHandler = async ({ url }) => {
 					columns: { id: true }
 				});
 				if (show) {
-					searchTitles = await getSeriesSearchTitles(show.id);
+					searchTitles = await getSeriesSearchTitles(show.id, effectiveLanguage);
 					if (searchTitles.length <= 1) {
 						fetchAndStoreSeriesAlternateTitles(show.id, tmdbId).catch(() => {});
-						searchTitles = await getSeriesSearchTitles(show.id);
+						searchTitles = await getSeriesSearchTitles(show.id, effectiveLanguage);
 					}
 				}
 			}

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -11,7 +11,8 @@
 		SlidersHorizontal,
 		LayoutGrid,
 		List,
-		Plus
+		Plus,
+		Info
 	} from 'lucide-svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { getLocale } from '$lib/paraglide/runtime.js';
@@ -528,6 +529,16 @@
 				</div>
 			</div>
 		{/if}
+
+		<div
+			class="flex items-start gap-2 rounded-lg bg-base-200 px-3 py-2 text-sm text-base-content/50"
+		>
+			<Info class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+			<p>
+				TV series must be in your library and monitored for upcoming episodes to appear here. Movies
+				can optionally include upcoming releases outside your library.
+			</p>
+		</div>
 
 		{#if loading}
 			<div class="flex items-center justify-center py-12">

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -30,7 +30,7 @@
 	import { apiPostStream } from '$lib/api';
 	import type { SeriesEditData } from '$lib/components/library/SeriesEditModal.svelte';
 	import type { SearchMode } from '$lib/components/search/InteractiveSearchModal.svelte';
-	import { CheckSquare, FileEdit, Wifi, WifiOff, Loader2, RefreshCw } from 'lucide-svelte';
+	import { CheckSquare, FileEdit, Wifi, WifiOff, Loader2, RefreshCw, X } from 'lucide-svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -285,6 +285,7 @@
 	let isSearchModalOpen = $state(false);
 	let isRenameModalOpen = $state(false);
 	let isDeleteModalOpen = $state(false);
+	let cascadeMonitorOpen = $state(false);
 	let isSaving = $state(false);
 	let isRefreshing = $state(false);
 	let refreshProgress = $state<{ current: number; total: number; message: string } | null>(null);
@@ -453,10 +454,53 @@
 
 	// Handlers
 	async function handleMonitorToggle(newValue: boolean) {
+		if (newValue && !series.monitored) {
+			cascadeMonitorOpen = true;
+			return;
+		}
 		isSaving = true;
 		try {
 			await updateSeries(series.id, { monitored: newValue });
 			series.monitored = newValue;
+		} catch (error) {
+			showActionError(m.toast_library_tvDetail_failedToUpdateMonitor(), error);
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	async function enableMonitorSeriesOnly() {
+		cascadeMonitorOpen = false;
+		isSaving = true;
+		try {
+			await updateSeries(series.id, { monitored: true });
+			series.monitored = true;
+		} catch (error) {
+			showActionError(m.toast_library_tvDetail_failedToUpdateMonitor(), error);
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	async function enableMonitorCascade() {
+		cascadeMonitorOpen = false;
+		isSaving = true;
+		try {
+			await updateSeries(series.id, { monitored: true });
+			series.monitored = true;
+			await Promise.all(
+				seasons
+					.filter((s) => s.seasonNumber > 0)
+					.map((s) => updateSeason(s.id, { monitored: true, updateEpisodes: true }))
+			);
+			if (seasonsState) {
+				seasonsState = seasonsState.map((s) => ({
+					...s,
+					monitored: s.seasonNumber > 0 ? true : s.monitored,
+					episodes:
+						s.seasonNumber > 0 ? s.episodes.map((ep) => ({ ...ep, monitored: true })) : s.episodes
+				}));
+			}
 		} catch (error) {
 			showActionError(m.toast_library_tvDetail_failedToUpdateMonitor(), error);
 		} finally {
@@ -1950,6 +1994,36 @@
 		void refreshSeriesFromApi();
 	}}
 />
+
+<!-- Cascade Monitor Prompt -->
+{#if cascadeMonitorOpen}
+	<ModalWrapper
+		open={cascadeMonitorOpen}
+		onClose={() => (cascadeMonitorOpen = false)}
+		maxWidth="sm"
+	>
+		<div class="mb-4 flex items-center justify-between">
+			<h3 class="text-lg font-bold">Enable monitoring</h3>
+			<button
+				type="button"
+				class="btn btn-circle btn-ghost btn-sm"
+				onclick={() => (cascadeMonitorOpen = false)}
+				aria-label="Close"
+			>
+				<X class="h-4 w-4" />
+			</button>
+		</div>
+		<p class="py-2 text-base-content/80">Also enable monitoring for all seasons and episodes?</p>
+		<div class="modal-action">
+			<button type="button" class="btn btn-ghost" onclick={enableMonitorSeriesOnly}>
+				Series only
+			</button>
+			<button type="button" class="btn btn-primary" onclick={enableMonitorCascade}>
+				Yes, enable all
+			</button>
+		</div>
+	</ModalWrapper>
+{/if}
 
 <!-- Delete Confirmation Modal -->
 <DeleteConfirmationModal

--- a/src/routes/settings/general/status/+page.svelte
+++ b/src/routes/settings/general/status/+page.svelte
@@ -308,7 +308,7 @@
 		<div class="flex gap-2">
 			<button
 				type="button"
-				class="btn ml-auto w-full gap-2 btn-sm btn-primary sm:w-auto"
+				class="btn ml-auto gap-2 btn-sm btn-primary"
 				onclick={() => void triggerLibraryScan()}
 				disabled={scanning || data.rootFolders.length === 0}
 			>
@@ -323,7 +323,7 @@
 			{#if data.servers.length > 0}
 				<button
 					type="button"
-					class="btn ml-auto w-full gap-2 btn-outline btn-sm sm:w-auto"
+					class="btn ml-auto gap-2 btn-outline btn-sm"
 					onclick={() => void triggerServerSync()}
 					disabled={syncing}
 				>

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -8,6 +8,8 @@ import {
 	redactIndexerSettingsForForm
 } from '$lib/server/indexers/settingsSecrets';
 import type { IndexerDefinition, IndexerWithStatus } from '$lib/types/indexer';
+import { getProwlarrConnection } from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
+import { getJackettConnection } from '$lib/server/indexers/jackett/JackettConnectionService.js';
 
 export const load: PageServerLoad = async () => {
 	const manager = await getIndexerManager();
@@ -90,9 +92,36 @@ export const load: PageServerLoad = async () => {
 		.map(toUIDefinition)
 		.sort((a, b) => a.name.localeCompare(b.name));
 
+	const [prowlarrConn, jackettConn] = await Promise.all([
+		getProwlarrConnection(),
+		getJackettConnection()
+	]);
+
 	return {
 		indexers,
 		definitions,
-		definitionErrors: manager.getDefinitionErrors()
+		definitionErrors: manager.getDefinitionErrors(),
+		prowlarrConnection: prowlarrConn
+			? {
+					url: prowlarrConn.url,
+					autoSync: prowlarrConn.autoSync,
+					syncIntervalHours: prowlarrConn.syncIntervalHours,
+					syncAddNew: prowlarrConn.syncAddNew,
+					lastSyncAt: prowlarrConn.lastSyncAt,
+					lastSyncResult: prowlarrConn.lastSyncResult,
+					lastSyncError: prowlarrConn.lastSyncError
+				}
+			: null,
+		jackettConnection: jackettConn
+			? {
+					url: jackettConn.url,
+					autoSync: jackettConn.autoSync,
+					syncIntervalHours: jackettConn.syncIntervalHours,
+					syncAddNew: jackettConn.syncAddNew,
+					lastSyncAt: jackettConn.lastSyncAt,
+					lastSyncResult: jackettConn.lastSyncResult,
+					lastSyncError: jackettConn.lastSyncError
+				}
+			: null
 	};
 };

--- a/src/routes/settings/integrations/indexers/+page.svelte
+++ b/src/routes/settings/integrations/indexers/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
-	import { Plus } from 'lucide-svelte';
+	import { Plus, Download } from 'lucide-svelte';
 	import type { PageData } from './$types';
 	import type {
 		Indexer,
@@ -14,6 +14,8 @@
 	import IndexerFilters from '$lib/components/indexers/IndexerFilters.svelte';
 	import IndexerBulkActions from '$lib/components/indexers/IndexerBulkActions.svelte';
 	import IndexerModal from '$lib/components/indexers/IndexerModal.svelte';
+	import ProwlarrImportModal from '$lib/components/indexers/ProwlarrImportModal.svelte';
+	import JackettImportModal from '$lib/components/indexers/JackettImportModal.svelte';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { getResponseErrorMessage } from '$lib/utils/http';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -49,10 +51,33 @@
 		direction: 'asc'
 	});
 
+	// Prowlarr import modal state
+	let prowlarrImportOpen = $state(false);
+
+	// Jackett import modal state
+	let jackettImportOpen = $state(false);
+
 	// Confirmation dialog state
 	let confirmDeleteOpen = $state(false);
 	let deleteTarget = $state<Indexer | null>(null);
 	let confirmBulkDeleteOpen = $state(false);
+
+	const isDeleteTargetProwlarr = $derived.by(() => {
+		const prowlarrBase = data.prowlarrConnection?.url?.replace(/\/+$/, '');
+		if (!prowlarrBase || !deleteTarget) return false;
+		if (!deleteTarget.baseUrl.startsWith(prowlarrBase + '/')) return false;
+		const suffix = deleteTarget.baseUrl.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
+		return /^\d+$/.test(suffix);
+	});
+
+	const isDeleteTargetJackett = $derived.by(() => {
+		const jackettBase = data.jackettConnection?.url?.replace(/\/+$/, '');
+		if (!jackettBase || !deleteTarget) return false;
+		const prefix = `${jackettBase}/api/v2.0/indexers/`;
+		return (
+			deleteTarget.baseUrl.startsWith(prefix) && deleteTarget.baseUrl.includes('/results/torznab')
+		);
+	});
 
 	// Derived: filtered and sorted indexers
 	const filteredIndexers = $derived(() => {
@@ -464,7 +489,15 @@
 
 <SettingsPage title={m.nav_indexers()} subtitle={m.settings_integrations_indexers_subtitle()}>
 	{#snippet actions()}
-		<button class="btn w-full gap-2 btn-sm btn-primary sm:w-auto" onclick={openAddModal}>
+		<button class="btn gap-2 btn-outline btn-sm" onclick={() => (jackettImportOpen = true)}>
+			<Download class="h-4 w-4" />
+			{data.jackettConnection ? 'Jackett' : 'Connect Jackett'}
+		</button>
+		<button class="btn gap-2 btn-outline btn-sm" onclick={() => (prowlarrImportOpen = true)}>
+			<Download class="h-4 w-4" />
+			{data.prowlarrConnection ? 'Prowlarr' : 'Connect Prowlarr'}
+		</button>
+		<button class="btn gap-2 btn-sm btn-primary" onclick={openAddModal}>
 			<Plus class="h-4 w-4" />
 			{m.settings_integrations_indexers_addButton()}
 		</button>
@@ -512,6 +545,8 @@
 				{canReorder}
 				{testingIds}
 				{togglingIds}
+				prowlarrBaseUrl={data.prowlarrConnection?.url ?? null}
+				jackettBaseUrl={data.jackettConnection?.url ?? null}
 				onSelect={handleSelect}
 				onSelectAll={handleSelectAll}
 				onSort={handleSort}
@@ -533,6 +568,8 @@
 	indexer={editingIndexer}
 	definitions={data.definitions}
 	{saving}
+	prowlarrBaseUrl={data.prowlarrConnection?.url ?? null}
+	jackettBaseUrl={data.jackettConnection?.url ?? null}
 	onClose={closeModal}
 	onSave={handleSave}
 	onDelete={handleDelete}
@@ -542,11 +579,19 @@
 <!-- Delete Confirmation Modal -->
 <ConfirmationModal
 	open={confirmDeleteOpen}
-	title={m.ui_modal_deleteTitle()}
-	messagePrefix={m.settings_integrations_deleteConfirmPrefix()}
+	title={isDeleteTargetProwlarr || isDeleteTargetJackett
+		? 'Remove from Cinephage'
+		: m.ui_modal_deleteTitle()}
+	messagePrefix={isDeleteTargetProwlarr || isDeleteTargetJackett
+		? 'Remove '
+		: m.settings_integrations_deleteConfirmPrefix()}
 	messageEmphasis={deleteTarget?.name ?? ''}
-	messageSuffix={m.settings_integrations_deleteConfirmSuffix()}
-	confirmLabel={m.action_delete()}
+	messageSuffix={isDeleteTargetProwlarr
+		? ' from Cinephage? It will still exist in Prowlarr and can be re-imported.'
+		: isDeleteTargetJackett
+			? ' from Cinephage? It will still exist in Jackett and can be re-imported.'
+			: m.settings_integrations_deleteConfirmSuffix()}
+	confirmLabel={isDeleteTargetProwlarr || isDeleteTargetJackett ? 'Remove' : m.action_delete()}
 	confirmVariant="error"
 	onConfirm={handleConfirmDelete}
 	onCancel={() => (confirmDeleteOpen = false)}
@@ -562,4 +607,18 @@
 	confirmVariant="error"
 	onConfirm={handleConfirmBulkDelete}
 	onCancel={() => (confirmBulkDeleteOpen = false)}
+/>
+
+<!-- Prowlarr Import Modal -->
+<ProwlarrImportModal
+	open={prowlarrImportOpen}
+	storedConnection={data.prowlarrConnection}
+	onClose={() => (prowlarrImportOpen = false)}
+/>
+
+<!-- Jackett Import Modal -->
+<JackettImportModal
+	open={jackettImportOpen}
+	storedConnection={data.jackettConnection}
+	onClose={() => (jackettImportOpen = false)}
 />

--- a/src/routes/settings/logs/+page.svelte
+++ b/src/routes/settings/logs/+page.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
 	import { SvelteMap, SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
-	import { Download, Loader2, Wifi, WifiOff } from 'lucide-svelte';
+	import {
+		Download,
+		Loader2,
+		Search,
+		CalendarSync,
+		CalendarClock,
+		Wifi,
+		WifiOff,
+		X
+	} from 'lucide-svelte';
 
 	import * as m from '$lib/paraglide/messages.js';
-	import { SettingsPage, SettingsSection } from '$lib/components/ui/settings';
+	import { SettingsPage } from '$lib/components/ui/settings';
 	import { layoutState, deriveMobileSseStatus } from '$lib/layout.svelte';
 	import type {
 		CapturedLogDomain,
@@ -64,9 +73,6 @@
 	let initialized = false;
 
 	let search = $state('');
-	let supportId = $state('');
-	let requestId = $state('');
-	let correlationId = $state('');
 	let selectedDomain = $state<CapturedLogDomain | 'all'>('all');
 	let levels = new SvelteSet<CapturedLogLevel>(DEFAULT_LEVELS);
 	let from = $state('');
@@ -82,6 +88,10 @@
 	let pendingLiveEntries = $state<CapturedLogEntry[]>([]);
 
 	let selectedEntryId = $state<string | null>(null);
+	let activeQuickRange = $state<number | null>(null);
+	let mobileInspectorOpen = $state(false);
+	let mobileDateOpen = $state(false);
+	let mobileDateManual = $state(false);
 
 	$effect(() => {
 		if (initialized) return;
@@ -96,7 +106,7 @@
 			historyPagesLoaded.add(data.initialPage);
 		}
 		retentionDays = data.retentionDays;
-		selectedEntryId = data.initialEntries[0]?.id ?? null;
+		selectedEntryId = null;
 		lastLoadedFilterKey = buildFilterKey();
 	});
 
@@ -107,7 +117,7 @@
 	});
 
 	const selectedEntry = $derived.by(
-		() => entries.find((entry) => entry.id === selectedEntryId) ?? entries[0] ?? null
+		() => entries.find((entry) => entry.id === selectedEntryId) ?? null
 	);
 
 	const pendingLiveCount = $derived(pendingLiveEntries.length);
@@ -124,9 +134,6 @@
 	const hasActiveFilters = $derived.by(
 		() =>
 			search.trim().length > 0 ||
-			supportId.trim().length > 0 ||
-			requestId.trim().length > 0 ||
-			correlationId.trim().length > 0 ||
 			selectedDomain !== 'all' ||
 			levels.size !== availableLevels.length ||
 			from.length > 0 ||
@@ -145,37 +152,11 @@
 		params.set('pageSize', String(historyPageSize));
 		params.set('levels', [...levels].join(','));
 
-		if (page) {
-			params.set('page', String(page));
-		}
-
-		if (selectedDomain !== 'all') {
-			params.set('logDomain', selectedDomain);
-		}
-
-		if (search.trim()) {
-			params.set('search', search.trim());
-		}
-
-		if (supportId.trim()) {
-			params.set('supportId', supportId.trim());
-		}
-
-		if (requestId.trim()) {
-			params.set('requestId', requestId.trim());
-		}
-
-		if (correlationId.trim()) {
-			params.set('correlationId', correlationId.trim());
-		}
-
-		if (from) {
-			params.set('from', new Date(from).toISOString());
-		}
-
-		if (to) {
-			params.set('to', new Date(to).toISOString());
-		}
+		if (page) params.set('page', String(page));
+		if (selectedDomain !== 'all') params.set('logDomain', selectedDomain);
+		if (search.trim()) params.set('search', search.trim());
+		if (from) params.set('from', new Date(from).toISOString());
+		if (to) params.set('to', new Date(to).toISOString());
 
 		return params;
 	}
@@ -185,9 +166,6 @@
 			[...levels].sort().join(','),
 			selectedDomain,
 			search.trim(),
-			supportId.trim(),
-			requestId.trim(),
-			correlationId.trim(),
 			from || 'none',
 			to || 'none'
 		].join('||');
@@ -201,24 +179,36 @@
 
 	function dedupeAndSort(items: CapturedLogEntry[], limit?: number): CapturedLogEntry[] {
 		const byId = new SvelteMap<string, CapturedLogEntry>();
-
 		for (const item of items) {
-			if (!byId.has(item.id)) {
-				byId.set(item.id, item);
-			}
+			if (!byId.has(item.id)) byId.set(item.id, item);
 		}
-
 		const sorted = [...byId.values()].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 		return typeof limit === 'number' ? sorted.slice(0, limit) : sorted;
 	}
 
-	function selectEntry(entry: CapturedLogEntry): void {
-		selectedEntryId = entry.id;
+	function handleRowClick(entry: CapturedLogEntry): void {
+		if (selectedEntryId === entry.id) {
+			selectedEntryId = null;
+			mobileInspectorOpen = false;
+		} else {
+			selectedEntryId = entry.id;
+			mobileInspectorOpen = true;
+		}
+	}
+
+	function closeInspector(): void {
+		selectedEntryId = null;
+		mobileInspectorOpen = false;
 	}
 
 	function handleListScroll(): void {
 		if (!listViewport) return;
 		isNearTop = listViewport.scrollTop < 24;
+		const nearBottom =
+			listViewport.scrollHeight - listViewport.scrollTop - listViewport.clientHeight < 120;
+		if (nearBottom && historyHasMore && !historyLoading) {
+			loadOlderHistory();
+		}
 	}
 
 	async function scrollToLatest(): Promise<void> {
@@ -233,35 +223,31 @@
 			levels.delete(level);
 			return;
 		}
-
 		levels.add(level);
 	}
 
 	function resetFilters(): void {
 		search = '';
-		supportId = '';
-		requestId = '';
-		correlationId = '';
 		selectedDomain = 'all';
 		levels.clear();
-		for (const level of DEFAULT_LEVELS) {
-			levels.add(level);
-		}
+		for (const level of DEFAULT_LEVELS) levels.add(level);
 		from = '';
 		to = '';
+		activeQuickRange = null;
+		if (!mobileDateManual) mobileDateOpen = false;
 	}
 
 	function setQuickRange(hours: number): void {
 		const nextTo = new Date();
 		to = toDateTimeLocalValue(nextTo);
 		from = toDateTimeLocalValue(new Date(nextTo.getTime() - hours * 60 * 60 * 1000));
+		activeQuickRange = hours;
+		mobileDateOpen = true;
+		mobileDateManual = false;
 	}
 
 	function replaceEntries(nextEntries: CapturedLogEntry[]): void {
 		entries = dedupeAndSort(nextEntries);
-		if (!selectedEntryId && entries[0]) {
-			selectedEntryId = entries[0].id;
-		}
 	}
 
 	function queueLiveEntry(entry: CapturedLogEntry): void {
@@ -270,18 +256,12 @@
 
 	function flushPendingLiveEntries(options: { scroll?: boolean } = {}): void {
 		if (pendingLiveEntries.length === 0) {
-			if (options.scroll) {
-				void scrollToLatest();
-			}
+			if (options.scroll) void scrollToLatest();
 			return;
 		}
-
 		replaceEntries([...pendingLiveEntries, ...entries]);
 		pendingLiveEntries = [];
-
-		if (options.scroll) {
-			void scrollToLatest();
-		}
+		if (options.scroll) void scrollToLatest();
 	}
 
 	function mergeLiveSeed(seedEntries: CapturedLogEntry[]): void {
@@ -293,7 +273,6 @@
 			queueLiveEntry(entry);
 			return;
 		}
-
 		replaceEntries([entry, ...entries]);
 		void scrollToLatest();
 	}
@@ -304,31 +283,19 @@
 	}>(
 		() => buildLiveUrl(),
 		{
-			'logs:seed': ({ entries: seedEntries }) => {
-				mergeLiveSeed(seedEntries);
-			},
-			'log:entry': (entry) => {
-				mergeLiveEntry(entry);
-			}
+			'logs:seed': ({ entries: seedEntries }) => mergeLiveSeed(seedEntries),
+			'log:entry': (entry) => mergeLiveEntry(entry)
 		},
-		{
-			heartbeatInterval: 30000
-		}
+		{ heartbeatInterval: 30000 }
 	);
 
 	$effect(() => {
 		layoutState.setMobileSseStatus(deriveMobileSseStatus(sse));
-		return () => {
-			layoutState.clearMobileSseStatus();
-		};
+		return () => layoutState.clearMobileSseStatus();
 	});
 
 	$effect(() => {
-		if (livePaused) return;
-		if (!autoFollowEnabled) return;
-		if (!isNearTop) return;
-		if (pendingLiveEntries.length === 0) return;
-
+		if (livePaused || !autoFollowEnabled || !isNearTop || pendingLiveEntries.length === 0) return;
 		flushPendingLiveEntries({ scroll: true });
 	});
 
@@ -342,14 +309,10 @@
 		try {
 			const sp = buildQueryParams(page);
 			const queryParams: Record<string, string> = {};
-			for (const [key, value] of sp) {
-				queryParams[key] = value;
-			}
+			for (const [key, value] of sp) queryParams[key] = value;
 
 			const payload = (await getLogHistory(queryParams)) as LogHistoryResponse;
-			if (!payload.success) {
-				throw new Error(payload.error ?? 'Failed to load log history');
-			}
+			if (!payload.success) throw new Error(payload.error ?? 'Failed to load log history');
 
 			const nextEntries = payload.entries ?? [];
 			entries =
@@ -369,11 +332,7 @@
 			lastLoadedFilterKey = buildFilterKey();
 			pendingLiveEntries = [];
 
-			if (entries[0]) {
-				selectedEntryId = entries.some((entry) => entry.id === selectedEntryId)
-					? selectedEntryId
-					: entries[0].id;
-			} else {
+			if (!entries.some((e) => e.id === selectedEntryId)) {
 				selectedEntryId = null;
 			}
 		} catch (error) {
@@ -401,13 +360,9 @@
 	$effect(() => {
 		if (!initialized) return;
 		const filterKey = buildFilterKey();
-		if (filterKey === lastLoadedFilterKey) {
-			return;
-		}
+		if (filterKey === lastLoadedFilterKey) return;
 
-		if (historyDebounceTimer) {
-			clearTimeout(historyDebounceTimer);
-		}
+		if (historyDebounceTimer) clearTimeout(historyDebounceTimer);
 
 		historyDebounceTimer = setTimeout(() => {
 			void loadHistoryPage(1, 'replace');
@@ -427,9 +382,7 @@
 			const queryParams = buildQueryParams();
 			queryParams.set('limit', '5000');
 			queryParams.set('format', 'jsonl');
-			queryParams.forEach((value, key) => {
-				params[key] = value;
-			});
+			queryParams.forEach((value, key) => (params[key] = value));
 			const response = await apiGetStream('/api/settings/logs/download', params);
 
 			const blob = await response.blob();
@@ -450,7 +403,6 @@
 		retentionSaving = true;
 		try {
 			const payload = await updateLogSettings(retentionDays);
-
 			retentionDays = payload.retentionDays ?? retentionDays;
 			toasts.success(`Log retention updated to ${retentionDays} days`);
 		} catch (error) {
@@ -483,22 +435,8 @@
 		}).format(new Date(value));
 	}
 
-	function levelColor(level: CapturedLogLevel): string {
-		switch (level) {
-			case 'debug':
-				return 'text-base-content/50';
-			case 'info':
-				return 'text-info';
-			case 'warn':
-				return 'text-warning';
-			case 'error':
-				return 'text-error';
-		}
-	}
-
 	function levelBadgeClass(level: CapturedLogLevel, active: boolean): string {
 		if (!active) return 'border-base-300 bg-base-200 text-base-content/45';
-
 		switch (level) {
 			case 'debug':
 				return 'border-base-content/20 bg-base-content/10 text-base-content/70';
@@ -511,17 +449,27 @@
 		}
 	}
 
+	function rowAccentClass(level: CapturedLogLevel): string {
+		switch (level) {
+			case 'error':
+				return 'border-l-[3px] border-l-error';
+			case 'warn':
+				return 'border-l-[3px] border-l-warning';
+			default:
+				return 'border-l-[3px] border-l-transparent';
+		}
+	}
+
 	function getSource(entry: CapturedLogEntry): string {
 		const parts = [entry.logDomain, entry.component, entry.service, entry.module].filter(
-			(value): value is string => typeof value === 'string' && value.length > 0
+			(v): v is string => typeof v === 'string' && v.length > 0
 		);
-		const deduped = parts.filter((value, index) => index === 0 || value !== parts[index - 1]);
+		const deduped = parts.filter((v, i) => i === 0 || v !== parts[i - 1]);
 		return deduped.length > 0 ? deduped.join('/') : 'unscoped';
 	}
 
 	function formatDetails(entry: CapturedLogEntry): string {
 		const obj: Record<string, unknown> = {};
-
 		if (entry.method || entry.path || entry.requestId || entry.supportId || entry.correlationId) {
 			const req: Record<string, unknown> = {};
 			if (entry.method) req.method = entry.method;
@@ -531,16 +479,13 @@
 			if (entry.correlationId) req.correlationId = entry.correlationId;
 			obj.request = req;
 		}
-
 		if (entry.data) obj.data = entry.data;
 		if (entry.err) obj.err = entry.err;
-
 		return JSON.stringify(obj, null, 2);
 	}
 
 	async function copyText(value: string, label: string): Promise<void> {
 		if (!value || !navigator.clipboard) return;
-
 		try {
 			await navigator.clipboard.writeText(value);
 			toasts.success(`${label} copied`);
@@ -554,190 +499,354 @@
 	<title>{m.settings_logs_pageTitle()}</title>
 </svelte:head>
 
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape' && selectedEntryId) closeInspector();
+	}}
+/>
+
+{#snippet inspectorBody(entry: CapturedLogEntry)}
+	<div class="space-y-4 p-4">
+		<div class="space-y-2">
+			<div class="flex flex-wrap items-center gap-2">
+				<span
+					class={`rounded border px-2 py-0.5 font-mono text-[10px] font-semibold tracking-widest uppercase ${levelBadgeClass(entry.level, true)}`}
+				>
+					{entry.level}
+				</span>
+				<span class="font-mono text-xs text-base-content/55">
+					{formatFullTimestamp(entry.timestamp)}
+				</span>
+			</div>
+			<p class="text-sm leading-6 wrap-break-word">{entry.msg}</p>
+			<p class="font-mono text-xs text-base-content/60">{getSource(entry)}</p>
+		</div>
+
+		{#if entry.method || entry.path || entry.requestId || entry.correlationId || entry.supportId}
+			<div>
+				<p class="mb-2 text-[10px] font-medium tracking-widest text-base-content/50 uppercase">
+					Identifiers
+				</p>
+				<div class="flex flex-wrap gap-2">
+					{#if entry.method && entry.path}
+						<button
+							class="rounded bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70 transition hover:bg-base-300/80"
+							onclick={() => copyText(`${entry.method} ${entry.path}`, 'Request path')}
+						>
+							{entry.method}
+							{entry.path}
+						</button>
+					{/if}
+					{#if entry.requestId}
+						<button
+							class="rounded bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70 transition hover:bg-base-300/80"
+							onclick={() => copyText(entry.requestId ?? '', 'Request ID')}
+						>
+							req:{entry.requestId}
+						</button>
+					{/if}
+					{#if entry.correlationId}
+						<button
+							class="rounded bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70 transition hover:bg-base-300/80"
+							onclick={() => copyText(entry.correlationId ?? '', 'Correlation ID')}
+						>
+							corr:{entry.correlationId}
+						</button>
+					{/if}
+					{#if entry.supportId}
+						<button
+							class="rounded bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70 transition hover:bg-base-300/80"
+							onclick={() => copyText(entry.supportId ?? '', 'Issue ID')}
+						>
+							issue:{entry.supportId}
+						</button>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		<div>
+			<div class="mb-2 flex items-center justify-between">
+				<p class="text-[10px] font-medium tracking-widest text-base-content/50 uppercase">
+					Payload
+				</p>
+				<button
+					class="btn btn-ghost btn-xs"
+					onclick={() => copyText(formatDetails(entry), 'Payload')}
+				>
+					Copy
+				</button>
+			</div>
+			<pre
+				class="max-h-88 overflow-auto bg-base-300/50 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap text-base-content/80">{formatDetails(
+					entry
+				)}</pre>
+		</div>
+	</div>
+{/snippet}
+
 <SettingsPage title={m.settings_logs_heading()} subtitle={m.settings_logs_subtitle()}>
 	{#snippet actions()}
-		<span
-			class:badge-success={sse.isConnected}
-			class:badge-warning={!sse.isConnected}
-			class="badge gap-1.5 text-xs"
-		>
+		<div class="hidden items-center gap-2 sm:flex">
 			{#if sse.isConnected}
-				<Wifi class="h-3 w-3" />
-				Live connected
+				<span class="badge gap-1 badge-success">
+					<Wifi class="h-3 w-3" />
+					{m.common_live()}
+				</span>
+			{:else if sse.status === 'connecting' || sse.status === 'error'}
+				<span class="badge gap-1 {sse.status === 'error' ? 'badge-error' : 'badge-warning'}">
+					<Loader2 class="h-3 w-3 animate-spin" />
+					{sse.status === 'error' ? m.common_reconnecting() : m.common_connecting()}
+				</span>
 			{:else}
-				<WifiOff class="h-3 w-3" />
-				Live reconnecting
+				<span class="badge gap-1 badge-ghost">
+					<WifiOff class="h-3 w-3" />
+					{m.common_disconnected()}
+				</span>
 			{/if}
-		</span>
-		<span class="badge badge-ghost text-xs">{historyTotal} matches</span>
-		{#if pendingLiveCount > 0}
-			<button
-				class="badge cursor-pointer badge-outline text-xs badge-warning"
-				onclick={() => flushPendingLiveEntries({ scroll: true })}
-			>
-				{pendingLiveCount} new entries
-			</button>
-		{/if}
+		</div>
 	{/snippet}
 
-	<SettingsSection
-		title="Unified Live Logs"
-		description="One live log surface that stays current while still letting you search and load older persisted history into the same stream."
-	>
-		<div class="border border-base-300 bg-base-100">
-			<div
-				class="sticky top-0 z-10 border-b border-base-300 bg-base-100/95 px-4 py-4 backdrop-blur"
-			>
-				<div class="grid gap-3 xl:grid-cols-[minmax(0,2.4fr)_repeat(4,minmax(0,1fr))]">
+	<!-- Log viewer card -->
+	<div class="flex flex-col rounded-xl border border-base-300 bg-base-200">
+		<!-- Toolbar (sticky) -->
+		<div class="sticky top-0 z-10 border-b border-base-300 bg-base-200/95 backdrop-blur">
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-2 px-3 py-3">
+				<!-- Search -->
+				<div class="relative min-w-0 flex-1" style="min-width: 180px;">
+					<Search
+						class="pointer-events-none absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2 text-base-content/40"
+					/>
 					<input
 						type="text"
-						class="input-bordered input input-sm w-full"
+						class="input input-sm w-full rounded-full border-base-content/20 bg-base-200/60 pr-4 pl-9 transition-all duration-200 placeholder:text-base-content/40 hover:bg-base-200 focus:border-primary/50 focus:bg-base-200 focus:ring-1 focus:ring-primary/20 focus:outline-none"
 						bind:value={search}
-						placeholder="Search message, source, path, payload, or error text"
+						placeholder="Search message, source, path, payload…"
 					/>
-					<select class="select-bordered select w-full select-sm" bind:value={selectedDomain}>
+				</div>
+
+				<!-- Domain -->
+				<div class="w-full sm:w-48">
+					<select
+						class="select select-sm border-base-content/20 transition-all duration-200 hover:bg-base-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none w-full"
+						bind:value={selectedDomain}
+					>
 						<option value="all">All domains</option>
 						{#each availableDomains as domain (domain)}
 							<option value={domain}>{domain}</option>
 						{/each}
 					</select>
+				</div>
+
+				<span class="h-5 w-px shrink-0 bg-base-300"></span>
+
+				<!-- Level pills -->
+				<div class="flex items-center gap-1">
+					{#each availableLevels as level (level)}
+						<button
+							class={`rounded border px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.15em] uppercase transition ${levelBadgeClass(level, levels.has(level))}`}
+							onclick={() => toggleLevel(level)}
+						>
+							{level}
+						</button>
+					{/each}
+				</div>
+
+				<span class="h-5 w-px shrink-0 bg-base-300"></span>
+
+				<!-- Quick date range + mobile custom toggle -->
+				<div class="flex items-center gap-1">
+					{#each [{ label: '1h', hours: 1 }, { label: '6h', hours: 6 }, { label: '24h', hours: 24 }, { label: '7d', hours: 168 }] as range (range.label)}
+						<button
+							class="btn btn-xs font-mono {activeQuickRange === range.hours
+								? 'btn-primary'
+								: 'btn-ghost'}"
+							onclick={() => setQuickRange(range.hours)}
+						>
+							{range.label}
+						</button>
+					{/each}
+					<!-- Mobile: toggle custom date inputs -->
+					<button
+						class="btn btn-xs sm:hidden {mobileDateOpen || from || to
+							? 'btn-primary'
+							: 'btn-ghost'}"
+						onclick={() => {
+							mobileDateOpen = !mobileDateOpen;
+							mobileDateManual = mobileDateOpen;
+						}}
+						aria-label="Custom date range"
+					>
+						<CalendarClock class="h-3 w-3" />
+					</button>
+				</div>
+
+				<!-- Custom from/to inputs: desktop only (inline) -->
+				<div class="hidden items-center gap-2 sm:flex">
+					<span class="h-5 w-px shrink-0 bg-base-300"></span>
 					<input
-						type="text"
-						class="input-bordered input input-sm w-full font-mono"
-						bind:value={supportId}
-						placeholder="Issue ID"
+						type="datetime-local"
+						class="input input-sm w-44 rounded-full border-base-content/20 bg-base-200/60 px-3 text-xs transition-all hover:bg-base-200 focus:border-primary/50 focus:outline-none"
+						bind:value={from}
+						title="From"
+						oninput={() => (activeQuickRange = null)}
 					/>
 					<input
-						type="text"
-						class="input-bordered input input-sm w-full font-mono"
-						bind:value={requestId}
-						placeholder="Request ID"
-					/>
-					<input
-						type="text"
-						class="input-bordered input input-sm w-full font-mono"
-						bind:value={correlationId}
-						placeholder="Correlation ID"
+						type="datetime-local"
+						class="input input-sm w-44 rounded-full border-base-content/20 bg-base-200/60 px-3 text-xs transition-all hover:bg-base-200 focus:border-primary/50 focus:outline-none"
+						bind:value={to}
+						title="To"
+						oninput={() => (activeQuickRange = null)}
 					/>
 				</div>
 
-				<div class="mt-3 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-					<div class="flex flex-wrap items-center gap-2">
-						{#each availableLevels as level (level)}
-							<button
-								class={`rounded-md border px-2.5 py-1 font-mono text-[11px] font-semibold tracking-[0.18em] uppercase transition ${levelBadgeClass(level, levels.has(level))}`}
-								onclick={() => toggleLevel(level)}
+				<span class="hidden flex-1 xl:block"></span>
+
+				<!-- Auto-follow + Pause (right side with actions) -->
+				<label class="label cursor-pointer gap-2 px-1 py-0">
+					<input type="checkbox" class="toggle toggle-xs" bind:checked={autoFollowEnabled} />
+					<span class="label-text text-xs">Auto-follow</span>
+				</label>
+				<label class="label cursor-pointer gap-2 px-1 py-0">
+					<input type="checkbox" class="toggle toggle-xs" bind:checked={livePaused} />
+					<span class="label-text text-xs">Pause</span>
+				</label>
+
+				<span class="h-5 w-px shrink-0 bg-base-300"></span>
+
+				<!-- Retention dropdown -->
+				<div class="dropdown">
+					<button class="btn btn-ghost btn-sm gap-1.5 text-xs" aria-label="Log retention settings">
+						<CalendarSync class="h-3.5 w-3.5" />
+						<span class="font-mono">{retentionDays}d</span>
+					</button>
+					<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+					<div
+						tabindex="0"
+						class="dropdown-content z-20 mt-1 w-56 rounded-xl border border-base-300 bg-base-200 shadow-lg xl:right-0 xl:left-auto"
+					>
+						<div class="p-3">
+							<p
+								class="mb-3 text-[10px] font-medium tracking-widest text-base-content/50 uppercase"
 							>
-								{level}
+								Log Retention
+							</p>
+							<div class="mb-3 flex items-center gap-2">
+								<input
+									id="retention-days"
+									type="number"
+									min="1"
+									max={maxRetentionDays}
+									class="input input-bordered input-xs w-20"
+									bind:value={retentionDays}
+								/>
+								<span class="text-xs text-base-content/60">days</span>
+								<button
+									class="btn btn-ghost btn-xs ml-auto"
+									onclick={() => (retentionDays = defaultRetentionDays)}
+									disabled={retentionSaving}
+								>
+									Default
+								</button>
+							</div>
+							<button
+								class="btn btn-primary btn-xs w-full"
+								onclick={saveRetentionDays}
+								disabled={retentionSaving}
+							>
+								{#if retentionSaving}
+									<Loader2 class="h-3 w-3 animate-spin" />
+								{/if}
+								Save
 							</button>
-						{/each}
-						<label class="label cursor-pointer gap-2 px-1 py-0">
-							<input type="checkbox" class="toggle toggle-xs" bind:checked={livePaused} />
-							<span class="label-text text-xs">Pause</span>
-						</label>
-						<label class="label cursor-pointer gap-2 px-1 py-0">
-							<input type="checkbox" class="toggle toggle-xs" bind:checked={autoFollowEnabled} />
-							<span class="label-text text-xs">Auto-follow</span>
-						</label>
-					</div>
-
-					<div class="flex flex-wrap items-center gap-2">
-						<button class="btn btn-ghost btn-xs" onclick={() => setQuickRange(1)}>1h</button>
-						<button class="btn btn-ghost btn-xs" onclick={() => setQuickRange(6)}>6h</button>
-						<button class="btn btn-ghost btn-xs" onclick={() => setQuickRange(24)}>24h</button>
-						<button class="btn btn-ghost btn-xs" onclick={() => setQuickRange(168)}>7d</button>
-						<input
-							type="datetime-local"
-							class="input-bordered input input-sm w-full sm:w-44"
-							bind:value={from}
-						/>
-						<input
-							type="datetime-local"
-							class="input-bordered input input-sm w-full sm:w-44"
-							bind:value={to}
-						/>
-						<button class="btn text-xs btn-ghost btn-sm" onclick={refreshCurrentView}>
-							{#if historyLoading}
-								<Loader2 class="h-3.5 w-3.5 animate-spin" />
-							{/if}
-							Refresh
-						</button>
-						<button class="btn text-xs btn-ghost btn-sm" onclick={downloadHistoryLogs}>
-							<Download class="h-3.5 w-3.5" />
-							Export
-						</button>
-						{#if hasActiveFilters}
-							<button class="btn text-xs btn-ghost btn-sm" onclick={resetFilters}>Clear</button>
-						{/if}
+						</div>
 					</div>
 				</div>
 
-				<div
-					class="mt-3 flex flex-col gap-2 border-t border-base-300 pt-3 text-xs text-base-content/60 xl:flex-row xl:items-center xl:justify-between"
-				>
-					<div class="flex flex-wrap items-center gap-3">
-						<span>{entries.length} visible rows</span>
-						<span>{historyTotal} persisted matches</span>
-						<span
-							>{historyPagesLoaded.size} page{historyPagesLoaded.size === 1 ? '' : 's'} loaded</span
-						>
-						<span>{liveStatusLabel}</span>
-					</div>
-					<div class="flex flex-wrap items-center gap-2">
-						<input
-							id="retention-days"
-							type="number"
-							min="1"
-							max={maxRetentionDays}
-							class="input-bordered input input-xs w-24"
-							bind:value={retentionDays}
-						/>
-						<span>Retention days</span>
-						<button
-							class="btn btn-ghost btn-xs"
-							onclick={() => (retentionDays = defaultRetentionDays)}
-							disabled={retentionSaving}
-						>
-							Default
-						</button>
-						<button
-							class="btn btn-xs btn-primary"
-							onclick={saveRetentionDays}
-							disabled={retentionSaving}
-						>
-							{#if retentionSaving}
-								<Loader2 class="h-3 w-3 animate-spin" />
-							{/if}
-							Save
-						</button>
-					</div>
-				</div>
+				<!-- Refresh (shows spinner inline while loading) -->
+				<button class="btn btn-ghost btn-sm text-xs" onclick={refreshCurrentView}>
+					{#if historyLoading}
+						<Loader2 class="h-3.5 w-3.5 animate-spin" />
+					{/if}
+					Refresh
+				</button>
+
+				<button class="btn btn-ghost btn-sm text-xs" onclick={downloadHistoryLogs}>
+					<Download class="h-3.5 w-3.5" />
+					<span class="sm:inline">Export</span>
+				</button>
+
+				{#if hasActiveFilters}
+					<button class="btn btn-ghost btn-xs gap-1 text-error" onclick={resetFilters}>
+						<X class="h-3 w-3" />
+						Clear filters
+					</button>
+				{/if}
 			</div>
 
-			{#if historyError}
-				<div class="border-b border-base-300 px-4 py-4 text-sm text-error">{historyError}</div>
+			<!-- Mobile: expandable custom date range row -->
+			{#if mobileDateOpen}
+				<div class="flex flex-col gap-2 border-t border-base-300 px-3 py-3 sm:hidden">
+					<input
+						type="datetime-local"
+						class="input input-bordered input-sm w-full"
+						bind:value={from}
+						oninput={() => (activeQuickRange = null)}
+					/>
+					<input
+						type="datetime-local"
+						class="input input-bordered input-sm w-full"
+						bind:value={to}
+						oninput={() => (activeQuickRange = null)}
+					/>
+				</div>
 			{/if}
 
-			<div class="max-h-[42rem] overflow-auto" bind:this={listViewport} onscroll={handleListScroll}>
+			<!-- Status bar -->
+			<div
+				class="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-base-300 px-3 py-2 text-xs text-base-content/50"
+			>
+				<span>{entries.length} entries</span>
+				{#if historyTotal > entries.length}
+					<span class="text-base-content/20">·</span>
+					<span>{historyTotal} persisted</span>
+				{/if}
+				<span class="text-base-content/20">·</span>
+				<span>{liveStatusLabel}</span>
+			</div>
+		</div>
+
+		{#if historyError}
+			<div class="border-b border-base-300 px-3 py-3 text-sm text-error">{historyError}</div>
+		{/if}
+
+		<!-- Table + inspector side panel -->
+		<div class="flex overflow-hidden" style="min-height: 20rem; height: calc(100svh - 22rem);">
+			<!-- Log table -->
+			<div
+				class="min-w-0 flex-1 overflow-y-auto"
+				bind:this={listViewport}
+				onscroll={handleListScroll}
+			>
 				{#if historyLoading && entries.length === 0}
-					<div class="flex items-center gap-2 px-4 py-4 text-sm text-base-content/60">
+					<div class="flex items-center gap-2 px-1 py-6 text-sm text-base-content/60">
 						<Loader2 class="h-4 w-4 animate-spin" />
 						Loading logs
 					</div>
 				{:else if entries.length === 0}
-					<div class="px-4 py-4 text-sm text-base-content/60">
+					<div class="px-1 py-6 text-sm text-base-content/60">
 						No logs matched the current filters. Clear filters or wait for new matching entries.
 					</div>
 				{:else}
-					<table class="table-pin-rows table table-sm">
+					<table class="table-pin-rows table table-sm w-full">
 						<thead>
 							<tr
-								class="bg-base-200/90 text-[11px] tracking-[0.18em] text-base-content/55 uppercase"
+								class="bg-base-200/90 text-[10px] tracking-[0.12em] text-base-content/50 uppercase"
 							>
-								<th class="w-28">Time</th>
-								<th class="w-18">Level</th>
-								<th class="w-52">Source</th>
-								<th class="w-32">Issue ID</th>
+								<th class="w-4 pl-0 pr-0"></th>
+								<th class="w-24">Time</th>
+								<th class="w-16">Level</th>
+								<th class="hidden w-32 sm:table-cell">Source</th>
 								<th>Message</th>
 							</tr>
 						</thead>
@@ -746,21 +855,31 @@
 								<tr
 									class={[
 										'cursor-pointer border-b border-base-200/70 align-top transition-colors',
+										rowAccentClass(entry.level),
 										selectedEntry?.id === entry.id ? 'bg-primary/8' : 'hover:bg-base-200/60'
 									]}
-									onclick={() => selectEntry(entry)}
+									onclick={() => handleRowClick(entry)}
 								>
-									<td class="font-mono text-xs text-base-content/70"
-										>{formatTimestamp(entry.timestamp)}</td
+									<td class="px-0 py-2"></td>
+									<td class="py-3 font-mono text-xs text-base-content/60 sm:py-2">
+										{formatTimestamp(entry.timestamp)}
+									</td>
+									<td class="py-3 sm:py-2">
+										<span
+											class={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold tracking-wide uppercase ${levelBadgeClass(entry.level, true)}`}
+										>
+											{entry.level}
+										</span>
+									</td>
+									<td class="hidden py-2 sm:table-cell">
+										<span
+											class="rounded bg-base-300 px-1.5 py-0.5 font-mono text-[10px] text-base-content/65"
+										>
+											{getSource(entry)}
+										</span>
+									</td>
+									<td class="py-3 text-sm wrap-break-word whitespace-normal sm:py-2">{entry.msg}</td
 									>
-									<td class={`font-mono text-xs uppercase ${levelColor(entry.level)}`}
-										>{entry.level}</td
-									>
-									<td class="max-w-52 truncate font-mono text-xs text-base-content/60"
-										>{getSource(entry)}</td
-									>
-									<td class="font-mono text-xs text-base-content/55">{entry.supportId ?? '-'}</td>
-									<td class="max-w-[48rem] text-sm break-words whitespace-normal">{entry.msg}</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -768,120 +887,88 @@
 				{/if}
 			</div>
 
-			<div class="border-t border-base-300 px-4 py-3">
-				<div class="flex flex-wrap items-center justify-between gap-3 text-xs text-base-content/60">
-					<div class="flex flex-wrap items-center gap-3">
-						{#if pendingLiveCount > 0}
-							<span>{pendingLiveCount} live entries queued</span>
-						{/if}
-						{#if historyHasMore}
-							<span>Older persisted results are available</span>
-						{/if}
-					</div>
-					<div class="flex flex-wrap items-center gap-2">
-						{#if showJumpToLatest}
-							<button class="btn btn-xs btn-primary" onclick={jumpToLatest}>
-								Jump to latest
-							</button>
-						{/if}
+			<!-- Desktop inspector side panel -->
+			{#if selectedEntry}
+				<div
+					class="hidden w-104 shrink-0 flex-col overflow-y-auto border-l border-base-300 bg-base-200/30 xl:flex"
+				>
+					<div
+						class="sticky top-0 flex items-center justify-between border-b border-base-300 bg-base-200/80 px-4 py-3 backdrop-blur"
+					>
+						<p class="text-[10px] font-medium tracking-widest text-base-content/50 uppercase">
+							Inspector
+						</p>
 						<button
-							class="btn btn-ghost btn-xs"
-							onclick={loadOlderHistory}
-							disabled={historyLoading || !historyHasMore}
+							type="button"
+							class="btn btn-circle btn-ghost btn-xs"
+							onclick={closeInspector}
+							aria-label="Close inspector"
 						>
-							{#if historyLoading && historyHasMore}
-								<Loader2 class="h-3 w-3 animate-spin" />
-							{/if}
-							Load older
+							<X class="h-3.5 w-3.5" />
 						</button>
 					</div>
+					{@render inspectorBody(selectedEntry)}
 				</div>
-			</div>
+			{/if}
+		</div>
 
-			<div class="border-t border-base-300 bg-base-200/20 px-4 py-4">
-				<div class="mb-3 flex items-center justify-between gap-3">
-					<div>
-						<p class="text-xs tracking-[0.18em] text-base-content/55 uppercase">Inspector</p>
-						<p class="mt-1 text-xs text-base-content/60">
-							Selected row details stay below the unified stream.
-						</p>
-					</div>
+		<!-- Footer bar (sticky bottom so it's always accessible) -->
+		<div
+			class="sticky bottom-0 z-10 border-t border-base-300 bg-base-200/95 px-3 py-3 backdrop-blur"
+		>
+			<div class="flex flex-wrap items-center justify-between gap-3 text-xs text-base-content/55">
+				<div>
+					{#if historyHasMore}
+						<span>Older persisted results are available</span>
+					{/if}
 				</div>
-
-				{#if selectedEntry}
-					<div class="space-y-4">
-						<div class="space-y-2">
-							<div class="flex flex-wrap items-center gap-2">
-								<span class={`font-mono text-xs uppercase ${levelColor(selectedEntry.level)}`}>
-									{selectedEntry.level}
-								</span>
-								<span class="font-mono text-xs text-base-content/55">
-									{formatFullTimestamp(selectedEntry.timestamp)}
-								</span>
-							</div>
-							<p class="text-sm leading-6 break-words">{selectedEntry.msg}</p>
-							<p class="font-mono text-xs text-base-content/60">{getSource(selectedEntry)}</p>
-						</div>
-
-						<div class="flex flex-wrap gap-2">
-							{#if selectedEntry.method && selectedEntry.path}
-								<button
-									class="rounded-md bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70"
-									onclick={() =>
-										copyText(`${selectedEntry.method} ${selectedEntry.path}`, 'Request path')}
-								>
-									{selectedEntry.method}
-									{selectedEntry.path}
-								</button>
+				<div class="flex items-center gap-2">
+					{#if showJumpToLatest}
+						<button class="btn btn-primary btn-xs" onclick={jumpToLatest}>
+							{#if pendingLiveCount > 0}
+								Jump to latest ({pendingLiveCount} new)
+							{:else}
+								Jump to latest
 							{/if}
-							{#if selectedEntry.requestId}
-								<button
-									class="rounded-md bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70"
-									onclick={() => copyText(selectedEntry.requestId ?? '', 'Request ID')}
-								>
-									req:{selectedEntry.requestId}
-								</button>
-							{/if}
-							{#if selectedEntry.correlationId}
-								<button
-									class="rounded-md bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70"
-									onclick={() => copyText(selectedEntry.correlationId ?? '', 'Correlation ID')}
-								>
-									corr:{selectedEntry.correlationId}
-								</button>
-							{/if}
-							{#if selectedEntry.supportId}
-								<button
-									class="rounded-md bg-base-300 px-2 py-1 font-mono text-xs text-base-content/70"
-									onclick={() => copyText(selectedEntry.supportId ?? '', 'Issue ID')}
-								>
-									issue:{selectedEntry.supportId}
-								</button>
-							{/if}
-						</div>
-
-						<div>
-							<div class="mb-2 flex items-center justify-between">
-								<p class="text-xs tracking-[0.18em] text-base-content/55 uppercase">Payload</p>
-								<button
-									class="btn btn-ghost btn-xs"
-									onclick={() => copyText(formatDetails(selectedEntry), 'Payload')}
-								>
-									Copy
-								</button>
-							</div>
-							<pre
-								class="max-h-[22rem] overflow-auto bg-base-300/50 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap text-base-content/80">{formatDetails(
-									selectedEntry
-								)}</pre>
-						</div>
-					</div>
-				{:else}
-					<div class="text-sm text-base-content/60">
-						Select a row to inspect request IDs, payload data, and structured errors.
-					</div>
-				{/if}
+						</button>
+					{/if}
+					<button
+						class="btn btn-ghost btn-xs"
+						onclick={loadOlderHistory}
+						disabled={historyLoading || !historyHasMore}
+					>
+						{#if historyLoading && historyHasMore}
+							<Loader2 class="h-3 w-3 animate-spin" />
+						{/if}
+						Load older
+					</button>
+				</div>
 			</div>
 		</div>
-	</SettingsSection>
+	</div>
 </SettingsPage>
+
+<!-- Mobile inspector bottom sheet -->
+{#if selectedEntry && mobileInspectorOpen}
+	<div class="fixed inset-0 z-40 xl:hidden" role="presentation" onclick={closeInspector}></div>
+	<div
+		class="fixed right-0 bottom-0 left-0 z-50 max-h-[60vh] overflow-y-auto border-t border-base-300 bg-base-100 xl:hidden"
+	>
+		<div
+			class="sticky top-0 flex items-center justify-between border-b border-base-300 bg-base-100/90 px-4 py-3 backdrop-blur"
+		>
+			<p class="text-[10px] font-medium tracking-widest text-base-content/50 uppercase">
+				Inspector
+			</p>
+			<button
+				type="button"
+				class="btn btn-circle btn-ghost btn-xs"
+				onclick={closeInspector}
+				aria-label="Close inspector"
+			>
+				<X class="h-3.5 w-3.5" />
+			</button>
+		</div>
+		{@render inspectorBody(selectedEntry)}
+	</div>
+{/if}

--- a/src/routes/settings/logs/+page.svelte
+++ b/src/routes/settings/logs/+page.svelte
@@ -124,11 +124,24 @@
 	const showJumpToLatest = $derived.by(
 		() => pendingLiveCount > 0 || !isNearTop || !autoFollowEnabled || livePaused
 	);
+	const activeFilterLabel = $derived.by(() => {
+		const parts: string[] = [];
+		if (levels.size === 1) {
+			const [level] = [...levels];
+			parts.push(`${level} only`);
+		} else if (levels.size < availableLevels.length) {
+			parts.push(`${levels.size} levels`);
+		}
+		if (selectedDomain !== 'all') parts.push(selectedDomain);
+		if (search.trim()) parts.push(`"${search.trim()}"`);
+		return parts.length > 0 ? `Filtered: ${parts.join(', ')}` : '';
+	});
+
 	const liveStatusLabel = $derived.by(() => {
 		if (livePaused) return 'Live paused';
 		if (autoFollowEnabled && isNearTop) return 'Following newest entries';
-		if (pendingLiveCount > 0) return 'Browsing while new entries queue';
-		return 'Browsing current results';
+		if (pendingLiveCount > 0) return 'New entries queuing';
+		return activeFilterLabel;
 	});
 
 	const hasActiveFilters = $derived.by(
@@ -806,13 +819,15 @@
 			<div
 				class="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-base-300 px-3 py-2 text-xs text-base-content/50"
 			>
-				<span>{entries.length} entries</span>
 				{#if historyTotal > entries.length}
-					<span class="text-base-content/20">·</span>
-					<span>{historyTotal} persisted</span>
+					<span>Showing {entries.length} of {historyTotal}</span>
+				{:else}
+					<span>{entries.length} entries</span>
 				{/if}
-				<span class="text-base-content/20">·</span>
-				<span>{liveStatusLabel}</span>
+				{#if liveStatusLabel}
+					<span class="text-base-content/20">·</span>
+					<span>{liveStatusLabel}</span>
+				{/if}
 			</div>
 		</div>
 


### PR DESCRIPTION
## Summary

Adds Jackett and Prowlarr as external indexer manager integrations, improves search reliability for FlareSolverr-backed indexers, overhauls the log viewer, and fixes an SSE filter bug that let filtered-out entries through.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Add Jackett connection service with direct POST auth and trailing-slash bypass; sync indexer names automatically when they drift
- Add Prowlarr connection service and sync scheduler
- Show P/J source badges in search results and stats; FlareSolverr hint on degraded Jackett indexer health badges
- Warm-up call to Jackett Torznab endpoint before connection test to reset Jackett's internal circuit breaker
- Fix search variant loop to exit early once results are found, preventing FlareSolverr overload and result timeouts
- Smarter search title ordering: preferred language first, original second; language-aware TMDB alternate ranking via country-to-language map
- Extend Cyrillic-preference detection to RuTor, NNMClub, and any `.ru` host
- Torznab URL auto-discovery: resolve bare host URLs to the correct endpoint during indexer setup
- Log viewer overhaul: full-height layout, sticky toolbar, inspector side panel, mobile bottom-sheet inspector
- Fix SSE level/domain/search filter changes not reconnecting the live stream (open-connection guard blocked reconnect)
- Log status bar: "Showing X of Y" pagination pattern, contextual filter label, drop filler text
- Calendar notice explaining TV series library requirement; cascade monitor state prompt for library items

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
