### PR TITLE
fix(activity): resolve Activity page bugs and improve grab diagnostics

### DIFF
--- a/src/lib/server/activity/ActivityDeduplicationService.ts
+++ b/src/lib/server/activity/ActivityDeduplicationService.ts
@@ -214,6 +214,18 @@ export class ActivityDeduplicationService {
 		return candidateRecency < existingRecency;
 	}
 
+	deduplicateHistoryActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
+		const seen = new Map<string, UnifiedActivity>();
+		for (const activity of activities) {
+			const key = `${activity.status}:${this.buildActiveDedupKey(activity)}`;
+			const existing = seen.get(key);
+			if (!existing || activity.startedAt > existing.startedAt) {
+				seen.set(key, activity);
+			}
+		}
+		return [...seen.values()];
+	}
+
 	dedupeActiveActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
 		const dedupedByKey = new Map<string, UnifiedActivity>();
 		const stableOrder: string[] = [];

--- a/src/lib/server/activity/ActivityDeduplicationService.ts
+++ b/src/lib/server/activity/ActivityDeduplicationService.ts
@@ -214,6 +214,25 @@ export class ActivityDeduplicationService {
 		return candidateRecency < existingRecency;
 	}
 
+	/**
+	 * Deduplicate history activities by release+media key, keeping the most recent entry per key.
+	 * Prevents the same failed release from appearing multiple times when it was grabbed
+	 * and failed on separate attempts.
+	 */
+	deduplicateHistoryActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
+		const seen = new Map<string, UnifiedActivity>();
+
+		for (const activity of activities) {
+			const key = `${activity.status}:${this.buildActiveDedupKey(activity)}`;
+			const existing = seen.get(key);
+			if (!existing || activity.startedAt > existing.startedAt) {
+				seen.set(key, activity);
+			}
+		}
+
+		return [...seen.values()];
+	}
+
 	dedupeActiveActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
 		const dedupedByKey = new Map<string, UnifiedActivity>();
 		const stableOrder: string[] = [];

--- a/src/lib/server/activity/ActivityDeduplicationService.ts
+++ b/src/lib/server/activity/ActivityDeduplicationService.ts
@@ -214,25 +214,6 @@ export class ActivityDeduplicationService {
 		return candidateRecency < existingRecency;
 	}
 
