### PR TITLE
feat(indexers): orphaned managed indexer handling and upstream-enabled state

### DIFF
--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -212,7 +212,10 @@
 			<button
 				class="btn btn-ghost btn-xs"
 				onclick={() => onToggle(indexer)}
-				disabled={testing || toggling || reorderMode || (indexer.upstreamEnabled === false && !indexer.orphaned)}
+				disabled={testing ||
+					toggling ||
+					reorderMode ||
+					(indexer.upstreamEnabled === false && !indexer.orphaned)}
 				title={indexer.orphaned
 					? 'Deleted from upstream - click to test connection and restore'
 					: indexer.upstreamEnabled === false

--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -3,6 +3,7 @@
 		Loader2,
 		FlaskConical,
 		Lock,
+		RotateCcw,
 		Trash2,
 		Search,
 		Zap,
@@ -127,11 +128,16 @@
 			</button>
 			{#if isProwlarrIndexer()}
 				<span class="badge badge-xs badge-primary">Prowlarr</span>
-				{#if indexer.upstreamEnabled === false}
+				{#if indexer.orphaned}
+					<span class="badge badge-xs badge-error">Deleted</span>
+				{:else if indexer.upstreamEnabled === false}
 					<span class="badge badge-xs badge-warning">Disabled in Prowlarr</span>
 				{/if}
 			{:else if isJackettIndexer()}
 				<span class="badge badge-xs badge-secondary">Jackett</span>
+				{#if indexer.orphaned}
+					<span class="badge badge-xs badge-error">Deleted</span>
+				{/if}
 			{/if}
 		</div>
 	</td>
@@ -206,11 +212,19 @@
 			<button
 				class="btn btn-ghost btn-xs"
 				onclick={() => onToggle(indexer)}
-				disabled={testing || toggling || reorderMode || indexer.upstreamEnabled === false}
-				title={indexer.upstreamEnabled === false ? 'Disabled in Prowlarr — enable it there first' : indexer.enabled ? 'Disable' : 'Enable'}
+				disabled={testing || toggling || reorderMode || (indexer.upstreamEnabled === false && !indexer.orphaned)}
+				title={indexer.orphaned
+					? 'Deleted from upstream - click to test connection and restore'
+					: indexer.upstreamEnabled === false
+						? 'Disabled in Prowlarr - enable it there first'
+						: indexer.enabled
+							? 'Disable'
+							: 'Enable'}
 			>
 				{#if toggling}
 					<Loader2 class="h-4 w-4 animate-spin" />
+				{:else if indexer.orphaned}
+					<RotateCcw class="h-4 w-4 text-error" />
 				{:else if indexer.upstreamEnabled === false}
 					<Lock class="h-4 w-4 text-warning" />
 				{:else if indexer.enabled}

--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -2,6 +2,7 @@
 	import {
 		Loader2,
 		FlaskConical,
+		Lock,
 		Trash2,
 		Search,
 		Zap,
@@ -126,7 +127,7 @@
 			</button>
 			{#if isProwlarrIndexer()}
 				<span class="badge badge-xs badge-primary">Prowlarr</span>
-				{#if indexer.settings?.prowlarrEnabled === 'false'}
+				{#if indexer.upstreamEnabled === false}
 					<span class="badge badge-xs badge-warning">Disabled in Prowlarr</span>
 				{/if}
 			{:else if isJackettIndexer()}
@@ -205,11 +206,13 @@
 			<button
 				class="btn btn-ghost btn-xs"
 				onclick={() => onToggle(indexer)}
-				disabled={testing || toggling || reorderMode}
-				title={indexer.enabled ? 'Disable' : 'Enable'}
+				disabled={testing || toggling || reorderMode || indexer.upstreamEnabled === false}
+				title={indexer.upstreamEnabled === false ? 'Disabled in Prowlarr — enable it there first' : indexer.enabled ? 'Disable' : 'Enable'}
 			>
 				{#if toggling}
 					<Loader2 class="h-4 w-4 animate-spin" />
+				{:else if indexer.upstreamEnabled === false}
+					<Lock class="h-4 w-4 text-warning" />
 				{:else if indexer.enabled}
 					<ToggleRight class="h-4 w-4 text-success" />
 				{:else}

--- a/src/lib/components/indexers/IndexerTable.svelte
+++ b/src/lib/components/indexers/IndexerTable.svelte
@@ -7,6 +7,7 @@
 		FlaskConical,
 		Loader2,
 		Lock,
+		RotateCcw,
 		Search,
 		Zap,
 		ToggleLeft,
@@ -267,11 +268,16 @@
 								</span>
 								{#if isProwlarrIndexer(indexer)}
 									<span class="badge badge-xs badge-primary">Prowlarr</span>
-									{#if indexer.upstreamEnabled === false}
+									{#if indexer.orphaned}
+										<span class="badge badge-xs badge-error">Deleted</span>
+									{:else if indexer.upstreamEnabled === false}
 										<span class="badge badge-xs badge-warning">Disabled in Prowlarr</span>
 									{/if}
 								{:else if isJackettIndexer(indexer)}
 									<span class="badge badge-xs badge-secondary">Jackett</span>
+									{#if indexer.orphaned}
+										<span class="badge badge-xs badge-error">Deleted</span>
+									{/if}
 								{/if}
 							</div>
 						</div>
@@ -340,12 +346,26 @@
 					<button
 						class="btn btn-ghost btn-xs"
 						onclick={() => onToggle(indexer)}
-						disabled={testingIds.has(indexer.id) || togglingIds.has(indexer.id) || reorderMode || indexer.upstreamEnabled === false}
-						title={indexer.upstreamEnabled === false ? 'Disabled in Prowlarr — enable it there first' : indexer.enabled ? 'Disable' : 'Enable'}
-						aria-label={indexer.upstreamEnabled === false ? 'Locked — disabled in Prowlarr' : indexer.enabled ? 'Disable indexer' : 'Enable indexer'}
+						disabled={testingIds.has(indexer.id) || togglingIds.has(indexer.id) || reorderMode || (indexer.upstreamEnabled === false && !indexer.orphaned)}
+						title={indexer.orphaned
+							? 'Deleted from upstream - tap to test connection and restore'
+							: indexer.upstreamEnabled === false
+								? 'Disabled in Prowlarr - enable it there first'
+								: indexer.enabled
+									? 'Disable'
+									: 'Enable'}
+						aria-label={indexer.orphaned
+							? 'Deleted - tap to restore'
+							: indexer.upstreamEnabled === false
+								? 'Locked - disabled in Prowlarr'
+								: indexer.enabled
+									? 'Disable indexer'
+									: 'Enable indexer'}
 					>
 						{#if togglingIds.has(indexer.id)}
 							<Loader2 class="h-4 w-4 animate-spin" />
+						{:else if indexer.orphaned}
+							<RotateCcw class="h-4 w-4 text-error" />
 						{:else if indexer.upstreamEnabled === false}
 							<Lock class="h-4 w-4 text-warning" />
 						{:else if indexer.enabled}

--- a/src/lib/components/indexers/IndexerTable.svelte
+++ b/src/lib/components/indexers/IndexerTable.svelte
@@ -346,7 +346,10 @@
 					<button
 						class="btn btn-ghost btn-xs"
 						onclick={() => onToggle(indexer)}
-						disabled={testingIds.has(indexer.id) || togglingIds.has(indexer.id) || reorderMode || (indexer.upstreamEnabled === false && !indexer.orphaned)}
+						disabled={testingIds.has(indexer.id) ||
+							togglingIds.has(indexer.id) ||
+							reorderMode ||
+							(indexer.upstreamEnabled === false && !indexer.orphaned)}
 						title={indexer.orphaned
 							? 'Deleted from upstream - tap to test connection and restore'
 							: indexer.upstreamEnabled === false

--- a/src/lib/components/indexers/IndexerTable.svelte
+++ b/src/lib/components/indexers/IndexerTable.svelte
@@ -6,6 +6,7 @@
 		GripVertical,
 		FlaskConical,
 		Loader2,
+		Lock,
 		Search,
 		Zap,
 		ToggleLeft,
@@ -266,7 +267,7 @@
 								</span>
 								{#if isProwlarrIndexer(indexer)}
 									<span class="badge badge-xs badge-primary">Prowlarr</span>
-									{#if indexer.settings?.prowlarrEnabled === 'false'}
+									{#if indexer.upstreamEnabled === false}
 										<span class="badge badge-xs badge-warning">Disabled in Prowlarr</span>
 									{/if}
 								{:else if isJackettIndexer(indexer)}
@@ -339,12 +340,14 @@
 					<button
 						class="btn btn-ghost btn-xs"
 						onclick={() => onToggle(indexer)}
-						disabled={testingIds.has(indexer.id) || togglingIds.has(indexer.id) || reorderMode}
-						title={indexer.enabled ? 'Disable' : 'Enable'}
-						aria-label={indexer.enabled ? 'Disable indexer' : 'Enable indexer'}
+						disabled={testingIds.has(indexer.id) || togglingIds.has(indexer.id) || reorderMode || indexer.upstreamEnabled === false}
+						title={indexer.upstreamEnabled === false ? 'Disabled in Prowlarr — enable it there first' : indexer.enabled ? 'Disable' : 'Enable'}
+						aria-label={indexer.upstreamEnabled === false ? 'Locked — disabled in Prowlarr' : indexer.enabled ? 'Disable indexer' : 'Enable indexer'}
 					>
 						{#if togglingIds.has(indexer.id)}
 							<Loader2 class="h-4 w-4 animate-spin" />
+						{:else if indexer.upstreamEnabled === false}
+							<Lock class="h-4 w-4 text-warning" />
 						{:else if indexer.enabled}
 							<ToggleRight class="h-4 w-4 text-success" />
 						{:else}

--- a/src/lib/server/db/migrations/093-add-indexer-upstream-enabled.ts
+++ b/src/lib/server/db/migrations/093-add-indexer-upstream-enabled.ts
@@ -11,9 +11,7 @@ export const migration_v093: MigrationDefinition = {
 		if (!tableExists(sqlite, 'indexers')) return;
 
 		if (!columnExists(sqlite, 'indexers', 'upstream_enabled')) {
-			sqlite
-				.prepare(`ALTER TABLE "indexers" ADD COLUMN "upstream_enabled" integer`)
-				.run();
+			sqlite.prepare(`ALTER TABLE "indexers" ADD COLUMN "upstream_enabled" integer`).run();
 			logger.info('[Migration v093] Added upstream_enabled column to indexers');
 
 			// Backfill from settings JSON for existing Prowlarr-managed indexers.
@@ -29,7 +27,9 @@ export const migration_v093: MigrationDefinition = {
 					 WHERE json_extract("settings", '$.prowlarrEnabled') IS NOT NULL`
 				)
 				.run();
-			logger.info('[Migration v093] Backfilled upstream_enabled from prowlarrEnabled settings field');
+			logger.info(
+				'[Migration v093] Backfilled upstream_enabled from prowlarrEnabled settings field'
+			);
 		}
 	}
 };

--- a/src/lib/server/db/migrations/093-add-indexer-upstream-enabled.ts
+++ b/src/lib/server/db/migrations/093-add-indexer-upstream-enabled.ts
@@ -1,0 +1,35 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+import { columnExists, tableExists } from '../migration-helpers.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'system' as const });
+
+export const migration_v093: MigrationDefinition = {
+	version: 93,
+	name: 'add_indexer_upstream_enabled',
+	apply: (sqlite) => {
+		if (!tableExists(sqlite, 'indexers')) return;
+
+		if (!columnExists(sqlite, 'indexers', 'upstream_enabled')) {
+			sqlite
+				.prepare(`ALTER TABLE "indexers" ADD COLUMN "upstream_enabled" integer`)
+				.run();
+			logger.info('[Migration v093] Added upstream_enabled column to indexers');
+
+			// Backfill from settings JSON for existing Prowlarr-managed indexers.
+			// settings->>'prowlarrEnabled' is stored as the string 'true'/'false'.
+			sqlite
+				.prepare(
+					`UPDATE "indexers"
+					 SET "upstream_enabled" = CASE
+					   WHEN json_extract("settings", '$.prowlarrEnabled') = 'false' THEN 0
+					   WHEN json_extract("settings", '$.prowlarrEnabled') = 'true'  THEN 1
+					   ELSE NULL
+					 END
+					 WHERE json_extract("settings", '$.prowlarrEnabled') IS NOT NULL`
+				)
+				.run();
+			logger.info('[Migration v093] Backfilled upstream_enabled from prowlarrEnabled settings field');
+		}
+	}
+};

--- a/src/lib/server/db/migrations/094-add-indexer-orphaned.ts
+++ b/src/lib/server/db/migrations/094-add-indexer-orphaned.ts
@@ -1,0 +1,20 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+import { columnExists, tableExists } from '../migration-helpers.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'system' as const });
+
+export const migration_v094: MigrationDefinition = {
+	version: 94,
+	name: 'add_indexer_orphaned',
+	apply: (sqlite) => {
+		if (!tableExists(sqlite, 'indexers')) return;
+
+		if (!columnExists(sqlite, 'indexers', 'orphaned')) {
+			sqlite
+				.prepare(`ALTER TABLE "indexers" ADD COLUMN "orphaned" integer NOT NULL DEFAULT 0`)
+				.run();
+			logger.info('[Migration v094] Added orphaned column to indexers');
+		}
+	}
+};

--- a/src/lib/server/db/migrations/index.ts
+++ b/src/lib/server/db/migrations/index.ts
@@ -91,6 +91,7 @@ import { migration_v090 } from './090-add-library-jobs.js';
 import { migration_v091 } from './091-add-download-release-date.js';
 import { migration_v092 } from './092-split-release-date-columns.js';
 import { migration_v093 } from './093-add-indexer-upstream-enabled.js';
+import { migration_v094 } from './094-add-indexer-orphaned.js';
 
 export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v002,
@@ -184,5 +185,6 @@ export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v090,
 	migration_v091,
 	migration_v092,
-	migration_v093
+	migration_v093,
+	migration_v094
 ];

--- a/src/lib/server/db/migrations/index.ts
+++ b/src/lib/server/db/migrations/index.ts
@@ -90,6 +90,7 @@ import { migration_v089 } from './089-add-blocked-keywords-table.js';
 import { migration_v090 } from './090-add-library-jobs.js';
 import { migration_v091 } from './091-add-download-release-date.js';
 import { migration_v092 } from './092-split-release-date-columns.js';
+import { migration_v093 } from './093-add-indexer-upstream-enabled.js';
 
 export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v002,
@@ -182,5 +183,6 @@ export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v089,
 	migration_v090,
 	migration_v091,
-	migration_v092
+	migration_v092,
+	migration_v093
 ];

--- a/src/lib/server/db/schema-sync.ts
+++ b/src/lib/server/db/schema-sync.ts
@@ -121,7 +121,7 @@ import {
  * Version 89: Add blocked keywords table
  * Version 90: Add durable library job tables
  */
-export const CURRENT_SCHEMA_VERSION = 93;
+export const CURRENT_SCHEMA_VERSION = 94;
 
 export const SYSTEM_LIBRARY_SEEDS = [
 	{

--- a/src/lib/server/db/schema-sync.ts
+++ b/src/lib/server/db/schema-sync.ts
@@ -121,7 +121,7 @@ import {
  * Version 89: Add blocked keywords table
  * Version 90: Add durable library job tables
  */
-export const CURRENT_SCHEMA_VERSION = 92;
+export const CURRENT_SCHEMA_VERSION = 93;
 
 export const SYSTEM_LIBRARY_SEEDS = [
 	{

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -232,9 +232,13 @@ export const indexers = sqliteTable(
 		// Enable/disable toggle (user preference)
 		enabled: integer('enabled', { mode: 'boolean' }).default(true),
 		// Upstream enabled state mirrored from Prowlarr on each sync.
-		// null = not managed by an upstream source (Jackett, manual) — treated as true.
+		// null = not managed by an upstream source (Jackett, manual) - treated as true.
 		// false = Prowlarr has this indexer disabled; Cinephage locks it out regardless of `enabled`.
 		upstreamEnabled: integer('upstream_enabled', { mode: 'boolean' }),
+		// True when sync detected the indexer is no longer present in the upstream service
+		// (Prowlarr or Jackett). Soft-marks rather than hard-deletes so the user sees a
+		// "Deleted" badge and can manually remove or re-enable after testing.
+		orphaned: integer('orphaned', { mode: 'boolean' }).default(false),
 		// Selected base URL (from definition's urls array)
 		baseUrl: text('base_url').notNull(),
 		// Alternate URLs for failover (JSON array)

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -229,8 +229,12 @@ export const indexers = sqliteTable(
 		name: text('name').notNull(),
 		// Reference to the YAML definition ID
 		definitionId: text('definition_id').notNull(),
-		// Enable/disable toggle
+		// Enable/disable toggle (user preference)
 		enabled: integer('enabled', { mode: 'boolean' }).default(true),
+		// Upstream enabled state mirrored from Prowlarr on each sync.
+		// null = not managed by an upstream source (Jackett, manual) — treated as true.
+		// false = Prowlarr has this indexer disabled; Cinephage locks it out regardless of `enabled`.
+		upstreamEnabled: integer('upstream_enabled', { mode: 'boolean' }),
 		// Selected base URL (from definition's urls array)
 		baseUrl: text('base_url').notNull(),
 		// Alternate URLs for failover (JSON array)

--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -353,17 +353,14 @@ export class IndexerManager {
 		const statusTracker = getPersistentStatusTracker();
 		const enabledChanged = updates.enabled !== undefined && updates.enabled !== existing.enabled;
 		const upstreamChanged =
-			updates.upstreamEnabled !== undefined &&
-			updates.upstreamEnabled !== existing.upstreamEnabled;
+			updates.upstreamEnabled !== undefined && updates.upstreamEnabled !== existing.upstreamEnabled;
 		const orphanedChanged =
 			updates.orphaned !== undefined && updates.orphaned !== existing.orphaned;
 
 		if (enabledChanged || upstreamChanged || orphanedChanged) {
 			const newEnabled = updates.enabled ?? existing.enabled;
 			const newUpstream =
-				updates.upstreamEnabled !== undefined
-					? updates.upstreamEnabled
-					: existing.upstreamEnabled;
+				updates.upstreamEnabled !== undefined ? updates.upstreamEnabled : existing.upstreamEnabled;
 			const newOrphaned = updates.orphaned !== undefined ? updates.orphaned : existing.orphaned;
 			const effectiveEnabled = newEnabled && (newUpstream ?? true) && !newOrphaned;
 			if (effectiveEnabled) {

--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -232,6 +232,7 @@ export class IndexerManager {
 				definitionId: config.definitionId,
 				enabled: config.enabled,
 				upstreamEnabled: config.upstreamEnabled ?? null,
+				orphaned: config.orphaned ?? false,
 				baseUrl: config.baseUrl ?? defaultUrl,
 				alternateUrls: config.alternateUrls ?? null,
 				priority: config.priority,
@@ -305,6 +306,7 @@ export class IndexerManager {
 		if (updates.name !== undefined) updateData.name = updates.name;
 		if (updates.enabled !== undefined) updateData.enabled = updates.enabled ? 1 : 0;
 		if (updates.upstreamEnabled !== undefined) updateData.upstreamEnabled = updates.upstreamEnabled;
+		if (updates.orphaned !== undefined) updateData.orphaned = updates.orphaned ? 1 : 0;
 		if (updates.baseUrl !== undefined) updateData.baseUrl = updates.baseUrl;
 		if (updates.alternateUrls !== undefined) updateData.alternateUrls = updates.alternateUrls;
 		if (updates.priority !== undefined) updateData.priority = updates.priority;
@@ -353,13 +355,17 @@ export class IndexerManager {
 		const upstreamChanged =
 			updates.upstreamEnabled !== undefined &&
 			updates.upstreamEnabled !== existing.upstreamEnabled;
+		const orphanedChanged =
+			updates.orphaned !== undefined && updates.orphaned !== existing.orphaned;
 
-		if (enabledChanged || upstreamChanged) {
+		if (enabledChanged || upstreamChanged || orphanedChanged) {
 			const newEnabled = updates.enabled ?? existing.enabled;
-			const newUpstream = updates.upstreamEnabled !== undefined
-				? updates.upstreamEnabled
-				: existing.upstreamEnabled;
-			const effectiveEnabled = newEnabled && (newUpstream ?? true);
+			const newUpstream =
+				updates.upstreamEnabled !== undefined
+					? updates.upstreamEnabled
+					: existing.upstreamEnabled;
+			const newOrphaned = updates.orphaned !== undefined ? updates.orphaned : existing.orphaned;
+			const effectiveEnabled = newEnabled && (newUpstream ?? true) && !newOrphaned;
 			if (effectiveEnabled) {
 				statusTracker.enable(id);
 			} else {
@@ -434,7 +440,9 @@ export class IndexerManager {
 		const configs = await this.getIndexers();
 		// Effective enabled = user toggle AND upstream not locked out.
 		// upstreamEnabled === null means no upstream constraint (Jackett / manual).
-		const enabledConfigs = configs.filter((c) => c.enabled && (c.upstreamEnabled ?? true));
+		const enabledConfigs = configs.filter(
+			(c) => c.enabled && (c.upstreamEnabled ?? true) && !c.orphaned
+		);
 
 		// Separate cached from uncached for batch processing
 		const cached: IIndexer[] = [];
@@ -611,6 +619,7 @@ export class IndexerManager {
 			definitionId: row.definitionId,
 			enabled: !!row.enabled,
 			upstreamEnabled: row.upstreamEnabled ?? null,
+			orphaned: !!row.orphaned,
 			baseUrl: row.baseUrl,
 			alternateUrls: row.alternateUrls ?? [],
 			priority: row.priority ?? 25,

--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -231,6 +231,7 @@ export class IndexerManager {
 				name: config.name,
 				definitionId: config.definitionId,
 				enabled: config.enabled,
+				upstreamEnabled: config.upstreamEnabled ?? null,
 				baseUrl: config.baseUrl ?? defaultUrl,
 				alternateUrls: config.alternateUrls ?? null,
 				priority: config.priority,
@@ -303,6 +304,7 @@ export class IndexerManager {
 		const updateData: Record<string, unknown> = {};
 		if (updates.name !== undefined) updateData.name = updates.name;
 		if (updates.enabled !== undefined) updateData.enabled = updates.enabled ? 1 : 0;
+		if (updates.upstreamEnabled !== undefined) updateData.upstreamEnabled = updates.upstreamEnabled;
 		if (updates.baseUrl !== undefined) updateData.baseUrl = updates.baseUrl;
 		if (updates.alternateUrls !== undefined) updateData.alternateUrls = updates.alternateUrls;
 		if (updates.priority !== undefined) updateData.priority = updates.priority;
@@ -343,17 +345,25 @@ export class IndexerManager {
 		this.indexerInstances.delete(id);
 		this.indexerFactory.removeIndexer(id);
 
-		// Update status tracking
+		// Update status tracking.
+		// The effective enabled state is: user `enabled` AND upstream not locked out.
+		// Re-evaluate whenever either flag changes so health polling stays in sync.
 		const statusTracker = getPersistentStatusTracker();
-		if (updates.enabled !== undefined) {
-			// Only change runtime health state when enabled flag actually changes.
-			// Saving unrelated edits should not reset failure/backoff history.
-			if (updates.enabled !== existing.enabled) {
-				if (updates.enabled) {
-					statusTracker.enable(id);
-				} else {
-					statusTracker.disable(id);
-				}
+		const enabledChanged = updates.enabled !== undefined && updates.enabled !== existing.enabled;
+		const upstreamChanged =
+			updates.upstreamEnabled !== undefined &&
+			updates.upstreamEnabled !== existing.upstreamEnabled;
+
+		if (enabledChanged || upstreamChanged) {
+			const newEnabled = updates.enabled ?? existing.enabled;
+			const newUpstream = updates.upstreamEnabled !== undefined
+				? updates.upstreamEnabled
+				: existing.upstreamEnabled;
+			const effectiveEnabled = newEnabled && (newUpstream ?? true);
+			if (effectiveEnabled) {
+				statusTracker.enable(id);
+			} else {
+				statusTracker.disable(id);
 			}
 		}
 		if (updates.priority !== undefined) {
@@ -422,7 +432,9 @@ export class IndexerManager {
 	/** Get all enabled indexer instances with batch optimization */
 	async getEnabledIndexers(): Promise<IIndexer[]> {
 		const configs = await this.getIndexers();
-		const enabledConfigs = configs.filter((c) => c.enabled);
+		// Effective enabled = user toggle AND upstream not locked out.
+		// upstreamEnabled === null means no upstream constraint (Jackett / manual).
+		const enabledConfigs = configs.filter((c) => c.enabled && (c.upstreamEnabled ?? true));
 
 		// Separate cached from uncached for batch processing
 		const cached: IIndexer[] = [];
@@ -598,6 +610,7 @@ export class IndexerManager {
 			name: row.name,
 			definitionId: row.definitionId,
 			enabled: !!row.enabled,
+			upstreamEnabled: row.upstreamEnabled ?? null,
 			baseUrl: row.baseUrl,
 			alternateUrls: row.alternateUrls ?? [],
 			priority: row.priority ?? 25,

--- a/src/lib/server/indexers/jackett/JackettConnectionService.ts
+++ b/src/lib/server/indexers/jackett/JackettConnectionService.ts
@@ -263,18 +263,20 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 		const ji = indexerId ? jackettById.get(indexerId) : undefined;
 
 		if (!ji) {
-			// Removed from Jackett; remove from Cinephage
+			// No longer in Jackett - soft-mark as orphaned rather than hard-delete.
 			try {
-				await manager.deleteIndexer(indexer.id);
-				result.removed += 1;
-				logger.info(
-					{ indexerName: indexer.name, jackettId: indexerId },
-					'[Jackett] Removed indexer deleted in Jackett'
-				);
+				if (!indexer.orphaned) {
+					await manager.updateIndexer(indexer.id, { enabled: false, orphaned: true });
+					result.removed += 1;
+					logger.info(
+						{ indexerName: indexer.name, jackettId: indexerId },
+						'[Jackett] Orphaned indexer no longer in Jackett'
+					);
+				}
 			} catch (err) {
 				result.failed += 1;
 				result.errors.push(
-					`Remove ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+					`Orphan ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
 				);
 			}
 			continue;
@@ -283,6 +285,8 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 		// Still exists in Jackett; sync name and API key
 		const updates: Record<string, unknown> = {};
 		if (ji.name !== indexer.name) updates.name = ji.name;
+		// Clear orphaned flag if the indexer has re-appeared in Jackett
+		if (indexer.orphaned) updates.orphaned = false;
 
 		const existingSettings = indexer.settings as Record<string, unknown> | null;
 		const currentKey = existingSettings?.apikey;

--- a/src/lib/server/indexers/loader/IndexerFactory.ts
+++ b/src/lib/server/indexers/loader/IndexerFactory.ts
@@ -92,6 +92,7 @@ export class IndexerFactory {
 			definitionId: config.definitionId,
 			enabled: config.enabled,
 			upstreamEnabled: config.upstreamEnabled ?? null,
+			orphaned: config.orphaned ?? false,
 			baseUrl: config.baseUrl,
 			alternateUrls: config.alternateUrls ?? null,
 			priority: config.priority ?? 25,

--- a/src/lib/server/indexers/loader/IndexerFactory.ts
+++ b/src/lib/server/indexers/loader/IndexerFactory.ts
@@ -91,6 +91,7 @@ export class IndexerFactory {
 			name: config.name,
 			definitionId: config.definitionId,
 			enabled: config.enabled,
+			upstreamEnabled: config.upstreamEnabled ?? null,
 			baseUrl: config.baseUrl,
 			alternateUrls: config.alternateUrls ?? null,
 			priority: config.priority ?? 25,

--- a/src/lib/server/indexers/loader/YamlIndexerFactory.ts
+++ b/src/lib/server/indexers/loader/YamlIndexerFactory.ts
@@ -71,6 +71,7 @@ export class YamlIndexerFactory implements IIndexerFactory {
 			definitionId: config.definitionId,
 			enabled: config.enabled,
 			upstreamEnabled: config.upstreamEnabled ?? null,
+			orphaned: config.orphaned ?? false,
 			baseUrl: config.baseUrl,
 			alternateUrls: config.alternateUrls ?? null,
 			priority: config.priority ?? 25,

--- a/src/lib/server/indexers/loader/YamlIndexerFactory.ts
+++ b/src/lib/server/indexers/loader/YamlIndexerFactory.ts
@@ -70,6 +70,7 @@ export class YamlIndexerFactory implements IIndexerFactory {
 			name: config.name,
 			definitionId: config.definitionId,
 			enabled: config.enabled,
+			upstreamEnabled: config.upstreamEnabled ?? null,
 			baseUrl: config.baseUrl,
 			alternateUrls: config.alternateUrls ?? null,
 			priority: config.priority ?? 25,

--- a/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
@@ -160,18 +160,21 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 		const pi = prowlarrById.get(prowlarrId);
 
 		if (!pi) {
-			// Deleted in Prowlarr - remove from Cinephage
+			// No longer in Prowlarr - soft-mark as orphaned rather than hard-delete.
+			// The UI shows a "Deleted" badge; re-appearing in a future sync clears the flag.
 			try {
-				await manager.deleteIndexer(indexer.id);
-				result.removed += 1;
-				logger.info(
-					{ indexerName: indexer.name, prowlarrId },
-					'[Prowlarr] Removed indexer deleted in Prowlarr'
-				);
+				if (!indexer.orphaned) {
+					await manager.updateIndexer(indexer.id, { enabled: false, orphaned: true });
+					result.removed += 1;
+					logger.info(
+						{ indexerName: indexer.name, prowlarrId },
+						'[Prowlarr] Orphaned indexer no longer in Prowlarr'
+					);
+				}
 			} catch (err) {
 				result.failed += 1;
 				result.errors.push(
-					`Remove ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
+					`Orphan ${indexer.name}: ${err instanceof Error ? err.message : String(err)}`
 				);
 			}
 			continue;
@@ -183,6 +186,8 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 		const updates: Record<string, unknown> = {};
 		if (pi.name !== indexer.name) updates.name = pi.name;
 		if (pi.enable !== indexer.upstreamEnabled) updates.upstreamEnabled = pi.enable;
+		// If the indexer was previously orphaned but is now back in Prowlarr, clear the flag.
+		if (indexer.orphaned) updates.orphaned = false;
 
 		const existingSettings = indexer.settings as Record<string, unknown> | null;
 		const currentKey = existingSettings?.apikey;

--- a/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
@@ -177,19 +177,19 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 			continue;
 		}
 
-		// Still exists in Prowlarr — sync name, enabled state, API key, and prowlarrEnabled
+		// Still exists in Prowlarr — sync name, upstream enabled state, and API key.
+		// We do NOT touch `enabled` (the user's Cinephage preference) here; only
+		// `upstreamEnabled` tracks what Prowlarr thinks.
 		const updates: Record<string, unknown> = {};
 		if (pi.name !== indexer.name) updates.name = pi.name;
-		if (pi.enable !== indexer.enabled) updates.enabled = pi.enable;
+		if (pi.enable !== indexer.upstreamEnabled) updates.upstreamEnabled = pi.enable;
 
 		const existingSettings = indexer.settings as Record<string, unknown> | null;
 		const currentKey = existingSettings?.apikey;
-		const currentProwlarrEnabled = existingSettings?.prowlarrEnabled;
-		if (currentKey !== conn.apiKey || currentProwlarrEnabled !== pi.enable) {
+		if (currentKey !== conn.apiKey) {
 			updates.settings = {
 				...(existingSettings ?? {}),
-				apikey: conn.apiKey,
-				prowlarrEnabled: pi.enable
+				apikey: conn.apiKey
 			};
 		}
 
@@ -227,9 +227,10 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 					definitionId,
 					baseUrl,
 					alternateUrls: [],
-					enabled: pi.enable === true,
+					enabled: true,
+					upstreamEnabled: pi.enable,
 					priority: 25,
-					settings: { apikey: conn.apiKey, prowlarrEnabled: pi.enable },
+					settings: { apikey: conn.apiKey },
 					enableAutomaticSearch: true,
 					enableInteractiveSearch: true,
 					minimumSeeders: 1,

--- a/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
@@ -79,7 +79,7 @@ export function normalizeProwlarrUrl(url: string): string {
 	return url.replace(/\/+$/, '');
 }
 
-function isIndexerFromConnection(baseUrl: string, prowlarrBase: string): boolean {
+export function isIndexerFromConnection(baseUrl: string, prowlarrBase: string): boolean {
 	if (!baseUrl.startsWith(prowlarrBase + '/')) return false;
 	const suffix = baseUrl.slice(prowlarrBase.length + 1).replace(/\/+$/, '');
 	return /^\d+$/.test(suffix);
@@ -160,7 +160,7 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 		const pi = prowlarrById.get(prowlarrId);
 
 		if (!pi) {
-			// Deleted in Prowlarr — remove from Cinephage
+			// Deleted in Prowlarr - remove from Cinephage
 			try {
 				await manager.deleteIndexer(indexer.id);
 				result.removed += 1;
@@ -177,7 +177,7 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 			continue;
 		}
 
-		// Still exists in Prowlarr — sync name, upstream enabled state, and API key.
+		// Still exists in Prowlarr - sync name, upstream enabled state, and API key.
 		// We do NOT touch `enabled` (the user's Cinephage preference) here; only
 		// `upstreamEnabled` tracks what Prowlarr thinks.
 		const updates: Record<string, unknown> = {};
@@ -279,7 +279,7 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 			}
 		}
 	} catch {
-		// Health passthrough is best-effort — don't fail the sync if it errors
+		// Health passthrough is best-effort - don't fail the sync if it errors
 	}
 
 	conn.lastSyncAt = new Date().toISOString();

--- a/src/lib/server/indexers/types/config.ts
+++ b/src/lib/server/indexers/types/config.ts
@@ -31,11 +31,17 @@ export interface IndexerConfig {
 	enabled: boolean;
 	/**
 	 * Upstream enabled state mirrored from Prowlarr on each sync.
-	 * null = not managed by Prowlarr (Jackett / manual) — no upstream restriction.
+	 * null = not managed by Prowlarr (Jackett / manual) - no upstream restriction.
 	 * false = Prowlarr has this indexer disabled; search and health polling are locked out
 	 *         regardless of the user's `enabled` preference.
 	 */
 	upstreamEnabled?: boolean | null;
+	/**
+	 * True when sync detected the indexer is no longer present in the upstream service.
+	 * Shows a "Deleted" badge in the UI; excluded from searches.
+	 * Cleared automatically if the indexer re-appears in a subsequent sync.
+	 */
+	orphaned?: boolean;
 	/** Base URL (can override definition default) */
 	baseUrl: string;
 	/** Alternative/fallback URLs (tried in order if primary fails) */

--- a/src/lib/server/indexers/types/config.ts
+++ b/src/lib/server/indexers/types/config.ts
@@ -27,8 +27,15 @@ export interface IndexerConfig {
 	name: string;
 	/** Definition ID this instance is based on */
 	definitionId: string;
-	/** Whether the indexer is enabled */
+	/** Whether the indexer is enabled (user preference) */
 	enabled: boolean;
+	/**
+	 * Upstream enabled state mirrored from Prowlarr on each sync.
+	 * null = not managed by Prowlarr (Jackett / manual) — no upstream restriction.
+	 * false = Prowlarr has this indexer disabled; search and health polling are locked out
+	 *         regardless of the user's `enabled` preference.
+	 */
+	upstreamEnabled?: boolean | null;
 	/** Base URL (can override definition default) */
 	baseUrl: string;
 	/** Alternative/fallback URLs (tried in order if primary fails) */

--- a/src/lib/types/indexer.ts
+++ b/src/lib/types/indexer.ts
@@ -133,6 +133,8 @@ export interface Indexer {
 	enabled: boolean;
 	/** null = not Prowlarr-managed; false = disabled in Prowlarr (locked out in Cinephage) */
 	upstreamEnabled?: boolean | null;
+	/** True when sync detected this indexer no longer exists in the upstream service */
+	orphaned?: boolean;
 	baseUrl: string;
 	/** Alternative/fallback URLs (tried in order if primary fails) */
 	alternateUrls: string[];

--- a/src/lib/types/indexer.ts
+++ b/src/lib/types/indexer.ts
@@ -131,6 +131,8 @@ export interface Indexer {
 	name: string;
 	definitionId: string;
 	enabled: boolean;
+	/** null = not Prowlarr-managed; false = disabled in Prowlarr (locked out in Cinephage) */
+	upstreamEnabled?: boolean | null;
 	baseUrl: string;
 	/** Alternative/fallback URLs (tried in order if primary fails) */
 	alternateUrls: string[];

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -28,6 +28,8 @@ export const indexerCreateSchema = z.object({
 	/** Alternative/fallback URLs */
 	alternateUrls: z.array(z.string().url('Must be a valid URL')).default([]),
 	enabled: z.boolean().default(true),
+	/** True when upstream sync detected this indexer no longer exists; cleared on re-appearance */
+	orphaned: z.boolean().optional(),
 	priority: z.number().int().min(1).max(100).default(25),
 	/** User-provided settings for YAML indexers (apiKey, cookie, passkey, etc.) */
 	settings: z

--- a/src/routes/api/indexers/[id]/+server.ts
+++ b/src/routes/api/indexers/[id]/+server.ts
@@ -75,6 +75,7 @@ export const PUT: RequestHandler = async (event) => {
 		const updated = await manager.updateIndexer(params.id, {
 			name: validated.name,
 			enabled: validated.enabled,
+			orphaned: validated.orphaned,
 			baseUrl: validated.baseUrl,
 			alternateUrls: validated.alternateUrls,
 			priority: validated.priority,

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -301,14 +301,14 @@ export const POST: RequestHandler = async (event) => {
 
 			if (source) {
 				try {
-					await manager.updateIndexer(indexerId, { enabled: false });
+					await manager.updateIndexer(indexerId, { enabled: false, orphaned: true });
 				} catch {
 					// Ignore - the error response below is still correct
 				}
 				return json(
 					{
 						success: false,
-						error: `Indexer not found in ${source} - it was likely removed. Auto-disabled in Cinephage; it will be removed on the next sync.`
+						error: `Indexer not found in ${source} - it was likely removed. Marked as deleted; enable it to run a connection test and restore it if it comes back.`
 					},
 					{ status: 400 }
 				);

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -192,6 +192,17 @@ export const POST: RequestHandler = async (event) => {
 		}
 		existingSettings = existing.settings;
 
+		// If Prowlarr has this indexer disabled, skip the test and tell the user where to fix it.
+		if (existing.upstreamEnabled === false) {
+			return json(
+				{
+					success: false,
+					error: 'This indexer is disabled in Prowlarr. Enable it there first, then re-sync.'
+				},
+				{ status: 422 }
+			);
+		}
+
 		// For Jackett-sourced indexers, make a warm-up search against Jackett's Torznab
 		// endpoint before running the Cinephage test. Jackett maintains an internal circuit
 		// breaker per indexer; if FlareSolverr previously failed, Jackett marks the indexer

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -10,6 +10,11 @@ import {
 	isIndexerFromJackett,
 	normalizeJackettUrl
 } from '$lib/server/indexers/jackett/JackettConnectionService.js';
+import {
+	getProwlarrConnection,
+	isIndexerFromConnection,
+	normalizeProwlarrUrl
+} from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
 
 function redactSensitiveDetails(message: string): string {
 	return message
@@ -176,6 +181,7 @@ export const POST: RequestHandler = async (event) => {
 	}
 
 	let existingSettings: Record<string, unknown> | undefined;
+	let existingBaseUrl: string | undefined;
 
 	// If testing an existing saved indexer from overview, verify it exists
 	// so health tracking updates apply only to real indexers.
@@ -191,6 +197,7 @@ export const POST: RequestHandler = async (event) => {
 			);
 		}
 		existingSettings = existing.settings;
+		existingBaseUrl = existing.baseUrl;
 
 		// If Prowlarr has this indexer disabled, skip the test and tell the user where to fix it.
 		if (existing.upstreamEnabled === false) {
@@ -267,7 +274,47 @@ export const POST: RequestHandler = async (event) => {
 		return json({ success: true });
 	} catch (e) {
 		const message = e instanceof Error ? e.message : 'Unknown error';
+		const lower = message.toLowerCase();
 		const apiStandard = inferApiStandard(validated.definitionId);
+
+		// Detect "indexer removed from upstream" and auto-disable to prevent it being
+		// used in searches until the next sync cleans it up.
+		// Patterns: HTTP 404 (Prowlarr and Jackett) or missing caps element (Jackett
+		// returns error XML instead of caps when an indexer is deleted).
+		const looksGone = lower.includes('404') || lower.includes('missing <caps>');
+
+		if (indexerId && existingBaseUrl && looksGone) {
+			const [prowlarrConn, jackettConn2] = await Promise.all([
+				getProwlarrConnection(),
+				getJackettConnection()
+			]);
+
+			let source: string | null = null;
+			if (prowlarrConn) {
+				const prowlarrBase = normalizeProwlarrUrl(prowlarrConn.url);
+				if (isIndexerFromConnection(existingBaseUrl, prowlarrBase)) source = 'Prowlarr';
+			}
+			if (!source && jackettConn2) {
+				const jackettBase = normalizeJackettUrl(jackettConn2.url);
+				if (isIndexerFromJackett(existingBaseUrl, jackettBase)) source = 'Jackett';
+			}
+
+			if (source) {
+				try {
+					await manager.updateIndexer(indexerId, { enabled: false });
+				} catch {
+					// Ignore - the error response below is still correct
+				}
+				return json(
+					{
+						success: false,
+						error: `Indexer not found in ${source} - it was likely removed. Auto-disabled in Cinephage; it will be removed on the next sync.`
+					},
+					{ status: 400 }
+				);
+			}
+		}
+
 		return json(
 			{ success: false, error: toFriendlyTestError(message, apiStandard) },
 			{ status: 400 }

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -62,6 +62,7 @@ export const load: PageServerLoad = async () => {
 			definitionId: config.definitionId,
 			enabled: config.enabled,
 			upstreamEnabled: config.upstreamEnabled ?? null,
+			orphaned: config.orphaned ?? false,
 			baseUrl: displayBaseUrl,
 			alternateUrls: config.alternateUrls,
 			priority: config.priority,

--- a/src/routes/settings/integrations/indexers/+page.server.ts
+++ b/src/routes/settings/integrations/indexers/+page.server.ts
@@ -61,6 +61,7 @@ export const load: PageServerLoad = async () => {
 			name: config.name,
 			definitionId: config.definitionId,
 			enabled: config.enabled,
+			upstreamEnabled: config.upstreamEnabled ?? null,
 			baseUrl: displayBaseUrl,
 			alternateUrls: config.alternateUrls,
 			priority: config.priority,

--- a/src/routes/settings/integrations/indexers/+page.svelte
+++ b/src/routes/settings/integrations/indexers/+page.svelte
@@ -461,6 +461,25 @@
 
 		togglingIds.add(indexer.id);
 		try {
+			// Orphaned indexers: run a silent connection test first.
+			// Pass and we clear orphaned + re-enable; fail and we keep it blocked.
+			if (indexer.orphaned) {
+				toasts.info('Testing connection before restoring...');
+				const passed = await handleTest(indexer, false, false);
+				if (!passed) {
+					toasts.error('Connection test failed - indexer is still unavailable');
+					return;
+				}
+				await updateIndexerById(
+					indexer.id,
+					{ enabled: true, orphaned: false },
+					'Failed to restore indexer'
+				);
+				toasts.success('Connection restored - indexer re-enabled');
+				await invalidateAll();
+				return;
+			}
+
 			await updateIndexerById(
 				indexer.id,
 				{ enabled: !indexer.enabled },


### PR DESCRIPTION
## Summary

Improves how Prowlarr/Jackett-managed indexers are handled when they fall out of sync with the upstream. Tracks whether an indexer is enabled upstream, soft-deletes orphaned entries instead of hard-removing them, and auto-disables orphans when a connection test detects they no longer exist upstream.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Added `upstream_enabled` column to `indexers` table (migration 093); backfills from legacy `settings.prowlarrEnabled` JSON for existing Prowlarr rows
- Added `orphaned` boolean column to `indexers` table (migration 094); orphaned indexers are excluded from searches but preserved in the DB
- `IndexerManager` marks removed managed indexers as orphaned on sync instead of deleting them, and reads/writes `upstreamEnabled`
- Connection test endpoint auto-disables managed indexers the upstream no longer returns
- `IndexerRow` and `IndexerTable` show a lock icon for upstream-disabled indexers and a visual indicator for orphaned ones

## Areas Affected

<!-- Check all that apply -->

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