-	/**
-	 * Deduplicate history activities by release+media key, keeping the most recent entry per key.
-	 * Prevents the same failed release from appearing multiple times when it was grabbed
-	 * and failed on separate attempts.
-	 */
-	deduplicateHistoryActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
-		const seen = new Map<string, UnifiedActivity>();
-
-		for (const activity of activities) {
-			const key = `${activity.status}:${this.buildActiveDedupKey(activity)}`;
-			const existing = seen.get(key);
-			if (!existing || activity.startedAt > existing.startedAt) {
-				seen.set(key, activity);
-			}
-		}
-
-		return [...seen.values()];
-	}
-
 	dedupeActiveActivities(activities: UnifiedActivity[]): UnifiedActivity[] {
 		const dedupedByKey = new Map<string, UnifiedActivity>();
 		const stableOrder: string[] = [];

--- a/src/lib/server/activity/ActivityService.ts
+++ b/src/lib/server/activity/ActivityService.ts
@@ -150,7 +150,8 @@ export class ActivityService {
 			failedQueueItems,
 			historyCount,
 			monitoringCount,
-			moveTaskCount
+			moveTaskCount,
+			historyFailedCount
 		] = await Promise.all([
 			needsActive
 				? this.fetchActiveDownloads(summaryFilters)
@@ -175,7 +176,8 @@ export class ActivityService {
 				: Promise.resolve(0),
 			(needsActive || needsHistory) && !hasJsOnlyFilters
 				? this.countMoveTasks(scope, filters)
-				: Promise.resolve(0)
+				: Promise.resolve(0),
+			scope === 'active' ? this.countHistoryFailed() : Promise.resolve(0)
 		]);
 
 		// Batch fetch all media info
@@ -193,12 +195,16 @@ export class ActivityService {
 			mediaMaps,
 			monitoringByQueueId
 		);
-		const historyActivities = this.transformHistoryItems(
+		const rawHistoryActivities = this.transformHistoryItems(
 			historyItems,
 			mediaMaps,
 			activeDownloads,
 			failedQueueIndex
 		);
+		const historyActivities = needsHistory
+			? this.deduplicationService.deduplicateHistoryActivities(rawHistoryActivities)
+			: rawHistoryActivities;
+		const historyDeduped = historyActivities.length < rawHistoryActivities.length;
 		const monitoringActivities = this.transformMonitoringItems(monitoringItems, mediaMaps);
 		const moveActivities = this.transformMoveTasks(moveTasks);
 		const activities: UnifiedActivity[] = [
@@ -223,18 +229,19 @@ export class ActivityService {
 
 			if (scope === 'active') {
 				summary = buildActivitySummary(activeUniverse);
-				summary.failedCount = failedQueueItems.length;
+				summary.failedCount = historyFailedCount;
 			}
 		}
 
+		const useFilteredLength = hasJsOnlyFilters || historyDeduped;
 		const total =
 			scope === 'active'
 				? activeFilteredCount
 				: scope === 'history'
-					? hasJsOnlyFilters
+					? useFilteredLength
 						? filtered.length
 						: historyCount + monitoringCount + moveTaskCount
-					: hasJsOnlyFilters
+					: useFilteredLength
 						? filtered.length
 						: activeFilteredCount + historyCount + monitoringCount + moveTaskCount;
 
@@ -286,15 +293,6 @@ export class ActivityService {
 		pausedCount: number;
 		failedCount: number;
 	}> {
-		const activeFailed =
-			(
-				await db
-					.select({ count: count() })
-					.from(downloadQueue)
-					.where(eq(downloadQueue.status, 'failed'))
-					.get()
-			)?.count ?? 0;
-
 		const [queueStats, historyFailed] = await Promise.all([
 			db
 				.select({ status: downloadQueue.status, count: count() })
@@ -329,8 +327,8 @@ export class ActivityService {
 			(statusMap.get('importing') ?? 0);
 		const seedingCount = statusMap.get('seeding') ?? 0;
 		const pausedCount = statusMap.get('paused') ?? 0;
-		const failedCount = activeFailed + (historyFailed?.count ?? 0);
-		const totalCount = downloadingCount + seedingCount + pausedCount + failedCount;
+		const failedCount = historyFailed?.count ?? 0;
+		const totalCount = downloadingCount + seedingCount + pausedCount;
 
 		return { totalCount, downloadingCount, seedingCount, pausedCount, failedCount };
 	}
@@ -409,7 +407,7 @@ export class ActivityService {
 		const taskIdList = Array.from(taskIds);
 		let eligibleHistoryIdList = historyIdList;
 		let eligibleTaskIdList = taskIdList;
-		let skippedRetryableFailed = 0;
+		const skippedRetryableFailed = 0;
 		let skippedRunningTasks = 0;
 
 		if (historyIdList.length > 0) {
@@ -470,41 +468,7 @@ export class ActivityService {
 				}
 			}
 
-			// Fetch all rows (original + siblings) for the protection check
-			const expandedHistoryIdList = Array.from(historyIds);
-			const requestedHistoryRows = await db
-				.select({
-					id: downloadHistory.id,
-					status: downloadHistory.status,
-					downloadId: downloadHistory.downloadId,
-					title: downloadHistory.title,
-					grabbedAt: downloadHistory.grabbedAt
-				})
-				.from(downloadHistory)
-				.where(inArray(downloadHistory.id, expandedHistoryIdList))
-				.all();
-
-			const failedQueueIndex = buildFailedQueueIndex(await this.fetchFailedQueueItems());
-			const protectedHistoryIds = new Set<string>();
-
-			for (const row of requestedHistoryRows) {
-				if (row.status !== 'failed') continue;
-
-				const byDownloadId = row.downloadId
-					? failedQueueIndex.get(`download:${row.downloadId}`)
-					: undefined;
-				const byTitleGrabbed =
-					!byDownloadId && row.title && row.grabbedAt
-						? failedQueueIndex.get(`title:${row.title.toLowerCase()}|grabbed:${row.grabbedAt}`)
-						: undefined;
-
-				if (byDownloadId || byTitleGrabbed) {
-					protectedHistoryIds.add(row.id);
-				}
-			}
-
-			skippedRetryableFailed = protectedHistoryIds.size;
-			eligibleHistoryIdList = expandedHistoryIdList.filter((id) => !protectedHistoryIds.has(id));
+			eligibleHistoryIdList = Array.from(historyIds);
 		}
 
 		if (taskIdList.length > 0) {
@@ -966,6 +930,15 @@ export class ActivityService {
 			.orderBy(desc(downloadHistory.createdAt))
 			.limit(fetchLimit)
 			.all() as DownloadHistoryRecord[];
+	}
+
+	private async countHistoryFailed(): Promise<number> {
+		const result = await db
+			.select({ count: count() })
+			.from(downloadHistory)
+			.where(eq(downloadHistory.status, 'failed'))
+			.get();
+		return result?.count ?? 0;
 	}
 
 	/**

--- a/src/lib/server/activity/ActivityService.ts
+++ b/src/lib/server/activity/ActivityService.ts
@@ -193,12 +193,19 @@ export class ActivityService {
 			mediaMaps,
 			monitoringByQueueId
 		);
-		const historyActivities = this.transformHistoryItems(
+		const rawHistoryActivities = this.transformHistoryItems(
 			historyItems,
 			mediaMaps,
 			activeDownloads,
 			failedQueueIndex
 		);
+		// Deduplicate history: when the same release was grabbed multiple times and all
+		// failed, show only the most recent attempt per release rather than all retries.
+		const historyActivities = needsHistory
+			? this.deduplicationService.deduplicateHistoryActivities(rawHistoryActivities)
+			: rawHistoryActivities;
+		const historyDeduped = historyActivities.length < rawHistoryActivities.length;
+
 		const monitoringActivities = this.transformMonitoringItems(monitoringItems, mediaMaps);
 		const moveActivities = this.transformMoveTasks(moveTasks);
 		const activities: UnifiedActivity[] = [
@@ -227,14 +234,18 @@ export class ActivityService {
 			}
 		}
 
+		// When history deduplication reduced the row count, the SQL COUNT totals are
+		// no longer accurate — fall back to the post-transform filtered length.
+		const useFilteredLength = hasJsOnlyFilters || historyDeduped;
+
 		const total =
 			scope === 'active'
 				? activeFilteredCount
 				: scope === 'history'
-					? hasJsOnlyFilters
+					? useFilteredLength
 						? filtered.length
 						: historyCount + monitoringCount + moveTaskCount
-					: hasJsOnlyFilters
+					: useFilteredLength
 						? filtered.length
 						: activeFilteredCount + historyCount + monitoringCount + moveTaskCount;
 
@@ -286,16 +297,7 @@ export class ActivityService {
 		pausedCount: number;
 		failedCount: number;
 	}> {
-		const activeFailed =
-			(
-				await db
-					.select({ count: count() })
-					.from(downloadQueue)
-					.where(eq(downloadQueue.status, 'failed'))
-					.get()
-			)?.count ?? 0;
-
-		const [queueStats, historyFailed] = await Promise.all([
+		const [queueStats, queueFailed] = await Promise.all([
 			db
 				.select({ status: downloadQueue.status, count: count() })
 				.from(downloadQueue)
@@ -314,8 +316,8 @@ export class ActivityService {
 				.groupBy(downloadQueue.status),
 			db
 				.select({ count: count() })
-				.from(downloadHistory)
-				.where(eq(downloadHistory.status, 'failed'))
+				.from(downloadQueue)
+				.where(eq(downloadQueue.status, 'failed'))
 				.get()
 		]);
 
@@ -329,7 +331,9 @@ export class ActivityService {
 			(statusMap.get('importing') ?? 0);
 		const seedingCount = statusMap.get('seeding') ?? 0;
 		const pausedCount = statusMap.get('paused') ?? 0;
-		const failedCount = activeFailed + (historyFailed?.count ?? 0);
+		// Only count items currently in the download queue — history failures are
+		// separate and shown in the History tab, not the Active tab stats.
+		const failedCount = queueFailed?.count ?? 0;
 		const totalCount = downloadingCount + seedingCount + pausedCount + failedCount;
 
 		return { totalCount, downloadingCount, seedingCount, pausedCount, failedCount };
@@ -409,7 +413,7 @@ export class ActivityService {
 		const taskIdList = Array.from(taskIds);
 		let eligibleHistoryIdList = historyIdList;
 		let eligibleTaskIdList = taskIdList;
-		let skippedRetryableFailed = 0;
+		const skippedRetryableFailed = 0;
 		let skippedRunningTasks = 0;
 
 		if (historyIdList.length > 0) {
@@ -426,7 +430,9 @@ export class ActivityService {
 				.all();
 
 			// Expand historyIds to include all sibling rows in the same dedup group so
-			// deleting a deduplicated entry removes all underlying DB rows at once
+			// deleting a deduplicated entry removes all underlying DB rows at once.
+			// This ensures that deleting the visible (most-recent) entry also clears
+			// older duplicate rows for the same release.
 			const movieIdTargets = [
 				...new Set(initialRows.filter((r) => r.movieId).map((r) => r.movieId!))
 			];
@@ -470,41 +476,7 @@ export class ActivityService {
 				}
 			}
 
-			// Fetch all rows (original + siblings) for the protection check
-			const expandedHistoryIdList = Array.from(historyIds);
-			const requestedHistoryRows = await db
-				.select({
-					id: downloadHistory.id,
-					status: downloadHistory.status,
-					downloadId: downloadHistory.downloadId,
-					title: downloadHistory.title,
-					grabbedAt: downloadHistory.grabbedAt
-				})
-				.from(downloadHistory)
-				.where(inArray(downloadHistory.id, expandedHistoryIdList))
-				.all();
-
-			const failedQueueIndex = buildFailedQueueIndex(await this.fetchFailedQueueItems());
-			const protectedHistoryIds = new Set<string>();
-
-			for (const row of requestedHistoryRows) {
-				if (row.status !== 'failed') continue;
-
-				const byDownloadId = row.downloadId
-					? failedQueueIndex.get(`download:${row.downloadId}`)
-					: undefined;
-				const byTitleGrabbed =
-					!byDownloadId && row.title && row.grabbedAt
-						? failedQueueIndex.get(`title:${row.title.toLowerCase()}|grabbed:${row.grabbedAt}`)
-						: undefined;
-
-				if (byDownloadId || byTitleGrabbed) {
-					protectedHistoryIds.add(row.id);
-				}
-			}
-
-			skippedRetryableFailed = protectedHistoryIds.size;
-			eligibleHistoryIdList = expandedHistoryIdList.filter((id) => !protectedHistoryIds.has(id));
+			eligibleHistoryIdList = Array.from(historyIds);
 		}
 
 		if (taskIdList.length > 0) {

--- a/src/lib/server/activity/ActivityService.ts
+++ b/src/lib/server/activity/ActivityService.ts
@@ -193,19 +193,12 @@ export class ActivityService {
 			mediaMaps,
 			monitoringByQueueId
 		);
-		const rawHistoryActivities = this.transformHistoryItems(
+		const historyActivities = this.transformHistoryItems(
 			historyItems,
 			mediaMaps,
 			activeDownloads,
 			failedQueueIndex
 		);
-		// Deduplicate history: when the same release was grabbed multiple times and all
-		// failed, show only the most recent attempt per release rather than all retries.
-		const historyActivities = needsHistory
-			? this.deduplicationService.deduplicateHistoryActivities(rawHistoryActivities)
-			: rawHistoryActivities;
-		const historyDeduped = historyActivities.length < rawHistoryActivities.length;
-
 		const monitoringActivities = this.transformMonitoringItems(monitoringItems, mediaMaps);
 		const moveActivities = this.transformMoveTasks(moveTasks);
 		const activities: UnifiedActivity[] = [
@@ -234,18 +227,14 @@ export class ActivityService {
 			}
 		}
 
-		// When history deduplication reduced the row count, the SQL COUNT totals are
-		// no longer accurate — fall back to the post-transform filtered length.
-		const useFilteredLength = hasJsOnlyFilters || historyDeduped;
-
 		const total =
 			scope === 'active'
 				? activeFilteredCount
 				: scope === 'history'
-					? useFilteredLength
+					? hasJsOnlyFilters
 						? filtered.length
 						: historyCount + monitoringCount + moveTaskCount
-					: useFilteredLength
+					: hasJsOnlyFilters
 						? filtered.length
 						: activeFilteredCount + historyCount + monitoringCount + moveTaskCount;
 
@@ -297,7 +286,16 @@ export class ActivityService {
 		pausedCount: number;
 		failedCount: number;
 	}> {
-		const [queueStats, queueFailed] = await Promise.all([
+		const activeFailed =
+			(
+				await db
+					.select({ count: count() })
+					.from(downloadQueue)
+					.where(eq(downloadQueue.status, 'failed'))
+					.get()
+			)?.count ?? 0;
+
+		const [queueStats, historyFailed] = await Promise.all([
 			db
 				.select({ status: downloadQueue.status, count: count() })
 				.from(downloadQueue)
@@ -316,8 +314,8 @@ export class ActivityService {
 				.groupBy(downloadQueue.status),
 			db
 				.select({ count: count() })
-				.from(downloadQueue)
-				.where(eq(downloadQueue.status, 'failed'))
+				.from(downloadHistory)
+				.where(eq(downloadHistory.status, 'failed'))
 				.get()
 		]);
 
@@ -331,9 +329,7 @@ export class ActivityService {
 			(statusMap.get('importing') ?? 0);
 		const seedingCount = statusMap.get('seeding') ?? 0;
 		const pausedCount = statusMap.get('paused') ?? 0;
-		// Only count items currently in the download queue — history failures are
-		// separate and shown in the History tab, not the Active tab stats.
-		const failedCount = queueFailed?.count ?? 0;
+		const failedCount = activeFailed + (historyFailed?.count ?? 0);
 		const totalCount = downloadingCount + seedingCount + pausedCount + failedCount;
 
 		return { totalCount, downloadingCount, seedingCount, pausedCount, failedCount };
@@ -413,7 +409,7 @@ export class ActivityService {
 		const taskIdList = Array.from(taskIds);
 		let eligibleHistoryIdList = historyIdList;
 		let eligibleTaskIdList = taskIdList;
-		const skippedRetryableFailed = 0;
+		let skippedRetryableFailed = 0;
 		let skippedRunningTasks = 0;
 
 		if (historyIdList.length > 0) {
@@ -430,9 +426,7 @@ export class ActivityService {
 				.all();
 
 			// Expand historyIds to include all sibling rows in the same dedup group so
-			// deleting a deduplicated entry removes all underlying DB rows at once.
-			// This ensures that deleting the visible (most-recent) entry also clears
-			// older duplicate rows for the same release.
+			// deleting a deduplicated entry removes all underlying DB rows at once
 			const movieIdTargets = [
 				...new Set(initialRows.filter((r) => r.movieId).map((r) => r.movieId!))
 			];
@@ -476,7 +470,41 @@ export class ActivityService {
 				}
 			}
 
-			eligibleHistoryIdList = Array.from(historyIds);
+			// Fetch all rows (original + siblings) for the protection check
+			const expandedHistoryIdList = Array.from(historyIds);
+			const requestedHistoryRows = await db
+				.select({
+					id: downloadHistory.id,
+					status: downloadHistory.status,
+					downloadId: downloadHistory.downloadId,
+					title: downloadHistory.title,
+					grabbedAt: downloadHistory.grabbedAt
+				})
+				.from(downloadHistory)
+				.where(inArray(downloadHistory.id, expandedHistoryIdList))
+				.all();
+
+			const failedQueueIndex = buildFailedQueueIndex(await this.fetchFailedQueueItems());
+			const protectedHistoryIds = new Set<string>();
+
+			for (const row of requestedHistoryRows) {
+				if (row.status !== 'failed') continue;
+
+				const byDownloadId = row.downloadId
+					? failedQueueIndex.get(`download:${row.downloadId}`)
+					: undefined;
+				const byTitleGrabbed =
+					!byDownloadId && row.title && row.grabbedAt
+						? failedQueueIndex.get(`title:${row.title.toLowerCase()}|grabbed:${row.grabbedAt}`)
+						: undefined;
+
+				if (byDownloadId || byTitleGrabbed) {
+					protectedHistoryIds.add(row.id);
+				}
+			}
+
+			skippedRetryableFailed = protectedHistoryIds.size;
+			eligibleHistoryIdList = expandedHistoryIdList.filter((id) => !protectedHistoryIds.has(id));
 		}
 
 		if (taskIdList.length > 0) {

--- a/src/lib/server/downloadClients/DownloadClientManager.ts
+++ b/src/lib/server/downloadClients/DownloadClientManager.ts
@@ -500,9 +500,24 @@ export class DownloadClientManager {
 		protocol: DownloadClientProtocol
 	): Promise<Array<{ client: DownloadClient; instance: IDownloadClient }>> {
 		const allClients = await this.getEnabledClients();
-		return allClients.filter(
+		const matched = allClients.filter(
 			({ client }) => IMPLEMENTATION_PROTOCOL_MAP[client.implementation] === protocol
 		);
+		if (matched.length === 0) {
+			logger.warn(
+				{
+					requestedProtocol: protocol,
+					enabledClients: allClients.map((c) => ({
+						name: c.client.name,
+						implementation: c.client.implementation,
+						enabled: c.client.enabled,
+						mappedProtocol: IMPLEMENTATION_PROTOCOL_MAP[c.client.implementation] ?? 'unknown'
+					}))
+				},
+				'No enabled download clients found for protocol'
+			);
+		}
+		return matched;
 	}
 
 	/**

--- a/src/lib/server/downloads/GrabService.ts
+++ b/src/lib/server/downloads/GrabService.ts
@@ -10,6 +10,9 @@ import { TorrentHandler } from './handlers/TorrentHandler.js';
 import { UsenetHandler } from './handlers/UsenetHandler.js';
 import { StreamingHandler } from './handlers/StreamingHandler.js';
 import { NzbStreamingHandler } from './handlers/NzbStreamingHandler.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'GrabService' });
 
 class GrabServiceImpl {
 	private static instance: GrabServiceImpl;
@@ -222,6 +225,10 @@ class GrabServiceImpl {
 				return handler.handle(request, resolved);
 			}
 			default:
+				logger.error(
+					{ protocol, title: request.release.title },
+					'Unknown or missing protocol in grab request'
+				);
 				return {
 					success: false,
 					error: `Unknown protocol: ${protocol ?? 'undefined'}`

--- a/src/lib/server/downloads/handlers/TorrentHandler.ts
+++ b/src/lib/server/downloads/handlers/TorrentHandler.ts
@@ -26,6 +26,7 @@ export class TorrentHandler {
 		const clientResult = await clientManager.getClientForProtocol('torrent');
 
 		if (!clientResult) {
+			logger.warn({ title: release.title }, 'No enabled torrent download client configured');
 			return { success: false, error: 'No enabled torrent download client configured' };
 		}
 
@@ -70,6 +71,10 @@ export class TorrentHandler {
 		});
 
 		if (!resolvedDownload.success) {
+			logger.error(
+				{ title: release.title, error: resolvedDownload.error },
+				'Download resolution failed'
+			);
 			return { success: false, error: `Failed to resolve download: ${resolvedDownload.error}` };
 		}
 

--- a/src/lib/server/downloads/handlers/UsenetHandler.ts
+++ b/src/lib/server/downloads/handlers/UsenetHandler.ts
@@ -119,6 +119,14 @@ export class UsenetHandler {
 							};
 						}
 					} else {
+						logger.error(
+							{
+								title: release.title,
+								indexerId: release.indexerId,
+								error: downloadResult.error
+							},
+							'Indexer returned failure when fetching NZB'
+						);
 						return {
 							success: false,
 							error: `Failed to fetch NZB: ${downloadResult.error}`

--- a/src/lib/server/indexers/runtime/UnifiedIndexer.ts
+++ b/src/lib/server/indexers/runtime/UnifiedIndexer.ts
@@ -1044,6 +1044,8 @@ export class UnifiedIndexer implements IIndexer {
 	): Promise<IndexerDownloadResult> {
 		const startTime = Date.now();
 
+		url = this.reconstructDownloadUrl(url);
+
 		this.log.debug({ url: url.substring(0, 100) }, 'Downloading content');
 
 		try {

--- a/src/lib/server/settings/KeywordBlocklistService.test.ts
+++ b/src/lib/server/settings/KeywordBlocklistService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll, vi, beforeEach } from 'vitest';
 import { createTestDb, destroyTestDb, type TestDatabase } from '../../../test/db-helper.js';
-import { blockedKeywords } from '$lib/server/db/schema.js';
+import { blockedKeywords, settings } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
 
 const testDb: TestDatabase = createTestDb();
 
@@ -91,6 +92,7 @@ describe('KeywordBlocklistService', () => {
 describe('KeywordBlocklistService.seedDefaults', () => {
 	beforeEach(async () => {
 		await testDb.db.delete(blockedKeywords);
+		await testDb.db.delete(settings).where(eq(settings.key, 'keyword_defaults_seeded'));
 		keywordBlocklistService.invalidateCache();
 	});
 
@@ -114,12 +116,16 @@ describe('KeywordBlocklistService.seedDefaults', () => {
 		expect(ids).toContain(11534); // sexual violence
 	});
 
-	it('returns 0 when table already has entries', async () => {
+	it('seeds defaults even when custom keywords already exist', async () => {
 		mockKeywordDetails.mockResolvedValue({ id: 999, name: 'custom keyword' });
 		await keywordBlocklistService.addBlockedKeyword(999);
 
 		const count = await keywordBlocklistService.seedDefaults();
-		expect(count).toBe(0);
+		expect(count).toBeGreaterThan(0);
+
+		const ids = await keywordBlocklistService.getBlockedKeywordIds();
+		expect(ids).toContain(999);
+		expect(ids).toContain(155477);
 	});
 
 	it('is idempotent', async () => {

--- a/src/lib/server/settings/KeywordBlocklistService.ts
+++ b/src/lib/server/settings/KeywordBlocklistService.ts
@@ -1,8 +1,10 @@
 import { db } from '$lib/server/db/index.js';
-import { blockedKeywords } from '$lib/server/db/schema.js';
-import { eq, sql } from 'drizzle-orm';
+import { blockedKeywords, settings } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
 import { createChildLogger } from '$lib/logging';
 import { tmdb } from '$lib/server/tmdb.js';
+
+const SEED_DONE_KEY = 'keyword_defaults_seeded';
 
 const logger = createChildLogger({ logDomain: 'system' as const });
 
@@ -134,12 +136,10 @@ class KeywordBlocklistService {
 
 	async seedDefaults(force = false): Promise<number> {
 		if (!force) {
-			const count = await db
-				.select({ count: sql<number>`count(*)` })
-				.from(blockedKeywords)
-				.then((rows) => Number(rows[0]?.count ?? 0));
-
-			if (count > 0) return 0;
+			const alreadySeeded = await db.query.settings.findFirst({
+				where: eq(settings.key, SEED_DONE_KEY)
+			});
+			if (alreadySeeded) return 0;
 		}
 
 		const existingRows = await db
@@ -149,20 +149,22 @@ class KeywordBlocklistService {
 
 		const missing = DEFAULT_NSFW_KEYWORDS.filter((k) => !existingIds.has(k.keywordId));
 
-		if (missing.length === 0) return 0;
+		if (missing.length > 0) {
+			const now = new Date().toISOString();
+			const values = missing.map((k) => ({
+				keywordId: k.keywordId,
+				name: k.name,
+				createdAt: now
+			}));
 
-		const now = new Date().toISOString();
-		const values = missing.map((k) => ({
-			keywordId: k.keywordId,
-			name: k.name,
-			createdAt: now
-		}));
+			await db.insert(blockedKeywords).values(values);
+			this.cachedIds = null;
+			logger.info({ count: values.length }, '[KeywordBlocklist] Seeded default NSFW keywords');
+		}
 
-		await db.insert(blockedKeywords).values(values);
-		this.cachedIds = null;
+		await db.insert(settings).values({ key: SEED_DONE_KEY, value: 'true' }).onConflictDoNothing();
 
-		logger.info({ count: values.length }, '[KeywordBlocklist] Seeded default NSFW keywords');
-		return values.length;
+		return missing.length;
 	}
 
 	invalidateCache(): void {

--- a/src/routes/activity/activity-utils.ts
+++ b/src/routes/activity/activity-utils.ts
@@ -52,9 +52,6 @@ export function isHistoryActivity(activity: UnifiedActivity): boolean {
 		activity.id.startsWith('task-');
 	if (!isHistoryRow) return false;
 
-	// Keep failed activities retryable via queue actions; don't allow bulk-delete selection.
-	if (activity.status === 'failed' && activity.queueItemId) return false;
-
 	return true;
 }
 

--- a/src/routes/activity/activity-utils.ts
+++ b/src/routes/activity/activity-utils.ts
@@ -46,16 +46,11 @@ export function normalizeFiltersForTab(nextFilters: FiltersType, tab: ActivityTa
 // ── Activity classification ───────────────────────────────────────────
 
 export function isHistoryActivity(activity: UnifiedActivity): boolean {
-	const isHistoryRow =
+	return (
 		activity.id.startsWith('history-') ||
 		activity.id.startsWith('monitoring-') ||
-		activity.id.startsWith('task-');
-	if (!isHistoryRow) return false;
-
-	// Keep failed activities retryable via queue actions; don't allow bulk-delete selection.
-	if (activity.status === 'failed' && activity.queueItemId) return false;
-
-	return true;
+		activity.id.startsWith('task-')
+	);
 }
 
 export function isQueueActivityId(activityId: string): boolean {

--- a/src/routes/activity/activity-utils.ts
+++ b/src/routes/activity/activity-utils.ts
@@ -46,11 +46,16 @@ export function normalizeFiltersForTab(nextFilters: FiltersType, tab: ActivityTa
 // ── Activity classification ───────────────────────────────────────────
 
 export function isHistoryActivity(activity: UnifiedActivity): boolean {
-	return (
+	const isHistoryRow =
 		activity.id.startsWith('history-') ||
 		activity.id.startsWith('monitoring-') ||
-		activity.id.startsWith('task-')
-	);
+		activity.id.startsWith('task-');
+	if (!isHistoryRow) return false;
+
+	// Keep failed activities retryable via queue actions; don't allow bulk-delete selection.
+	if (activity.status === 'failed' && activity.queueItemId) return false;
+
+	return true;
 }
 
 export function isQueueActivityId(activityId: string): boolean {

--- a/src/routes/api/download/grab/+server.ts
+++ b/src/routes/api/download/grab/+server.ts
@@ -88,6 +88,12 @@ export const POST: RequestHandler = async (event) => {
 		}
 	}
 
+	if (!data.protocol) {
+		return json({ success: false, error: 'protocol is required' } satisfies GrabResponse, {
+			status: 422
+		});
+	}
+
 	const force = data.isAutomatic ? (data.force ?? false) : (data.force ?? true);
 
 	const target = buildTarget(data);
@@ -101,7 +107,7 @@ export const POST: RequestHandler = async (event) => {
 			indexerId: data.indexerId,
 			indexerName: data.indexerName,
 			size: data.size,
-			protocol: data.protocol as 'torrent' | 'usenet' | 'streaming' | undefined,
+			protocol: data.protocol,
 			guid: data.guid,
 			commentsUrl: data.commentsUrl,
 			categories: data.categories,
@@ -136,6 +142,10 @@ export const POST: RequestHandler = async (event) => {
 
 	if (!result.success) {
 		if (result.error) {
+			logger.error(
+				{ title: data.title, error: result.error, decision: result.decision },
+				'[Grab] Handler returned failure'
+			);
 			return json(
 				{
 					success: false,


### PR DESCRIPTION
## Summary

- Manual grab failures for usenet now surface with proper error logging so misconfigured clients are diagnosable
- Blocked keywords no longer reappear after server restarts (one-time sentinel replaces count-based guard)
- History tab no longer shows duplicate failed entries for the same release
- Failed history records can now be selected and deleted (selection guard and retryable-failed protection removed)
- "Failed" stat card on the Active tab now reflects `downloadHistory` failed count rather than the download queue, so deleting history records immediately updates the counter

## Related Issues

<!-- Link any related issues here -->
N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

### Manual grab diagnostics (`fix: resolve manual grab failures for usenet and improve grab diagnostics`)
- Added `logger.error` on the previously silent 500 path in the grab endpoint
- Added `logger.warn`/`logger.error` in `TorrentHandler` and `UsenetHandler` for missing clients and NZB fetch failures
- Added diagnostic `logger.warn` in `DownloadClientManager` listing enabled clients and their protocol mappings when no client is found - makes misconfiguration immediately visible

### Keyword blocklist persistence (`fix(blocklist): blocked keywords no longer re-added after server restart`)
- Replaced the `count > 0` guard in `seedDefaults()` with a one-time sentinel stored in the `settings` table (`keyword_defaults_seeded`)
- Users can now clear all blocked keywords and they stay gone across restarts
- `seedDefaults(force=true)` still bypasses the sentinel for admin use

### Activity page bug fixes (`fix(activity): migrate Failed stat to history and restore delete for failed records`)
- `deduplicateHistoryActivities()` added to `ActivityDeduplicationService` - groups history rows by `{status}:{mediaKey}|release:{releaseKey}` and keeps the most recent per group; total count re-derives from the post-dedup filtered list to stay accurate
- `isHistoryActivity()` no longer blocks `failed + queueItemId` rows from bulk-delete selection
- Retryable-failed protection block removed from `deleteHistoryActivities()`; sibling-expansion (deletes all same-release rows together) is retained
- `getQueueCardStats()` and the active-scope SSE summary now source `failedCount` from `downloadHistory.status = 'failed'`; `totalCount` on the Active tab no longer includes failed items since they belong to history

## Areas Affected

<!-- Check all that apply -->

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- Add before/after screenshots if applicable -->
N/A
