### PR TITLE
feat(search): anime-aware filtering, adult categories, and provider c…

### DIFF
--- a/data/indexers/definitions/knaben.yaml
+++ b/data/indexers/definitions/knaben.yaml
@@ -22,6 +22,18 @@ caps:
     '2040': Movies/HD
     '5000': TV
     '5040': TV/HD
+    '6000': XXX
+    '6010': XXX/DVD
+    '6020': XXX/WMV
+    '6030': XXX/XviD
+    '6040': XXX/x264
+    '6045': XXX/UHD
+    '6050': XXX/Pack
+    '6060': XXX/ImgSet
+    '6070': XXX/Other
+    '8000': Other
+    '8010': Other/Misc
+    '8020': Other/Hashed
   categorymappings:
     - id: '3000000'
       cat: '2000'
@@ -76,6 +88,20 @@ search:
         size: '150'
         hide_unsafe: 'true'
         hide_xxx: '{{ .Config.hide_xxx }}'
+
+    # XXX search — override hide_xxx so adult searches always return adult results
+    # regardless of the user's "Hide XXX Content" preference for general browsing
+    - path: /v1
+      method: post
+      categories: [XXX]
+      inputs:
+        query: '{{ .Keywords }}'
+        search_field: title
+        order_by: seeders
+        order_direction: desc
+        size: '150'
+        hide_unsafe: 'true'
+        hide_xxx: 'false'
 
     # General search (all categories)
     - path: /v1

--- a/data/indexers/definitions/limetorrents.yaml
+++ b/data/indexers/definitions/limetorrents.yaml
@@ -53,6 +53,18 @@ caps:
     '2000': Movies
     '5000': TV
     '5070': TV/Anime
+    '6000': XXX
+    '6010': XXX/DVD
+    '6020': XXX/WMV
+    '6030': XXX/XviD
+    '6040': XXX/x264
+    '6045': XXX/UHD
+    '6050': XXX/Pack
+    '6060': XXX/ImgSet
+    '6070': XXX/Other
+    '8000': Other
+    '8010': Other/Misc
+    '8020': Other/Hashed
 
   categorymappings:
     - id: Movies

--- a/data/indexers/definitions/newznab.yaml
+++ b/data/indexers/definitions/newznab.yaml
@@ -41,6 +41,18 @@ caps:
     '5060': TV/Sport
     '5070': TV/Anime
     '5080': TV/Documentary
+    '6000': XXX
+    '6010': XXX/DVD
+    '6020': XXX/WMV
+    '6030': XXX/XviD
+    '6040': XXX/x264
+    '6045': XXX/UHD
+    '6050': XXX/Pack
+    '6060': XXX/ImgSet
+    '6070': XXX/Other
+    '8000': Other
+    '8010': Other/Misc
+    '8020': Other/Hashed
   categorymappings:
     - id: '2000'
       cat: Movies

--- a/data/indexers/definitions/scenetime.yaml
+++ b/data/indexers/definitions/scenetime.yaml
@@ -59,6 +59,18 @@ caps:
     '5040': TV/HD
     '5045': TV/UHD
     '5070': TV/Anime
+    '6000': XXX
+    '6010': XXX/DVD
+    '6020': XXX/WMV
+    '6030': XXX/XviD
+    '6040': XXX/x264
+    '6045': XXX/UHD
+    '6050': XXX/Pack
+    '6060': XXX/ImgSet
+    '6070': XXX/Other
+    '8000': Other
+    '8010': Other/Misc
+    '8020': Other/Hashed
   categorymappings:
     # Movies
     - id: '16'

--- a/data/indexers/definitions/torznab.yaml
+++ b/data/indexers/definitions/torznab.yaml
@@ -40,6 +40,18 @@ caps:
     '5060': TV/Sport
     '5070': TV/Anime
     '5080': TV/Documentary
+    '6000': XXX
+    '6010': XXX/DVD
+    '6020': XXX/WMV
+    '6030': XXX/XviD
+    '6040': XXX/x264
+    '6045': XXX/UHD
+    '6050': XXX/Pack
+    '6060': XXX/ImgSet
+    '6070': XXX/Other
+    '8000': Other
+    '8010': Other/Misc
+    '8020': Other/Hashed
   categorymappings:
     - id: '2000'
       cat: Movies

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -157,9 +157,7 @@ export async function updateTmdbSettings(apiKey: string) {
 }
 
 export interface MetadataProviderSettingsPayload {
-	anilistEnabled?: boolean;
-	malClientId?: string;
-	animeProviderPriority?: Array<'mal' | 'anilist' | 'tmdb'>;
+	animeEnrichmentEnabled?: boolean;
 }
 
 export async function getMetadataProviderSettings() {

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -141,11 +141,6 @@
 		}
 		return links;
 	});
-	const usesAnimeMetadataProvider = $derived(
-		(movie.metadataProvider === 'anilist' && Boolean(movie.providerRefs?.anilist)) ||
-			(movie.metadataProvider === 'mal' && Boolean(movie.providerRefs?.mal))
-	);
-
 	const bestQuality = $derived(getBestQualityFromFiles(movie.files));
 	const isStreamerProfile = $derived(movie.scoringProfileId === 'streamer');
 	const fileStatus = $derived.by(() => {
@@ -303,12 +298,6 @@
 									<span class="hidden sm:inline">•</span>
 								{/if}
 								<span>{formatRuntime(movie.runtime)}</span>
-							{/if}
-							{#if usesAnimeMetadataProvider && movie.studios && movie.studios.length > 0}
-								<span class="hidden sm:inline">•</span>
-								<span class="hidden sm:inline min-w-0 truncate"
-									>Studios: {movie.studios.slice(0, 2).join(', ')}</span
-								>
 							{/if}
 							{#if movie.genres && movie.genres.length > 0}
 								<span class="hidden sm:inline">•</span>

--- a/src/lib/components/library/LibrarySeriesHeader.svelte
+++ b/src/lib/components/library/LibrarySeriesHeader.svelte
@@ -29,7 +29,6 @@
 		tmdbId: number;
 		tvdbId: number | null;
 		imdbId: string | null;
-		metadataProvider?: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
 		providerRefs?: Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null;
 		title: string;
 		year: number | null;
@@ -148,11 +147,6 @@
 		return links;
 	});
 
-	const usesAnimeMetadataProvider = $derived(
-		(series.metadataProvider === 'anilist' && Boolean(series.providerRefs?.anilist)) ||
-			(series.metadataProvider === 'mal' && Boolean(series.providerRefs?.mal))
-	);
-
 	const overview = $derived(tmdbSeries?.overview ?? series.overview);
 	const hasTrailer = $derived(
 		tmdbSeries?.videos?.results?.some(
@@ -225,10 +219,7 @@
 									{formatSeriesStatus(series.status)}
 								</span>
 							{/if}
-							{#if usesAnimeMetadataProvider && series.network}
-								<span class="hidden sm:inline">•</span>
-								<span class="hidden sm:inline min-w-0 truncate">Studios: {series.network}</span>
-							{:else if series.network}
+							{#if series.network}
 								<span class="hidden sm:inline">•</span>
 								<span class="hidden sm:inline">{series.network}</span>
 							{/if}

--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -47,7 +47,6 @@
 		minimumAvailability: string;
 		availabilityDelay: number;
 		wantsSubtitles: boolean;
-		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
 		folderPath?: string;
 	}
 
@@ -60,7 +59,6 @@
 	let minimumAvailability = $state('released');
 	let availabilityDelay = $state(0);
 	let wantsSubtitles = $state(true);
-	let metadataProvider = $state<'auto' | 'tmdb' | 'anilist' | 'mal'>('auto');
 	let moveFilesOnRootChange = $state(false);
 	let moveOptionTouched = $state(false);
 	let folderPath = $state('');
@@ -84,9 +82,6 @@
 	const hasExistingFiles = $derived(movie.hasFile === true);
 	const rootFolderChanged = $derived((rootFolderId || null) !== (movie.rootFolderId ?? null));
 	const canMoveExistingFiles = $derived(hasExistingFiles && rootFolderChanged && !!rootFolderId);
-	const showAnimeMetadataProviderControl = $derived(
-		detectedAnime || metadataProvider === 'anilist' || metadataProvider === 'mal'
-	);
 
 	async function loadAnimeRoutingContext(tmdbId: number) {
 		try {
@@ -134,7 +129,6 @@
 			minimumAvailability = movie.minimumAvailability ?? 'released';
 			availabilityDelay = movie.availabilityDelay ?? 0;
 			wantsSubtitles = movie.wantsSubtitles ?? true;
-			metadataProvider = movie.metadataProvider ?? 'auto';
 			moveFilesOnRootChange = false;
 			moveOptionTouched = false;
 			animeRootWarningShown = false;
@@ -226,7 +220,6 @@
 			minimumAvailability,
 			availabilityDelay,
 			wantsSubtitles,
-			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto',
 			...(folderPathChanged && folderPath.trim() ? { folderPath: folderPath.trim() } : {})
 		});
 	}
@@ -266,25 +259,6 @@
 			description={m.library_editMovie_autoDownloadSubtitlesDesc()}
 			variant="toggle"
 		/>
-
-		{#if showAnimeMetadataProviderControl}
-			<!-- Metadata Provider -->
-			<div class="form-control">
-				<label class="label" for="movie-metadata-provider">
-					<span class="label-text font-medium">Metadata Provider (Anime)</span>
-				</label>
-				<select
-					id="movie-metadata-provider"
-					bind:value={metadataProvider}
-					class="select-bordered select w-full select-sm"
-				>
-					<option value="auto">Auto (inherit from library)</option>
-					<option value="tmdb">TMDB</option>
-					<option value="anilist">AniList</option>
-					<option value="mal">MyAnimeList</option>
-				</select>
-			</div>
-		{/if}
 
 		<!-- Quality Profile -->
 		<div class="form-control">

--- a/src/lib/components/library/SeriesEditModal.svelte
+++ b/src/lib/components/library/SeriesEditModal.svelte
@@ -23,7 +23,6 @@
 		seasonFolder: boolean | null;
 		wantsSubtitles: boolean | null;
 		seriesType: string | null;
-		metadataProvider?: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
 		path?: string | null;
 	}
 
@@ -62,7 +61,6 @@
 		seasonFolder: boolean;
 		wantsSubtitles: boolean;
 		seriesType: 'standard' | 'anime' | 'daily';
-		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
 		folderPath?: string;
 	}
 
@@ -75,7 +73,6 @@
 	let seasonFolder = $state(true);
 	let wantsSubtitles = $state(true);
 	let seriesType = $state<'standard' | 'anime' | 'daily'>('standard');
-	let metadataProvider = $state<'auto' | 'tmdb' | 'anilist' | 'mal'>('auto');
 	let moveFilesOnRootChange = $state(false);
 	let moveOptionTouched = $state(false);
 	let folderPath = $state('');
@@ -99,13 +96,6 @@
 	const hasExistingFiles = $derived((series.episodeFileCount ?? 0) > 0);
 	const rootFolderChanged = $derived((rootFolderId || null) !== (series.rootFolderId ?? null));
 	const canMoveExistingFiles = $derived(hasExistingFiles && rootFolderChanged && !!rootFolderId);
-	const showAnimeMetadataProviderControl = $derived(
-		seriesType === 'anime' ||
-			detectedAnime ||
-			metadataProvider === 'anilist' ||
-			metadataProvider === 'mal'
-	);
-
 	async function loadAnimeRoutingContext(tmdbId: number) {
 		try {
 			const [classificationData, details] = await Promise.all([
@@ -176,7 +166,6 @@
 			seasonFolder = series.seasonFolder ?? true;
 			wantsSubtitles = series.wantsSubtitles ?? true;
 			seriesType = normalizeSeriesType(series.seriesType);
-			metadataProvider = series.metadataProvider ?? 'auto';
 			moveFilesOnRootChange = false;
 			moveOptionTouched = false;
 			animeRootWarningShown = false;
@@ -250,7 +239,6 @@
 			seasonFolder,
 			wantsSubtitles,
 			seriesType,
-			metadataProvider: showAnimeMetadataProviderControl ? metadataProvider : 'auto',
 			...(folderPathChanged && folderPath.trim() ? { folderPath: folderPath.trim() } : {})
 		});
 	}
@@ -320,25 +308,6 @@
 				</span>
 			</div>
 		</div>
-
-		{#if showAnimeMetadataProviderControl}
-			<!-- Metadata Provider -->
-			<div class="form-control">
-				<label class="label" for="series-metadata-provider">
-					<span class="label-text font-medium">Metadata Provider (Anime)</span>
-				</label>
-				<select
-					id="series-metadata-provider"
-					bind:value={metadataProvider}
-					class="select-bordered select w-full select-sm"
-				>
-					<option value="auto">Auto (inherit from library)</option>
-					<option value="tmdb">TMDB</option>
-					<option value="anilist">AniList</option>
-					<option value="mal">MyAnimeList</option>
-				</select>
-			</div>
-		{/if}
 
 		<!-- Quality Profile -->
 		<div class="form-control">

--- a/src/lib/components/library/tv/TVSeriesSidebar.svelte
+++ b/src/lib/components/library/tv/TVSeriesSidebar.svelte
@@ -37,8 +37,6 @@
 	const providerLinkRows = $derived.by(() => {
 		const isAnimeItem =
 			(series.rootFolderPath ?? '').toLowerCase().includes('/anime/') ||
-			series.metadataProvider === 'anilist' ||
-			series.metadataProvider === 'mal' ||
 			Boolean(series.providerRefs?.anilist) ||
 			Boolean(series.providerRefs?.mal);
 		if (!isAnimeItem) return [];

--- a/src/lib/components/search/InteractiveSearchModal.svelte
+++ b/src/lib/components/search/InteractiveSearchModal.svelte
@@ -32,12 +32,21 @@
 		message: string;
 	}
 
+	interface FilterBreakdown {
+		afterSeasonEpisode: number;
+		afterCategory: number;
+		afterNonVideo: number;
+		afterIdTitle: number;
+	}
+
 	interface SearchMeta {
 		totalResults: number;
 		/** Results after first deduplication */
 		afterDedup?: number;
 		/** Results after season/category filtering */
 		afterFiltering?: number;
+		/** Per-step filter breakdown */
+		filterBreakdown?: FilterBreakdown;
 		/** Results after enrichment and smart dedup */
 		afterEnrichment?: number;
 		rejectedCount?: number;

--- a/src/lib/components/search/SearchStats.svelte
+++ b/src/lib/components/search/SearchStats.svelte
@@ -32,10 +32,18 @@
 		message: string;
 	}
 
+	interface FilterBreakdown {
+		afterSeasonEpisode: number;
+		afterCategory: number;
+		afterNonVideo: number;
+		afterIdTitle: number;
+	}
+
 	interface SearchMeta {
 		totalResults: number;
 		afterDedup?: number;
 		afterFiltering?: number;
+		filterBreakdown?: FilterBreakdown;
 		afterEnrichment?: number;
 		rejectedCount?: number;
 		searchTimeMs: number;
@@ -186,6 +194,41 @@
 								{/if}</span
 							>
 						</div>
+						{#if meta.filterBreakdown && meta.afterDedup !== undefined && meta.afterFiltering < meta.afterDedup}
+							<div class="ml-4 space-y-0.5 text-xs text-base-content/60">
+								<div class="flex justify-between">
+									<span>&#9500; after season/episode:</span>
+									<span class="font-mono">{meta.filterBreakdown.afterSeasonEpisode}</span>
+								</div>
+								<div
+									class="flex justify-between {meta.filterBreakdown.afterCategory <
+									meta.filterBreakdown.afterSeasonEpisode
+										? 'text-error/70'
+										: ''}"
+								>
+									<span>&#9500; after category:</span>
+									<span class="font-mono">{meta.filterBreakdown.afterCategory}</span>
+								</div>
+								<div
+									class="flex justify-between {meta.filterBreakdown.afterNonVideo <
+									meta.filterBreakdown.afterCategory
+										? 'text-error/70'
+										: ''}"
+								>
+									<span>&#9500; after non-video filter:</span>
+									<span class="font-mono">{meta.filterBreakdown.afterNonVideo}</span>
+								</div>
+								<div
+									class="flex justify-between {meta.filterBreakdown.afterIdTitle <
+									meta.filterBreakdown.afterNonVideo
+										? 'text-error/70'
+										: ''}"
+								>
+									<span>&#9492; after ID/title match:</span>
+									<span class="font-mono">{meta.filterBreakdown.afterIdTitle}</span>
+								</div>
+							</div>
+						{/if}
 					{/if}
 					{#if meta.afterEnrichment !== undefined}
 						<div class="flex justify-between">

--- a/src/lib/server/db/migrations/095-drop-provider-choice-columns.ts
+++ b/src/lib/server/db/migrations/095-drop-provider-choice-columns.ts
@@ -1,0 +1,47 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+import { columnExists, tableExists } from '../migration-helpers.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'system' as const });
+
+export const migration_v095: MigrationDefinition = {
+	version: 95,
+	name: 'drop_provider_choice_columns',
+	apply: (sqlite) => {
+		// Drop indexes referencing the columns before dropping the columns themselves.
+		// SQLite refuses to drop a column while a covering index still references it.
+		sqlite.prepare(`DROP INDEX IF EXISTS "idx_libraries_metadata_provider"`).run();
+		sqlite.prepare(`DROP INDEX IF EXISTS "idx_movies_metadata_provider"`).run();
+		sqlite.prepare(`DROP INDEX IF EXISTS "idx_series_metadata_provider"`).run();
+
+		if (
+			tableExists(sqlite, 'libraries') &&
+			columnExists(sqlite, 'libraries', 'metadata_provider')
+		) {
+			sqlite.prepare(`ALTER TABLE "libraries" DROP COLUMN "metadata_provider"`).run();
+			logger.info('[Migration v095] Dropped metadata_provider from libraries');
+		}
+
+		if (tableExists(sqlite, 'movies')) {
+			if (columnExists(sqlite, 'movies', 'metadata_provider')) {
+				sqlite.prepare(`ALTER TABLE "movies" DROP COLUMN "metadata_provider"`).run();
+				logger.info('[Migration v095] Dropped metadata_provider from movies');
+			}
+			if (columnExists(sqlite, 'movies', 'pinned_external')) {
+				sqlite.prepare(`ALTER TABLE "movies" DROP COLUMN "pinned_external"`).run();
+				logger.info('[Migration v095] Dropped pinned_external from movies');
+			}
+		}
+
+		if (tableExists(sqlite, 'series')) {
+			if (columnExists(sqlite, 'series', 'metadata_provider')) {
+				sqlite.prepare(`ALTER TABLE "series" DROP COLUMN "metadata_provider"`).run();
+				logger.info('[Migration v095] Dropped metadata_provider from series');
+			}
+			if (columnExists(sqlite, 'series', 'pinned_external')) {
+				sqlite.prepare(`ALTER TABLE "series" DROP COLUMN "pinned_external"`).run();
+				logger.info('[Migration v095] Dropped pinned_external from series');
+			}
+		}
+	}
+};

--- a/src/lib/server/db/migrations/096-add-adult-columns.ts
+++ b/src/lib/server/db/migrations/096-add-adult-columns.ts
@@ -1,0 +1,41 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+import { columnExists, tableExists } from '../migration-helpers.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'system' as const });
+
+export const migration_v096: MigrationDefinition = {
+	version: 96,
+	name: 'add_adult_columns',
+	apply: (sqlite) => {
+		if (tableExists(sqlite, 'movies')) {
+			if (!columnExists(sqlite, 'movies', 'adult')) {
+				sqlite.prepare(`ALTER TABLE "movies" ADD COLUMN "adult" integer NOT NULL DEFAULT 0`).run();
+				logger.info('[Migration v096] Added adult column to movies');
+			}
+			if (!columnExists(sqlite, 'movies', 'adult_source')) {
+				sqlite.prepare(`ALTER TABLE "movies" ADD COLUMN "adult_source" text`).run();
+				logger.info('[Migration v096] Added adult_source column to movies');
+			}
+			if (!columnExists(sqlite, 'movies', 'adult_confidence')) {
+				sqlite.prepare(`ALTER TABLE "movies" ADD COLUMN "adult_confidence" text`).run();
+				logger.info('[Migration v096] Added adult_confidence column to movies');
+			}
+		}
+
+		if (tableExists(sqlite, 'series')) {
+			if (!columnExists(sqlite, 'series', 'adult')) {
+				sqlite.prepare(`ALTER TABLE "series" ADD COLUMN "adult" integer NOT NULL DEFAULT 0`).run();
+				logger.info('[Migration v096] Added adult column to series');
+			}
+			if (!columnExists(sqlite, 'series', 'adult_source')) {
+				sqlite.prepare(`ALTER TABLE "series" ADD COLUMN "adult_source" text`).run();
+				logger.info('[Migration v096] Added adult_source column to series');
+			}
+			if (!columnExists(sqlite, 'series', 'adult_confidence')) {
+				sqlite.prepare(`ALTER TABLE "series" ADD COLUMN "adult_confidence" text`).run();
+				logger.info('[Migration v096] Added adult_confidence column to series');
+			}
+		}
+	}
+};

--- a/src/lib/server/db/migrations/index.ts
+++ b/src/lib/server/db/migrations/index.ts
@@ -92,6 +92,8 @@ import { migration_v091 } from './091-add-download-release-date.js';
 import { migration_v092 } from './092-split-release-date-columns.js';
 import { migration_v093 } from './093-add-indexer-upstream-enabled.js';
 import { migration_v094 } from './094-add-indexer-orphaned.js';
+import { migration_v095 } from './095-drop-provider-choice-columns.js';
+import { migration_v096 } from './096-add-adult-columns.js';
 
 export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v002,
@@ -186,5 +188,7 @@ export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v091,
 	migration_v092,
 	migration_v093,
-	migration_v094
+	migration_v094,
+	migration_v095,
+	migration_v096
 ];

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -627,7 +627,6 @@ export const libraries = sqliteTable(
 		defaultWantsSubtitles: integer('default_wants_subtitles', { mode: 'boolean' })
 			.notNull()
 			.default(true),
-		metadataProvider: text('metadata_provider').notNull().default('auto'),
 		sortOrder: integer('sort_order').notNull().default(0),
 		createdAt: text('created_at').$defaultFn(() => new Date().toISOString()),
 		updatedAt: text('updated_at').$defaultFn(() => new Date().toISOString())
@@ -681,14 +680,9 @@ export const movies = sqliteTable(
 		backdropPath: text('backdrop_path'),
 		runtime: integer('runtime'), // Minutes
 		genres: text('genres', { mode: 'json' }).$type<string[]>(),
-		metadataProvider: text('metadata_provider').notNull().default('auto'),
 		providerRefs: text('provider_refs', { mode: 'json' }).$type<
 			Partial<Record<'tmdb' | 'mal' | 'anilist', string>>
 		>(),
-		pinnedExternal: text('pinned_external', { mode: 'json' }).$type<{
-			provider: 'tmdb' | 'mal' | 'anilist';
-			id: string;
-		}>(),
 		// Path to the movie folder (relative to root folder)
 		path: text('path').notNull(),
 		libraryId: text('library_id').references(() => libraries.id, { onDelete: 'set null' }),
@@ -721,7 +715,10 @@ export const movies = sqliteTable(
 		downloadReleaseType: text('download_release_type'),
 		digitalReleaseDate: text('digital_release_date'),
 		physicalReleaseDate: text('physical_release_date'),
-		availabilityDelay: integer('availability_delay').notNull().default(0)
+		availabilityDelay: integer('availability_delay').notNull().default(0),
+		adult: integer('adult', { mode: 'boolean' }).default(false),
+		adultSource: text('adult_source'),
+		adultConfidence: text('adult_confidence')
 	},
 	(table) => [
 		index('idx_movies_monitored_hasfile').on(table.monitored, table.hasFile),
@@ -805,14 +802,9 @@ export const series = sqliteTable(
 		status: text('status'), // 'Continuing', 'Ended', 'Upcoming'
 		network: text('network'),
 		genres: text('genres', { mode: 'json' }).$type<string[]>(),
-		metadataProvider: text('metadata_provider').notNull().default('auto'),
 		providerRefs: text('provider_refs', { mode: 'json' }).$type<
 			Partial<Record<'tmdb' | 'mal' | 'anilist', string>>
 		>(),
-		pinnedExternal: text('pinned_external', { mode: 'json' }).$type<{
-			provider: 'tmdb' | 'mal' | 'anilist';
-			id: string;
-		}>(),
 		// Path to the series folder (relative to root folder)
 		path: text('path').notNull(),
 		libraryId: text('library_id').references(() => libraries.id, { onDelete: 'set null' }),
@@ -839,7 +831,10 @@ export const series = sqliteTable(
 		episodeFileCount: integer('episode_file_count').default(0),
 		// Whether to search for subtitles for this series (inherited by episodes by default)
 		wantsSubtitles: integer('wants_subtitles', { mode: 'boolean' }).default(true),
-		firstAirDate: text('first_air_date')
+		firstAirDate: text('first_air_date'),
+		adult: integer('adult', { mode: 'boolean' }).default(false),
+		adultSource: text('adult_source'),
+		adultConfidence: text('adult_confidence')
 	},
 	(table) => [
 		index('idx_series_monitored').on(table.monitored),

--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -541,20 +541,11 @@ export class IndexerManager {
 		}
 
 		const startedAt = Date.now();
-		try {
-			await instance.test();
+		await instance.test();
 
-			// If this test is for an existing saved indexer, update health status on success.
-			if (statusIndexerId) {
-				await getPersistentStatusTracker().recordSuccess(statusIndexerId, Date.now() - startedAt);
-			}
-		} catch (error) {
-			// Reflect manual test failures in health status for existing indexers.
-			if (statusIndexerId) {
-				const message = error instanceof Error ? error.message : String(error);
-				await getPersistentStatusTracker().recordFailure(statusIndexerId, message);
-			}
-			throw error;
+		// If this test is for an existing saved indexer, update health status on success.
+		if (statusIndexerId) {
+			await getPersistentStatusTracker().recordSuccess(statusIndexerId, Date.now() - startedAt);
 		}
 	}
 

--- a/src/lib/server/indexers/engine/TemplateEngine.ts
+++ b/src/lib/server/indexers/engine/TemplateEngine.ts
@@ -291,6 +291,7 @@ export class TemplateEngine {
 			'Episode.Standard',
 			'Episode.European',
 			'Episode.Compact',
+			'Episode.Absolute',
 			// Music
 			'Album',
 			'Artist',
@@ -348,14 +349,26 @@ export class TemplateEngine {
 			const standardFormat = generateEpisodeFormat(season, criteria.episode, 'standard');
 			const europeanFormat = generateEpisodeFormat(season, criteria.episode, 'european');
 			const compactFormat = generateEpisodeFormat(season, criteria.episode, 'compact');
+			// Absolute format: use the episode number directly (zero-padded) for anime
+			const absoluteFormat = generateEpisodeFormat(
+				season,
+				criteria.episode,
+				'absolute',
+				criteria.episode
+			);
 
 			// Set format-specific variables for YAML templates
 			this.variables.set('.Query.Episode.Standard', standardFormat);
 			this.variables.set('.Query.Episode.European', europeanFormat);
 			this.variables.set('.Query.Episode.Compact', compactFormat);
+			this.variables.set('.Query.Episode.Absolute', absoluteFormat);
 
-			// Get the preferred format value for .Query.Episode and keywords
-			const preferredFormatValue = generateEpisodeFormat(season, criteria.episode, preferredFormat);
+			// Get the preferred format value for .Query.Episode and keywords.
+			// For 'absolute' format pass the episode as the absolute episode number.
+			const preferredFormatValue =
+				preferredFormat === 'absolute'
+					? absoluteFormat
+					: generateEpisodeFormat(season, criteria.episode, preferredFormat);
 
 			// Default .Query.Episode uses the preferred format (or falls back to standard)
 			this.variables.set('.Query.Episode', preferredFormatValue ?? standardFormat);

--- a/src/lib/server/indexers/jackett/JackettConnectionService.ts
+++ b/src/lib/server/indexers/jackett/JackettConnectionService.ts
@@ -362,3 +362,26 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 	);
 	return result;
 }
+
+/**
+ * Push the current connection API key to every Jackett-sourced indexer that
+ * still has the old key.  Called immediately when connection settings are saved
+ * with a new API key so searches don't 401 until the next scheduled sync.
+ */
+export async function propagateJackettApiKey(newApiKey: string): Promise<void> {
+	const conn = await getJackettConnection();
+	if (!conn) return;
+
+	const jackettBase = normalizeJackettUrl(conn.url);
+	const manager = await getIndexerManager();
+	const indexers = await manager.getIndexers();
+
+	for (const indexer of indexers) {
+		if (!isIndexerFromJackett(indexer.baseUrl, jackettBase)) continue;
+		const existing = indexer.settings as Record<string, unknown> | null;
+		if ((existing?.apikey ?? '') === newApiKey) continue;
+		await manager.updateIndexer(indexer.id, {
+			settings: { ...(existing ?? {}), apikey: newApiKey }
+		});
+	}
+}

--- a/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
+++ b/src/lib/server/indexers/prowlarr/ProwlarrConnectionService.ts
@@ -303,3 +303,26 @@ export async function syncProwlarrIndexers(): Promise<SyncResult> {
 	);
 	return result;
 }
+
+/**
+ * Push the current connection API key to every Prowlarr-sourced indexer that
+ * still has the old key.  Called immediately when connection settings are saved
+ * with a new API key so searches don't 401 until the next scheduled sync.
+ */
+export async function propagateProwlarrApiKey(newApiKey: string): Promise<void> {
+	const conn = await getProwlarrConnection();
+	if (!conn) return;
+
+	const prowlarrBase = normalizeProwlarrUrl(conn.url);
+	const manager = await getIndexerManager();
+	const indexers = await manager.getIndexers();
+
+	for (const indexer of indexers) {
+		if (!isIndexerFromConnection(indexer.baseUrl, prowlarrBase)) continue;
+		const existing = indexer.settings as Record<string, unknown> | null;
+		if ((existing?.apikey ?? '') === newApiKey) continue;
+		await manager.updateIndexer(indexer.id, {
+			settings: { ...(existing ?? {}), apikey: newApiKey }
+		});
+	}
+}

--- a/src/lib/server/indexers/runtime/UnifiedIndexer.ts
+++ b/src/lib/server/indexers/runtime/UnifiedIndexer.ts
@@ -639,8 +639,9 @@ export class UnifiedIndexer implements IIndexer {
 	 * Example: Newznab returns <error code="100" description="..." /> with HTTP 200.
 	 */
 	private detectProviderError(content: string): string | null {
-		// Newznab-compatible providers commonly return structured API errors in XML.
-		if (this.definition.id === 'newznab') {
+		// Both Newznab and Torznab use the same <error code="N" description="..."/> XML format.
+		const defId = this.definition.id;
+		if (defId === 'newznab' || defId === 'torznab') {
 			const errorMatch = content.match(/<error\b([^>]*)\/?>/i);
 			if (!errorMatch) return null;
 

--- a/src/lib/server/indexers/search/SearchFormatProvider.ts
+++ b/src/lib/server/indexers/search/SearchFormatProvider.ts
@@ -58,6 +58,12 @@ export const DEFAULT_SEARCH_FORMATS: Required<SearchFormats> = {
  */
 export const ALL_EPISODE_FORMATS: EpisodeFormatType[] = ['standard', 'european', 'compact'];
 
+/**
+ * Episode formats for anime searches.
+ * Anime releases typically use absolute episode numbers (01, 02...) instead of S01E01.
+ */
+export const ANIME_EPISODE_FORMATS: EpisodeFormatType[] = ['standard', 'absolute'];
+
 // =============================================================================
 // EPISODE FORMAT GENERATION
 // =============================================================================
@@ -129,9 +135,9 @@ export function generateEpisodeFormat(
 			return null;
 
 		case 'absolute':
-			// Absolute episode number (for anime)
+			// Absolute episode number for anime (zero-padded: 01, 02, ..., 99, 100)
 			if (absoluteEpisode !== undefined) {
-				return String(absoluteEpisode);
+				return String(absoluteEpisode).padStart(2, '0');
 			}
 			return null;
 
@@ -158,12 +164,11 @@ export function getEpisodeFormats(
 	}
 
 	for (const type of formatTypes) {
-		const value = generateEpisodeFormat(
-			criteria.season,
-			criteria.episode,
-			type
-			// TODO: Add absoluteEpisode and airDate when we support anime/daily shows
-		);
+		// For absolute format, use the episode number as the absolute episode number.
+		// This is exact for S01 and an approximation for later seasons, but is correct
+		// for most anime (single-season series or shows with continuous absolute numbering).
+		const absoluteEpisode = type === 'absolute' ? criteria.episode : undefined;
+		const value = generateEpisodeFormat(criteria.season, criteria.episode, type, absoluteEpisode);
 
 		if (value !== null) {
 			formats.push({

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -359,8 +359,11 @@ export class SearchOrchestrator {
 		// (season/episode fields are unchanged from original criteria)
 		let filtered = this.filterBySeasonEpisode(deduped, criteriaWithSource);
 
-		// Filter by category match (reject releases in wrong categories)
-		if (criteria.searchType !== 'basic') {
+		// Filter by category match (reject releases in wrong categories).
+		// Skip for season-only TV searches: the season/episode filter already validated
+		// these releases as season packs, and indexer categories are an unreliable signal
+		// for packs (see isSeasonOnlyTvSearch).
+		if (criteria.searchType !== 'basic' && !this.isSeasonOnlyTvSearch(criteriaWithSource)) {
 			const searchType = criteria.searchType as 'movie' | 'tv' | 'music' | 'book';
 			filtered = this.filterByCategoryMatch(filtered, searchType, criteriaWithSource);
 		}
@@ -552,8 +555,11 @@ export class SearchOrchestrator {
 			'[SearchOrchestrator] DEBUG: after season/episode filter'
 		);
 
-		// Filter by category match (reject releases in wrong categories)
-		if (enrichedCriteria.searchType !== 'basic') {
+		// Filter by category match (reject releases in wrong categories).
+		// Skip for season-only TV searches: the season/episode filter already validated
+		// these releases as season packs, and indexer categories are an unreliable signal
+		// for packs (see isSeasonOnlyTvSearch).
+		if (enrichedCriteria.searchType !== 'basic' && !this.isSeasonOnlyTvSearch(enrichedCriteria)) {
 			const searchType = enrichedCriteria.searchType as 'movie' | 'tv' | 'music' | 'book';
 			filtered = this.filterByCategoryMatch(filtered, searchType, enrichedCriteria);
 		}
@@ -2025,6 +2031,19 @@ export class SearchOrchestrator {
 			return `E${String(episode).padStart(2, '0')}`;
 		}
 		return `S${String(season).padStart(2, '0')}E${String(episode).padStart(2, '0')}`;
+	}
+
+	/**
+	 * Whether this is a TV search scoped to a whole season (season set, no episode).
+	 * Used to bypass {@link filterByCategoryMatch}: by the time it would run,
+	 * {@link filterBySeasonEpisode} has already validated these releases as season packs
+	 * via strict title parsing. Indexer categories are unreliable for packs (often filed as
+	 * Movies/XXX/Other on Jackett/Prowlarr and other aggregators), so applying the broad
+	 * category guard to this already-narrow set can wipe out every pack and yield zero
+	 * results. The title/season match is the authoritative signal here.
+	 */
+	private isSeasonOnlyTvSearch(criteria: SearchCriteria): boolean {
+		return isTvSearch(criteria) && criteria.season !== undefined && criteria.episode === undefined;
 	}
 
 	/**

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -23,12 +23,15 @@ import {
 	indexerHasCategoriesForSearchType,
 	categoryMatchesSearchType,
 	getCategoryContentType,
+	isXxxCategory,
+	isMovieCategory,
 	CINEPHAGE_STREAM_DEFINITION_ID
 } from '../types';
 
 import {
 	getEffectiveEpisodeFormats,
 	getEpisodeFormats,
+	ANIME_EPISODE_FORMATS,
 	type EpisodeFormat
 } from './SearchFormatProvider';
 import { getPersistentStatusTracker, type PersistentStatusTracker } from '../status';
@@ -76,6 +79,13 @@ export interface SearchOrchestratorOptions {
 }
 
 /** Enhanced search result with enriched releases */
+export interface FilterBreakdown {
+	afterSeasonEpisode: number;
+	afterCategory: number;
+	afterNonVideo: number;
+	afterIdTitle: number;
+}
+
 export interface EnhancedSearchResult {
 	/** Enriched releases (parsed, scored, optionally TMDB-matched) */
 	releases: EnhancedReleaseResult[];
@@ -85,6 +95,8 @@ export interface EnhancedSearchResult {
 	afterDedup?: number;
 	/** Results after season/category filtering (before enrichment) */
 	afterFiltering?: number;
+	/** Per-step breakdown of how many results survived each filter */
+	filterBreakdown?: FilterBreakdown;
 	/** Results after enrichment (before limit applied) */
 	afterEnrichment?: number;
 	/** Number of releases rejected by quality filter */
@@ -350,9 +362,14 @@ export class SearchOrchestrator {
 		// Filter by category match (reject releases in wrong categories)
 		if (criteria.searchType !== 'basic') {
 			const searchType = criteria.searchType as 'movie' | 'tv' | 'music' | 'book';
-			filtered = this.filterByCategoryMatch(filtered, searchType);
+			filtered = this.filterByCategoryMatch(filtered, searchType, criteriaWithSource);
 		}
 		filtered = this.filterOutNonVideoArtifacts(filtered, criteriaWithSource);
+
+		// Hard filter by ID match with title+year fallback (same as searchEnhanced path).
+		if (isMovieSearch(criteriaWithSource) || isTvSearch(criteriaWithSource)) {
+			filtered = this.filterByIdOrTitleMatch(filtered, criteriaWithSource);
+		}
 
 		// Boost releases matching preferred language
 		filtered = this.boostByLanguage(filtered, criteriaWithSource);
@@ -529,24 +546,27 @@ export class SearchOrchestrator {
 			seasonEpisodeCount,
 			seasonEpisodeCounts
 		});
+		const afterSeasonEpisodeCount = filtered.length;
 		logger.debug(
-			{ afterSeasonEpisode: filtered.length },
+			{ afterSeasonEpisode: afterSeasonEpisodeCount },
 			'[SearchOrchestrator] DEBUG: after season/episode filter'
 		);
 
 		// Filter by category match (reject releases in wrong categories)
 		if (enrichedCriteria.searchType !== 'basic') {
 			const searchType = enrichedCriteria.searchType as 'movie' | 'tv' | 'music' | 'book';
-			filtered = this.filterByCategoryMatch(filtered, searchType);
+			filtered = this.filterByCategoryMatch(filtered, searchType, enrichedCriteria);
 		}
+		const afterCategoryCount = filtered.length;
 		logger.debug(
-			{ afterCategory: filtered.length },
+			{ afterCategory: afterCategoryCount },
 			'[SearchOrchestrator] DEBUG: after category filter'
 		);
 
 		filtered = this.filterOutNonVideoArtifacts(filtered, enrichedCriteria);
+		const afterNonVideoCount = filtered.length;
 		logger.debug(
-			{ afterNonVideo: filtered.length },
+			{ afterNonVideo: afterNonVideoCount },
 			'[SearchOrchestrator] DEBUG: after non-video filter'
 		);
 
@@ -555,8 +575,9 @@ export class SearchOrchestrator {
 		if (isMovieSearch(enrichedCriteria) || isTvSearch(enrichedCriteria)) {
 			filtered = this.filterByIdOrTitleMatch(filtered, enrichedCriteria);
 		}
+		const afterIdTitleCount = filtered.length;
 		logger.debug(
-			{ afterIdTitle: filtered.length },
+			{ afterIdTitle: afterIdTitleCount },
 			'[SearchOrchestrator] DEBUG: after ID/title filter'
 		);
 
@@ -631,6 +652,12 @@ export class SearchOrchestrator {
 			totalResults: allReleases.length,
 			afterDedup: afterDedupCount,
 			afterFiltering: afterFilteringCount,
+			filterBreakdown: {
+				afterSeasonEpisode: afterSeasonEpisodeCount,
+				afterCategory: afterCategoryCount,
+				afterNonVideo: afterNonVideoCount,
+				afterIdTitle: afterIdTitleCount
+			},
 			afterEnrichment: afterEnrichmentCount,
 			rejectedCount: enrichResult.rejectedCount,
 			searchTimeMs,
@@ -1030,8 +1057,13 @@ export class SearchOrchestrator {
 				'Indexer search failed'
 			);
 
-			// Record failure
-			await this.statusTracker.recordFailure(indexer.id, message);
+			// Timeouts are caused by slow upstream aggregators (Prowlarr/Jackett gathering
+			// results across many trackers) and don't mean the indexer is broken.
+			// Only record a failure for actual errors, not search timeouts.
+			const isTimeout = message.toLowerCase().includes('timeout');
+			if (!isTimeout) {
+				await this.statusTracker.recordFailure(indexer.id, message);
+			}
 
 			return {
 				indexerId: indexer.id,
@@ -1183,7 +1215,13 @@ export class SearchOrchestrator {
 					indexer.capabilities.searchFormats?.episode,
 					true
 				);
-				episodeFormats = getEpisodeFormats(criteria, formatTypes);
+				// Anime uses absolute episode numbering (01, 02...) in addition to standard
+				// S01E05. Merge absolute into the format list so both query variants are tried.
+				const effectiveFormats =
+					criteria.isAnime && hasEpisode
+						? [...new Set([...formatTypes, ...ANIME_EPISODE_FORMATS])]
+						: formatTypes;
+				episodeFormats = getEpisodeFormats(criteria, effectiveFormats);
 			}
 		}
 
@@ -1628,9 +1666,10 @@ export class SearchOrchestrator {
 			return true;
 		};
 
-		// Season-only search: filter to single-season packs matching the target season
+		// Season-only search: filter to single-season packs matching the target season.
 		if (targetSeason !== undefined && targetEpisode === undefined) {
-			return parsedReleases
+			const isAnimeSearch = isTvSearch(criteria) && !!criteria.isAnime;
+			const parsedMatches = parsedReleases
 				.filter(
 					({ release, episodeInfo }) =>
 						episodeInfo.isSeasonPack &&
@@ -1642,18 +1681,52 @@ export class SearchOrchestrator {
 						)
 				)
 				.map(({ release }) => this.withFormattedSeasonPackTitle(release));
+
+			if (!isAnimeSearch) {
+				return parsedMatches;
+			}
+
+			// Anime trackers use non-standard pack formats like "[01-08 END]" that the
+			// episode parser cannot classify (episodeInfo=null). These are overwhelmingly
+			// season/series packs rather than individual episodes, so include them and let
+			// the title filter reject releases that don't match the show name.
+			// The _parsedRelease cache is already populated by the parsedReleases map above.
+			const animeUnparsedReleases = releases.filter((release) => {
+				const cached = release as ReleaseResult & {
+					_parsedRelease?: ReturnType<typeof parseRelease>;
+				};
+				return !cached._parsedRelease?.episode;
+			});
+
+			return [...parsedMatches, ...animeUnparsedReleases];
 		}
 
 		// Season + episode search:
 		// - interactive: prefer exact episodes, fallback to matching single-season packs
 		// - automatic: include exact episodes and matching single-season packs
 		if (targetSeason !== undefined && targetEpisode !== undefined) {
+			const isAnimeSearch = isTvSearch(criteria) && !!criteria.isAnime;
+
 			const exactEpisodeMatches = parsedReleases.filter(
 				({ episodeInfo }) =>
 					!episodeInfo.isSeasonPack &&
 					episodeInfo.season === targetSeason &&
 					episodeInfo.episodes?.includes(targetEpisode)
 			);
+			// Anime uses absolute episode numbering without an explicit season token.
+			// The parser sets `absoluteEpisode` (not `episodes`) for these releases:
+			// e.g. "Kegareboshi - 01" → { absoluteEpisode: 1, season: undefined }.
+			// Accept them when the absolute episode number matches the target episode.
+			const animeAbsoluteMatches = isAnimeSearch
+				? parsedReleases.filter(
+						({ episodeInfo }) =>
+							!episodeInfo.isSeasonPack &&
+							episodeInfo.season === undefined &&
+							episodeInfo.absoluteEpisode === targetEpisode
+					)
+				: [];
+			const allExactMatches = [...exactEpisodeMatches, ...animeAbsoluteMatches];
+
 			const seasonPackMatches = parsedReleases.filter(
 				({ episodeInfo }) =>
 					episodeInfo.isSeasonPack &&
@@ -1665,12 +1738,24 @@ export class SearchOrchestrator {
 				.map(({ release, episodeInfo }) =>
 					this.createEpisodePointerRelease(release, targetEpisode, targetSeason, episodeInfo)
 				);
-			const nonRuTrackerExactReleases = exactEpisodeMatches
+			const nonRuTrackerExactReleases = allExactMatches
 				.filter(({ release }) => !this.shouldCreateRutrackerEpisodePointer(release))
 				.map(({ release }) => release);
 			const nonRuTrackerSeasonPackReleases = seasonPackMatches
 				.filter(({ release }) => !this.shouldCreateRutrackerEpisodePointer(release))
 				.map(({ release }) => release);
+
+			// Anime packs like "[01-08 END]" have episodeInfo=null and are absent from
+			// parsedReleases. Surface them as a fallback when no individual episode file
+			// or parsed season pack is found; the title filter rejects wrong shows.
+			const animeUnparsedFallback = isAnimeSearch
+				? releases.filter((release) => {
+						const cached = release as ReleaseResult & {
+							_parsedRelease?: ReturnType<typeof parseRelease>;
+						};
+						return !cached._parsedRelease?.episode;
+					})
+				: [];
 
 			if (isInteractiveSearch) {
 				if (rutrackerSeasonPackPointers.length > 0) {
@@ -1681,15 +1766,19 @@ export class SearchOrchestrator {
 					return nonRuTrackerExactReleases;
 				}
 
-				return seasonPackMatches.map(({ release, episodeInfo }) =>
-					this.createEpisodePointerRelease(release, targetEpisode, targetSeason, episodeInfo)
-				);
+				return [
+					...seasonPackMatches.map(({ release, episodeInfo }) =>
+						this.createEpisodePointerRelease(release, targetEpisode, targetSeason, episodeInfo)
+					),
+					...animeUnparsedFallback
+				];
 			}
 
 			return [
 				...nonRuTrackerExactReleases,
 				...rutrackerSeasonPackPointers,
-				...nonRuTrackerSeasonPackReleases
+				...nonRuTrackerSeasonPackReleases,
+				...animeUnparsedFallback
 			];
 		}
 
@@ -1940,12 +2029,13 @@ export class SearchOrchestrator {
 
 	/**
 	 * Filter releases by category match.
-	 * Rejects releases where the category doesn't match the search type
-	 * (e.g., audio releases for movie searches).
+	 * Rejects releases where the category doesn't match the search type.
+	 * When criteria.isAdult is true, XXX categories (6xxx) are also accepted.
 	 */
 	private filterByCategoryMatch(
 		releases: ReleaseResult[],
-		searchType: 'movie' | 'tv' | 'music' | 'book'
+		searchType: 'movie' | 'tv' | 'music' | 'book',
+		criteria?: SearchCriteria
 	): ReleaseResult[] {
 		return releases.filter((release) => {
 			// If release has no categories, allow it (benefit of the doubt)
@@ -1953,9 +2043,18 @@ export class SearchOrchestrator {
 				return true;
 			}
 
-			// Check if ANY of the release's categories match the search type
-			const hasMatchingCategory = release.categories.some((cat) =>
-				categoryMatchesSearchType(cat, searchType)
+			// Check if ANY of the release's categories match the search type.
+			// Also accept "Other" (8000+) since many trackers (e.g. LimeTorrents) file
+			// anime/hentai under a generic catch-all rather than TV or XXX.
+			// Also accept XXX when the search is for adult content.
+			// Also accept Movies (2000-2999) when searching for adult TV content: hentai OVAs
+			// are often categorized as movies on public trackers even though the user is
+			// looking for them as part of a TV series.
+			const hasMatchingCategory = release.categories.some(
+				(cat) =>
+					categoryMatchesSearchType(cat, searchType) ||
+					(criteria?.isAdult && (isXxxCategory(cat) || isMovieCategory(cat))) ||
+					cat >= 8000
 			);
 
 			if (!hasMatchingCategory) {
@@ -2141,133 +2240,6 @@ export class SearchOrchestrator {
 	}
 
 	/**
-	 * Filter releases by title relevance.
-	 * Safety net to reject releases that are clearly for a different title
-	 * (e.g., random TV shows returned by a generic RSS feed when ID search fails).
-	 * Only filters when we have a known title to compare against.
-	 */
-	private filterByTitleRelevance(
-		releases: ReleaseResult[],
-		criteria: SearchCriteria
-	): ReleaseResult[] {
-		const isTvSearchCriteria = criteria.searchType === 'tv';
-		const hasEpisodeTarget = isTvSearchCriteria && criteria.episode !== undefined;
-		const hasSeasonTarget = isTvSearchCriteria && criteria.season !== undefined;
-		const allowInteractiveTvFallback =
-			isTvSearchCriteria &&
-			criteria.searchSource === 'interactive' &&
-			!hasEpisodeTarget &&
-			!hasSeasonTarget;
-		const allowInteractiveMovieFallback = false;
-		const allowInteractiveFallback = allowInteractiveTvFallback || allowInteractiveMovieFallback;
-
-		// Collect all expected titles: query + searchTitles
-		const expectedTitles: string[] = [];
-		if (criteria.query) expectedTitles.push(criteria.query);
-		if (criteria.searchTitles) expectedTitles.push(...criteria.searchTitles);
-
-		// If we have no titles to compare against, skip filtering
-		if (expectedTitles.length === 0) return releases;
-
-		// Normalize titles for comparison while preserving Unicode letters/numbers.
-		const normalize = (s: string): string =>
-			this.normalizeForComparison(s).replace(/\s+/g, '').trim();
-
-		const normalizedExpected = expectedTitles.map(normalize).filter((t) => t.length > 0);
-		if (normalizedExpected.length === 0) return releases;
-
-		const beforeCount = releases.length;
-		const filtered = releases.filter((release) => {
-			const releaseWithCache = release as ReleaseResult & {
-				_parsedRelease?: ReturnType<typeof parseRelease>;
-			};
-			if (!releaseWithCache._parsedRelease) {
-				releaseWithCache._parsedRelease = parseRelease(release.title, {
-					sourceLanguage: release.sourceLanguage
-				});
-			}
-			const parsed = releaseWithCache._parsedRelease;
-			const releaseName = normalize(parsed.cleanTitle);
-			// If we cannot derive a comparable title token, keep only for
-			// interactive browsing fallbacks; targeted episode/season lookups stay strict.
-			if (releaseName.length === 0) return allowInteractiveFallback;
-
-			// Check if any expected title is similar enough to the release name
-			// Using Levenshtein distance-based similarity instead of substring matching
-			// to prevent false positives like "TransformersOne" matching "Transformers"
-			const matches = normalizedExpected.some((expected) => {
-				const similarity = this.calculateTitleSimilarity(releaseName, expected);
-				if (similarity >= 0.7) {
-					return true;
-				}
-
-				// Accept strong containment matches for tracker titles that append
-				// extensive metadata after the base title (common on RuTracker).
-				return (
-					releaseName.length >= 5 &&
-					expected.length >= 5 &&
-					(releaseName.includes(expected) || expected.includes(releaseName))
-				);
-			});
-
-			if (!matches) {
-				const simDetails = normalizedExpected.map((expected) => ({
-					expected,
-					similarity: this.calculateTitleSimilarity(releaseName, expected),
-					containsEachOther: releaseName.includes(expected) || expected.includes(releaseName)
-				}));
-				logger.info(
-					{
-						releaseTitle: release.title,
-						releaseName, // normalized release name
-						parsedName: parsed.cleanTitle,
-						normalizedExpected,
-						similarityDetails: simDetails,
-						indexer: release.indexerName,
-						size: release.size
-					},
-					'[SearchOrchestrator] DEBUG: TITLE MISMATCH - Release rejected by title filter'
-				);
-			}
-
-			return matches;
-		});
-
-		if (filtered.length < beforeCount) {
-			logger.info(
-				{
-					before: beforeCount,
-					after: filtered.length,
-					removed: beforeCount - filtered.length,
-					expectedTitles: expectedTitles.slice(0, 3),
-					searchType: criteria.searchType,
-					searchSource: criteria.searchSource
-				},
-				'[SearchOrchestrator] Title relevance filter removed irrelevant results'
-			);
-		}
-
-		// For interactive TV, avoid a hard zero-result failure mode caused by
-		// localization/transliteration mismatches in tracker titles.
-		if (allowInteractiveFallback && beforeCount > 0 && filtered.length === 0) {
-			logger.info(
-				{
-					before: beforeCount,
-					expectedTitles: expectedTitles.slice(0, 3),
-					searchType: criteria.searchType,
-					searchSource: criteria.searchSource,
-					season: isTvSearchCriteria ? criteria.season : undefined,
-					episode: isTvSearchCriteria ? criteria.episode : undefined
-				},
-				'[SearchOrchestrator] Title relevance fallback applied for interactive search'
-			);
-			return releases;
-		}
-
-		return filtered;
-	}
-
-	/**
 	 * Calculate title similarity using Levenshtein distance.
 	 * Returns a value between 0 (completely different) and 1 (identical).
 	 */
@@ -2340,7 +2312,10 @@ export class SearchOrchestrator {
 
 		// Skip if we have no way to validate (no search IDs or titles)
 		const hasSearchIds = searchTmdbId || searchImdbId || searchTvdbId;
-		const hasSearchTitles = criteria.searchTitles && criteria.searchTitles.length > 0;
+		// Treat the query string as a title candidate when no explicit alternate titles are stored.
+		// This prevents wrong results from passing through when searchTitles hasn't been populated yet.
+		const hasSearchTitles =
+			!!(criteria.searchTitles && criteria.searchTitles.length > 0) || !!criteria.query;
 		const hasSearchYear = searchYear;
 
 		if (!hasSearchIds && !hasSearchTitles && !hasSearchYear) {
@@ -2443,8 +2418,10 @@ export class SearchOrchestrator {
 				}
 			}
 
-			// PRIORITY 2: Title + Year Fallback (if no ID match possible)
-			if (hasSearchTitles && hasSearchYear) {
+			// PRIORITY 2: Title Fallback (if no ID match possible)
+			// Runs whenever we have known titles; year is an additional filter only
+			// when the search criteria carries one (TV series often don't).
+			if (hasSearchTitles) {
 				const isEpisodeTarget = isTvSearch(criteria) && criteria.episode !== undefined;
 				const isSeasonTarget = isTvSearch(criteria) && criteria.season !== undefined;
 				const releaseHasAnyId = !!(release.tmdbId || release.imdbId || release.tvdbId);
@@ -2455,7 +2432,7 @@ export class SearchOrchestrator {
 				// Check title similarity. Include query as a fallback candidate in case
 				// alternate-title storage is incomplete for this language.
 				const titleCandidates = [
-					...criteria.searchTitles!,
+					...(criteria.searchTitles ?? []),
 					...(criteria.query ? [criteria.query] : [])
 				];
 				const normalizedCandidates = titleCandidates
@@ -2487,11 +2464,9 @@ export class SearchOrchestrator {
 						isInteractiveSearch && (isTvSearch(criteria) || releasePrefersNativeCyrillic);
 				}
 
-				// Check year.
-				// If year is absent in title, allow interactive fallback.
-				const yearMatch = parsedRelease.year
-					? parsedRelease.year === searchYear!
-					: isInteractiveSearch;
+				// Year check: only applies when both the search criteria and the parsed
+				// release title carry a year. Missing year on either side is not a failure.
+				const yearMatch = !searchYear || !parsedRelease.year || parsedRelease.year === searchYear;
 
 				if (!titleMatch || !yearMatch) {
 					// Interactive fallback for localized/transliterated indexer titles that
@@ -2545,12 +2520,11 @@ export class SearchOrchestrator {
 					return false; // Hard reject
 				}
 
-				// Title and year match - accept
+				// Title (and year when available) match - accept
 				return true;
 			}
 
-			// If we have no way to validate (no IDs, no criteria), keep it
-			// Let downstream filters handle it
+			// No IDs and no titles to validate against - keep it
 			return true;
 		});
 

--- a/src/lib/server/indexers/search/searchorchestrator.test.ts
+++ b/src/lib/server/indexers/search/searchorchestrator.test.ts
@@ -92,7 +92,6 @@ type OrchestratorPrivateApi = {
 	): ReleaseResult[];
 	filterByIdOrTitleMatch(releases: ReleaseResult[], criteria: SearchCriteria): ReleaseResult[];
 	filterOutNonVideoArtifacts(releases: ReleaseResult[], criteria: SearchCriteria): ReleaseResult[];
-	filterByTitleRelevance(releases: ReleaseResult[], criteria: SearchCriteria): ReleaseResult[];
 };
 
 function privateApi(orchestrator: SearchOrchestrator): OrchestratorPrivateApi {
@@ -956,7 +955,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['War Machine', 'Máquina de Guerra']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].title).toContain('War Machine');
 	});
@@ -976,7 +975,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['Особенности национальной охоты']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].title).toContain('Особенности национальной охоты');
 	});
@@ -992,7 +991,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['Peculiarities of the National Hunt']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(0);
 	});
 
@@ -1011,7 +1010,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['The Night Agent']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].title).toContain('The Night Agent');
 	});
@@ -1093,7 +1092,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['The Night Agent', 'Gecə Agenti']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(2);
 		expect(filtered).toEqual(releases);
 	});
@@ -1112,7 +1111,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			episode: 2
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(0);
 	});
 
@@ -1128,7 +1127,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			searchTitles: ['The Night Agent', 'Gecə Agenti']
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(0);
 	});
 
@@ -1183,7 +1182,7 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 			year: 2025
 		});
 
-		const filtered = privateApi(orchestrator).filterByTitleRelevance(releases, criteria);
+		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(0);
 	});
 

--- a/src/lib/server/indexers/search/searchorchestrator.test.ts
+++ b/src/lib/server/indexers/search/searchorchestrator.test.ts
@@ -90,6 +90,12 @@ type OrchestratorPrivateApi = {
 		criteria: SearchCriteria,
 		context?: { seasonEpisodeCount?: number }
 	): ReleaseResult[];
+	filterByCategoryMatch(
+		releases: ReleaseResult[],
+		searchType: 'movie' | 'tv' | 'music' | 'book',
+		criteria?: SearchCriteria
+	): ReleaseResult[];
+	isSeasonOnlyTvSearch(criteria: SearchCriteria): boolean;
 	filterByIdOrTitleMatch(releases: ReleaseResult[], criteria: SearchCriteria): ReleaseResult[];
 	filterOutNonVideoArtifacts(releases: ReleaseResult[], criteria: SearchCriteria): ReleaseResult[];
 };
@@ -1210,5 +1216,145 @@ describe('SearchOrchestrator.filterByTitleRelevance', () => {
 		const filtered = privateApi(orchestrator).filterByIdOrTitleMatch(releases, criteria);
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].title).toContain('Пикник');
+	});
+});
+
+describe('SearchOrchestrator season-only category filter', () => {
+	// Regression: a season-only TV search reduces the candidate pool to only season packs
+	// (via filterBySeasonEpisode). If those packs are categorized outside the TV range
+	// (Movies/XXX/Other — common on Jackett/Prowlarr and anime trackers), the broad
+	// filterByCategoryMatch guard would reject every pack and yield zero results.
+	// The category guard is therefore skipped for season-only TV searches.
+	const tvCaps = { ...mockCapabilities, categories: new Map([[Category.TV_HD, 'TV/HD']]) };
+
+	it('keeps a Movies-categorized season pack for a season-only TV search', async () => {
+		const orchestrator = new SearchOrchestrator();
+		const fakeIndexer = buildIndexer({
+			capabilities: tvCaps,
+			search: async () => [
+				createRelease({
+					guid: 'season-pack-filed-as-movies',
+					title: 'Smallville.S01.COMPLETE.1080p.BluRay',
+					// Movies/Foreign: would be rejected by filterByCategoryMatch for a TV search
+					categories: [Category.MOVIES_FOREIGN]
+				})
+			]
+		});
+
+		const criteria = createTvCriteria({ query: 'Smallville', season: 1 });
+
+		const result = await orchestrator.search([fakeIndexer], criteria, {
+			respectEnabled: false,
+			respectBackoff: false,
+			useCache: false
+		});
+
+		expect(result.releases).toHaveLength(1);
+		expect(result.releases[0].guid).toBe('season-pack-filed-as-movies');
+	});
+
+	it('still rejects a Movies-categorized episode for a season+episode TV search', async () => {
+		// Proves the skip is scoped to season-only: episode searches still apply the guard.
+		const orchestrator = new SearchOrchestrator();
+		const fakeIndexer = buildIndexer({
+			capabilities: tvCaps,
+			search: async () => [
+				createRelease({
+					guid: 'episode-filed-as-movies',
+					title: 'Smallville.S01E01.1080p.WEB-DL',
+					categories: [Category.MOVIES_FOREIGN]
+				})
+			]
+		});
+
+		const criteria = createTvCriteria({ query: 'Smallville', season: 1, episode: 1 });
+
+		const result = await orchestrator.search([fakeIndexer], criteria, {
+			respectEnabled: false,
+			respectBackoff: false,
+			useCache: false
+		});
+
+		expect(result.releases).toHaveLength(0);
+	});
+
+	it('isSeasonOnlyTvSearch is true only when a season is targeted without an episode', () => {
+		const orchestrator = new SearchOrchestrator();
+		const api = privateApi(orchestrator);
+
+		expect(api.isSeasonOnlyTvSearch(createTvCriteria({ season: 1 }))).toBe(true);
+		expect(api.isSeasonOnlyTvSearch(createTvCriteria({ season: 1, episode: 1 }))).toBe(false);
+		expect(api.isSeasonOnlyTvSearch(createTvCriteria({}))).toBe(false);
+		expect(api.isSeasonOnlyTvSearch(createMovieCriteria({}))).toBe(false);
+	});
+});
+
+describe('SearchOrchestrator.filterByCategoryMatch', () => {
+	const orchestrator = new SearchOrchestrator();
+
+	it('rejects a Music-categorized release for a movie search', () => {
+		// Guards against soundtracks masquerading as movies — the original purpose of this filter.
+		const releases = [
+			createRelease({ title: 'Awesome Movie Soundtrack 2024', categories: [Category.AUDIO_MP3] })
+		];
+
+		const filtered = privateApi(orchestrator).filterByCategoryMatch(releases, 'movie');
+
+		expect(filtered).toHaveLength(0);
+	});
+
+	it('keeps a Movie-categorized release for a movie search', () => {
+		const releases = [
+			createRelease({ title: 'Awesome Movie 2024 1080p', categories: [Category.MOVIES_HD] })
+		];
+
+		const filtered = privateApi(orchestrator).filterByCategoryMatch(releases, 'movie');
+
+		expect(filtered).toHaveLength(1);
+	});
+
+	it('keeps a TV-categorized release for a TV search', () => {
+		const releases = [
+			createRelease({ title: 'Awesome Show S01E01', categories: [Category.TV_HD] })
+		];
+
+		const filtered = privateApi(orchestrator).filterByCategoryMatch(
+			releases,
+			'tv',
+			createTvCriteria({})
+		);
+
+		expect(filtered).toHaveLength(1);
+	});
+
+	it('rejects a Movies-categorized release for a non-adult TV search', () => {
+		// Confirms the guard still rejects cross-type categories when it does run
+		// (i.e. the season-only skip is the only relaxation).
+		const releases = [
+			createRelease({ title: 'Awesome Show S01E01', categories: [Category.MOVIES_FOREIGN] })
+		];
+
+		const filtered = privateApi(orchestrator).filterByCategoryMatch(
+			releases,
+			'tv',
+			createTvCriteria({})
+		);
+
+		expect(filtered).toHaveLength(0);
+	});
+
+	it('accepts a Movies/XXX-categorized release for an adult TV search', () => {
+		const releases = [
+			createRelease({ title: 'Hentai OVA S01E01', categories: [Category.MOVIES_FOREIGN] }),
+			createRelease({ title: 'Hentai OVA Pack', categories: [Category.XXX_PACK] })
+		];
+
+		const filtered = privateApi(orchestrator).filterByCategoryMatch(
+			releases,
+			'tv',
+			createTvCriteria({ isAdult: true })
+		);
+
+		expect(filtered).toHaveLength(2);
 	});
 });

--- a/src/lib/server/indexers/status/PersistentStatusTracker.ts
+++ b/src/lib/server/indexers/status/PersistentStatusTracker.ts
@@ -505,7 +505,7 @@ export class PersistentStatusTracker {
 		if (status.isDisabled) return 'disabled';
 		const failingThreshold = Math.max(2, this.config.failuresBeforeDisable - 1);
 		if (status.consecutiveFailures >= failingThreshold) return 'failing';
-		if (status.consecutiveFailures >= 1) return 'warning';
+		if (status.consecutiveFailures >= 2) return 'warning';
 		return 'healthy';
 	}
 

--- a/src/lib/server/indexers/types/category.ts
+++ b/src/lib/server/indexers/types/category.ts
@@ -214,6 +214,21 @@ export const CONSOLE_CATEGORIES = [
 	Category.CONSOLE_PS4
 ] as const;
 
+/**
+ * All XXX/adult categories
+ */
+export const XXX_CATEGORIES = [
+	Category.XXX,
+	Category.XXX_DVD,
+	Category.XXX_WMV,
+	Category.XXX_XVID,
+	Category.XXX_X264,
+	Category.XXX_UHD,
+	Category.XXX_PACK,
+	Category.XXX_IMAGESET,
+	Category.XXX_OTHER
+] as const;
+
 // =============================================================================
 // CATEGORY UTILITIES
 // =============================================================================
@@ -301,9 +316,35 @@ export function getCategoriesForContentType(contentType: ContentType): Category[
 			return [...BOOK_CATEGORIES];
 		case 'software':
 			return [...PC_CATEGORIES, ...CONSOLE_CATEGORIES];
+		case 'xxx':
+			return [...XXX_CATEGORIES];
 		default:
 			return [];
 	}
+}
+
+/**
+ * Expand a base category list based on content classification flags.
+ * - isAnime: ensures Category.TV_ANIME (5070) is present when the base contains any TV category
+ * - isAdult: appends all XXX categories (6xxx)
+ * Returns a deduped, order-stable array.
+ */
+export function expandCategoriesForClassification(
+	base: number[],
+	flags: { isAnime?: boolean; isAdult?: boolean }
+): number[] {
+	const result = [...base];
+	if (flags.isAnime && base.some(isTvCategory) && !result.includes(Category.TV_ANIME)) {
+		result.push(Category.TV_ANIME);
+	}
+	if (flags.isAdult) {
+		for (const cat of XXX_CATEGORIES) {
+			if (!result.includes(cat)) {
+				result.push(cat);
+			}
+		}
+	}
+	return result;
 }
 
 /**

--- a/src/lib/server/indexers/types/index.ts
+++ b/src/lib/server/indexers/types/index.ts
@@ -124,6 +124,7 @@ export {
 	BOOK_CATEGORIES,
 	PC_CATEGORIES,
 	CONSOLE_CATEGORIES,
+	XXX_CATEGORIES,
 	// Functions
 	isMovieCategory,
 	isTvCategory,
@@ -134,6 +135,7 @@ export {
 	isXxxCategory,
 	getCategoryContentType,
 	getCategoriesForContentType,
+	expandCategoriesForClassification,
 	getCategoryName,
 	buildCategoryMap,
 	hasCategoriesForContentType,

--- a/src/lib/server/indexers/types/search.ts
+++ b/src/lib/server/indexers/types/search.ts
@@ -45,6 +45,10 @@ export interface BaseSearchCriteria {
 	/** Preferred audio language (ISO 639-1 code, e.g. 'fr', 'de').
 	 * Used for post-search language boosting of releases. */
 	language?: string;
+	/** True when the title is classified as anime (TMDB seriesType='anime'). Expands categories to include 5070. */
+	isAnime?: boolean;
+	/** True when the title is flagged adult AND the global include_adult toggle is on. Expands categories to include 6xxx. */
+	isAdult?: boolean;
 }
 
 // =============================================================================
@@ -328,6 +332,8 @@ export function criteriaToString(criteria: SearchCriteria): string {
 	if (criteria.categories?.length) {
 		parts.push(`cats=[${criteria.categories.join(',')}]`);
 	}
+	if (criteria.isAnime) parts.push('anime=true');
+	if (criteria.isAdult) parts.push('adult=true');
 
 	return parts.join(' ');
 }

--- a/src/lib/server/library/LibraryEntityService.ts
+++ b/src/lib/server/library/LibraryEntityService.ts
@@ -12,7 +12,6 @@ import { NotFoundError, ValidationError } from '$lib/errors';
 
 export type LibraryMediaType = 'movie' | 'tv';
 export type LibraryMediaSubType = 'standard' | 'anime';
-export type MetadataProviderSelection = 'auto' | 'tmdb' | 'anilist' | 'mal';
 
 export interface LibraryRootFolder {
 	id: string;
@@ -37,7 +36,6 @@ export interface LibraryEntity {
 	defaultMonitored: boolean;
 	defaultSearchOnAdd: boolean;
 	defaultWantsSubtitles: boolean;
-	metadataProvider: MetadataProviderSelection;
 	sortOrder: number;
 	createdAt: string;
 	updatedAt: string;
@@ -52,7 +50,6 @@ export interface CreateLibraryInput {
 	defaultMonitored?: boolean;
 	defaultSearchOnAdd?: boolean;
 	defaultWantsSubtitles?: boolean;
-	metadataProvider?: MetadataProviderSelection;
 	sortOrder?: number;
 }
 
@@ -308,7 +305,6 @@ export class LibraryEntityService {
 				defaultMonitored: libraries.defaultMonitored,
 				defaultSearchOnAdd: libraries.defaultSearchOnAdd,
 				defaultWantsSubtitles: libraries.defaultWantsSubtitles,
-				metadataProvider: libraries.metadataProvider,
 				sortOrder: libraries.sortOrder,
 				createdAt: libraries.createdAt,
 				updatedAt: libraries.updatedAt
@@ -380,7 +376,6 @@ export class LibraryEntityService {
 				defaultMonitored: row.defaultMonitored ?? true,
 				defaultSearchOnAdd: row.defaultSearchOnAdd ?? true,
 				defaultWantsSubtitles: row.defaultWantsSubtitles ?? true,
-				metadataProvider: (row.metadataProvider as MetadataProviderSelection) ?? 'auto',
 				sortOrder: row.sortOrder ?? 0,
 				createdAt: row.createdAt ?? '',
 				updatedAt: row.updatedAt ?? ''
@@ -407,7 +402,6 @@ export class LibraryEntityService {
 					defaultMonitored: true,
 					defaultSearchOnAdd: true,
 					defaultWantsSubtitles: true,
-					metadataProvider: 'auto',
 					sortOrder: def.sortOrder,
 					createdAt: now,
 					updatedAt: now
@@ -757,7 +751,6 @@ export class LibraryEntityService {
 			defaultMonitored: input.defaultMonitored ?? true,
 			defaultSearchOnAdd: input.defaultSearchOnAdd ?? true,
 			defaultWantsSubtitles: input.defaultWantsSubtitles ?? true,
-			metadataProvider: input.metadataProvider ?? 'auto',
 			sortOrder: nextSortOrder,
 			createdAt: now,
 			updatedAt: now
@@ -835,9 +828,6 @@ export class LibraryEntityService {
 		}
 		if (updates.defaultWantsSubtitles !== undefined) {
 			updateData.defaultWantsSubtitles = updates.defaultWantsSubtitles;
-		}
-		if (updates.metadataProvider !== undefined) {
-			updateData.metadataProvider = updates.metadataProvider;
 		}
 		if (updates.sortOrder !== undefined) {
 			updateData.sortOrder = updates.sortOrder;

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -32,7 +32,6 @@ import {
 	getMediaParseStem
 } from './tv-episode-resolver.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
-import { resolveProviderWithFallback } from '$lib/server/metadata/provider-resolution.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 
 /**
@@ -748,7 +747,7 @@ export class MediaMatcherService {
 				rootFolder.id,
 				'movie'
 			);
-			const animeSignal = isLikelyAnimeMedia({
+			const _animeSignal = isLikelyAnimeMedia({
 				genres: tmdbMovie.genres,
 				originalLanguage: tmdbMovie.original_language,
 				productionCountries: tmdbMovie.production_countries,
@@ -758,24 +757,6 @@ export class MediaMatcherService {
 				title: tmdbMovie.title,
 				originalTitle: tmdbMovie.original_title
 			});
-			const mediaTypeForProvider =
-				owningLibrary.mediaSubType === 'anime' || animeSignal ? 'anime' : 'movie';
-			const providerResolution = await resolveProviderWithFallback({
-				mediaType: mediaTypeForProvider,
-				libraryProvider: owningLibrary.metadataProvider
-			});
-			let providerRefs: Record<string, string> | undefined;
-			if (providerResolution.selectedProviderId !== 'tmdb') {
-				const providerMatches = await providerResolution.provider.searchTitle(
-					tmdbMovie.title,
-					mediaTypeForProvider
-				);
-				const topMatch = providerMatches[0];
-				if (topMatch) {
-					providerRefs = { [providerResolution.selectedProviderId]: topMatch.id };
-				}
-			}
-
 			try {
 				const [newMovie] = await db
 					.insert(movies)
@@ -792,8 +773,6 @@ export class MediaMatcherService {
 						backdropPath: tmdbMovie.backdrop_path,
 						runtime: tmdbMovie.runtime,
 						genres: tmdbMovie.genres?.map((g) => g.name),
-						metadataProvider: owningLibrary.metadataProvider,
-						providerRefs,
 						path: movieFolder || fileName,
 						libraryId: owningLibrary.id,
 						rootFolderId: rootFolder.id,
@@ -928,7 +907,7 @@ export class MediaMatcherService {
 				rootFolder.id,
 				'tv'
 			);
-			const animeSignal = isLikelyAnimeMedia({
+			const _animeSignal = isLikelyAnimeMedia({
 				genres: tmdbSeries.genres,
 				originalLanguage: tmdbSeries.original_language,
 				originCountries: tmdbSeries.origin_country,
@@ -936,23 +915,6 @@ export class MediaMatcherService {
 				title: tmdbSeries.name,
 				originalTitle: tmdbSeries.original_name
 			});
-			const mediaTypeForProvider =
-				owningLibrary.mediaSubType === 'anime' || animeSignal ? 'anime' : 'tv';
-			const providerResolution = await resolveProviderWithFallback({
-				mediaType: mediaTypeForProvider,
-				libraryProvider: owningLibrary.metadataProvider
-			});
-			let providerRefs: Record<string, string> | undefined;
-			if (providerResolution.selectedProviderId !== 'tmdb') {
-				const providerMatches = await providerResolution.provider.searchTitle(
-					tmdbSeries.name,
-					mediaTypeForProvider
-				);
-				const topMatch = providerMatches[0];
-				if (topMatch) {
-					providerRefs = { [providerResolution.selectedProviderId]: topMatch.id };
-				}
-			}
 			let createdSeries = false;
 
 			try {
@@ -973,8 +935,6 @@ export class MediaMatcherService {
 						status: tmdbSeries.status,
 						network: tmdbSeries.networks?.[0]?.name,
 						genres: tmdbSeries.genres?.map((g) => g.name),
-						metadataProvider: owningLibrary.metadataProvider,
-						providerRefs,
 						path: seriesFolder,
 						libraryId: owningLibrary.id,
 						rootFolderId: rootFolder.id,

--- a/src/lib/server/metadata/provider-ref-resolver.ts
+++ b/src/lib/server/metadata/provider-ref-resolver.ts
@@ -33,11 +33,13 @@ function tokenOverlapScore(a: string, b: string): number {
 	return shared / Math.max(aTokens.size, bTokens.size);
 }
 
+const INCLUDES_MIN_LEN = 4;
+
 function pickBestMatch(
 	results: MetadataSearchResult[],
 	titles: string[],
 	year?: number | null
-): MetadataSearchResult | null {
+): { result: MetadataSearchResult; confidence: 'high' | 'low' } | null {
 	if (results.length === 0) return null;
 	const normalizedTargets = titles.map((title) => normalize(title)).filter(Boolean);
 	const plainTargets = titles.filter((title) => title.trim().length > 0);
@@ -50,14 +52,19 @@ function pickBestMatch(
 				? Math.abs(year - result.year)
 				: null;
 		const exact = normalizedTargets.some((target) => normalizedTitle === target);
-		const includes = normalizedTargets.some(
-			(target) => target && (normalizedTitle.includes(target) || target.includes(normalizedTitle))
-		);
+		// Bidirectional includes: both sides must meet minimum length to avoid trivial matches
+		const includes = normalizedTargets.some((target) => {
+			if (!target || target.length < INCLUDES_MIN_LEN || normalizedTitle.length < INCLUDES_MIN_LEN)
+				return false;
+			return normalizedTitle.includes(target) || target.includes(normalizedTitle);
+		});
 		const overlap = plainTargets.length
 			? Math.max(...plainTargets.map((target) => tokenOverlapScore(result.title, target)))
 			: 0;
+		// Heavier year penalty when delta > 1 to push mismatched years down rankings
+		const yearPenalty = yearDelta !== null ? (yearDelta > 1 ? yearDelta * 50 : yearDelta) : 0;
 		const score =
-			(exact ? 1000 : 0) + (includes ? 200 : 0) + Math.round(overlap * 100) - (yearDelta ?? 0);
+			(exact ? 1000 : 0) + (includes ? 200 : 0) + Math.round(overlap * 100) - yearPenalty;
 		return { result, score, yearDelta, exact, includes, overlap };
 	});
 	candidates.sort((a, b) => b.score - a.score);
@@ -66,7 +73,15 @@ function pickBestMatch(
 	if (!best) return null;
 	const withinYear = typeof best.yearDelta !== 'number' || best.yearDelta <= 1;
 	const strongTextMatch = best.exact || best.includes || best.overlap >= 0.7;
-	return strongTextMatch && withinYear ? best.result : null;
+	if (!strongTextMatch || !withinYear) return null;
+
+	// Runner-up margin: if the second candidate is close and we have no exact match, downgrade confidence
+	const runnerUp = candidates[1];
+	const ambiguous = !best.exact && runnerUp !== undefined && best.score - runnerUp.score < 150;
+	const confidence: 'high' | 'low' =
+		best.exact || (best.overlap >= 0.8 && !ambiguous && withinYear) ? 'high' : 'low';
+
+	return { result: best.result, confidence };
 }
 
 export async function resolveAnimeProviderRef(input: {
@@ -88,7 +103,7 @@ export async function resolveAnimeProviderRef(input: {
 		try {
 			const results = await provider.searchTitle(query, 'anime');
 			const best = pickBestMatch(results, queryVariants, input.year);
-			if (best?.id) return String(best.id);
+			if (best?.confidence === 'high' && best.result.id) return String(best.result.id);
 		} catch {
 			// continue trying other variants
 		}

--- a/src/lib/server/metadata/provider-registry.ts
+++ b/src/lib/server/metadata/provider-registry.ts
@@ -6,7 +6,7 @@ import type { MetadataProvider, MetadataProviderId } from './providers/types.js'
 
 export interface MetadataProviderRegistry {
 	providers: Map<MetadataProviderId, MetadataProvider>;
-	animePriority: Array<Extract<MetadataProviderId, 'mal' | 'anilist' | 'tmdb'>>;
+	enrichmentEnabled: boolean;
 }
 
 export async function buildMetadataProviderRegistry(): Promise<MetadataProviderRegistry> {
@@ -14,8 +14,9 @@ export async function buildMetadataProviderRegistry(): Promise<MetadataProviderR
 	const providers = new Map<MetadataProviderId, MetadataProvider>();
 
 	providers.set('tmdb', new TmdbMetadataProvider());
-	providers.set('anilist', new AniListProvider(config.anilistEnabled));
-	providers.set('mal', new MalProvider(config.malClientId));
+	providers.set('anilist', new AniListProvider(config.animeEnrichmentEnabled));
+	// Jikan (MAL mirror) is always available - no API key required.
+	providers.set('mal', new MalProvider(config.animeEnrichmentEnabled));
 
-	return { providers, animePriority: config.animeProviderPriority };
+	return { providers, enrichmentEnabled: config.animeEnrichmentEnabled };
 }

--- a/src/lib/server/metadata/provider-resolution.ts
+++ b/src/lib/server/metadata/provider-resolution.ts
@@ -1,66 +1,81 @@
+/**
+ * Anime metadata enrichment helpers.
+ *
+ * Anime providers (AniList, Jikan) are supplementary to TMDB. They contribute:
+ *   - adult/hentai flag (WP-Q)
+ *   - alternate / romaji titles (feeds alternate-title store for search)
+ *   - additive genre tags (merged onto TMDB genres, never replacing)
+ *
+ * TMDB is always the canonical identity/overview/display record.
+ */
+
 import { buildMetadataProviderRegistry } from './provider-registry.js';
-import type {
-	MetadataMediaType,
-	MetadataProvider,
-	MetadataProviderId,
-	MetadataProviderSelection
-} from './providers/types.js';
+import { resolveAnimeProviderRef } from './provider-ref-resolver.js';
+import type { MetadataDetails, MetadataMediaType } from './providers/types.js';
+import { createChildLogger } from '$lib/logging';
 
-type AnimePriorityId = Extract<MetadataProviderId, 'mal' | 'anilist' | 'tmdb'>;
+const logger = createChildLogger({ logDomain: 'system' as const });
 
-export interface MetadataResolutionInput {
-	mediaType: MetadataMediaType;
-	seriesProvider?: MetadataProviderSelection | null;
-	libraryProvider?: MetadataProviderSelection | null;
+export interface AnimeEnrichmentInput {
+	tmdbTitle: string;
+	aliases: string[];
+	year?: number | null;
 }
 
-export async function resolveProviderWithFallback(
-	input: MetadataResolutionInput
-): Promise<{ selectedProviderId: MetadataProviderId; provider: MetadataProvider }> {
-	const { providers, animePriority } = await buildMetadataProviderRegistry();
-	const isAnime = input.mediaType === 'anime';
-	const normalizedSeriesProvider = normalizeSelection(input.seriesProvider);
-	const normalizedLibraryProvider = normalizeSelection(input.libraryProvider);
-	const pickedExplicit =
-		filterSelectionForMediaType(normalizedSeriesProvider, isAnime) ??
-		filterSelectionForMediaType(normalizedLibraryProvider, isAnime);
-	if (pickedExplicit) {
-		const explicitProvider = providers.get(pickedExplicit);
-		if (explicitProvider?.isConfigured()) {
-			return { selectedProviderId: pickedExplicit, provider: explicitProvider };
-		}
-	}
+export interface AnimeEnrichmentResult {
+	/** Refs keyed by provider id ('anilist', 'mal') for storage in providerRefs */
+	refs: Record<string, string>;
+	/** Provider details from each provider that resolved, for adult flag and alt-title extraction */
+	details: Record<string, MetadataDetails>;
+}
 
-	if (isAnime) {
-		for (const providerId of animePriority) {
-			const provider = providers.get(providerId as AnimePriorityId);
-			if (provider?.isConfigured()) {
-				return { selectedProviderId: providerId, provider };
+/**
+ * Fetch supplementary anime enrichment from AniList and Jikan.
+ * Returns empty if enrichment is disabled in config.
+ * Always fails soft: a provider outage does not throw.
+ */
+export async function enrichAnimeMetadata(
+	input: AnimeEnrichmentInput,
+	mediaType: MetadataMediaType
+): Promise<AnimeEnrichmentResult> {
+	const result: AnimeEnrichmentResult = { refs: {}, details: {} };
+
+	const registry = await buildMetadataProviderRegistry();
+	if (!registry.enrichmentEnabled) return result;
+
+	const providerIds = ['anilist', 'mal'] as const;
+
+	await Promise.all(
+		providerIds.map(async (providerId) => {
+			const provider = registry.providers.get(providerId);
+			if (!provider?.isConfigured()) return;
+
+			try {
+				const ref = await resolveAnimeProviderRef({
+					providerId,
+					title: input.tmdbTitle,
+					aliases: input.aliases,
+					year: input.year ?? undefined
+				});
+				if (!ref) return;
+
+				const details = await provider.getDetails(ref, mediaType);
+				if (!details) return;
+
+				result.refs[providerId] = ref;
+				result.details[providerId] = details;
+			} catch (err) {
+				logger.warn(
+					{
+						providerId,
+						title: input.tmdbTitle,
+						error: err instanceof Error ? err.message : String(err)
+					},
+					'[AnimeEnrichment] Provider failed - skipping'
+				);
 			}
-		}
-	}
+		})
+	);
 
-	const fallback = providers.get('tmdb');
-	if (!fallback) {
-		throw new Error('TMDB provider is not registered');
-	}
-	return { selectedProviderId: 'tmdb', provider: fallback };
-}
-
-function normalizeSelection(
-	value: MetadataProviderSelection | null | undefined
-): MetadataProviderId | null {
-	if (!value || value === 'auto') return null;
-	return value;
-}
-
-function filterSelectionForMediaType(
-	value: MetadataProviderId | null,
-	isAnime: boolean
-): MetadataProviderId | null {
-	if (!value) return null;
-	if (!isAnime && (value === 'anilist' || value === 'mal')) {
-		return null;
-	}
-	return value;
+	return result;
 }

--- a/src/lib/server/metadata/provider-settings.ts
+++ b/src/lib/server/metadata/provider-settings.ts
@@ -6,22 +6,8 @@ import type { MetadataProviderConfig } from './providers/types.js';
 const PROVIDER_SETTINGS_KEY = 'metadata_providers';
 
 const DEFAULT_PROVIDER_CONFIG: MetadataProviderConfig = {
-	anilistEnabled: false,
-	malClientId: '',
-	animeProviderPriority: ['anilist', 'mal', 'tmdb']
+	animeEnrichmentEnabled: true
 };
-
-function normalizePriority(value: unknown): MetadataProviderConfig['animeProviderPriority'] {
-	const allowed = new Set(['anilist', 'mal', 'tmdb']);
-	const configured = Array.isArray(value)
-		? value.filter((entry) => allowed.has(String(entry)))
-		: [];
-	const deduped = [...new Set(configured)] as MetadataProviderConfig['animeProviderPriority'];
-	for (const fallback of DEFAULT_PROVIDER_CONFIG.animeProviderPriority) {
-		if (!deduped.includes(fallback)) deduped.push(fallback);
-	}
-	return deduped;
-}
 
 export async function getMetadataProviderConfig(): Promise<MetadataProviderConfig> {
 	const row = await db.query.settings.findFirst({
@@ -31,11 +17,20 @@ export async function getMetadataProviderConfig(): Promise<MetadataProviderConfi
 	if (!row) return DEFAULT_PROVIDER_CONFIG;
 
 	try {
-		const parsed = JSON.parse(row.value) as Partial<MetadataProviderConfig>;
+		const parsed = JSON.parse(row.value) as Partial<MetadataProviderConfig> & {
+			// Legacy fields - ignored but not rejected so old DB rows parse cleanly
+			anilistEnabled?: boolean;
+			malClientId?: string;
+			animeProviderPriority?: unknown;
+		};
 		return {
-			anilistEnabled: Boolean(parsed.anilistEnabled),
-			malClientId: String(parsed.malClientId ?? '').trim(),
-			animeProviderPriority: normalizePriority(parsed.animeProviderPriority)
+			animeEnrichmentEnabled:
+				typeof parsed.animeEnrichmentEnabled === 'boolean'
+					? parsed.animeEnrichmentEnabled
+					: // Migrate: if either legacy provider was enabled, treat enrichment as enabled
+						Boolean(parsed.anilistEnabled) || Boolean(parsed.malClientId)
+						? true
+						: DEFAULT_PROVIDER_CONFIG.animeEnrichmentEnabled
 		};
 	} catch {
 		return DEFAULT_PROVIDER_CONFIG;
@@ -47,13 +42,10 @@ export async function setMetadataProviderConfig(
 ): Promise<MetadataProviderConfig> {
 	const current = await getMetadataProviderConfig();
 	const next: MetadataProviderConfig = {
-		anilistEnabled:
-			typeof config.anilistEnabled === 'boolean' ? config.anilistEnabled : current.anilistEnabled,
-		malClientId:
-			typeof config.malClientId === 'string' ? config.malClientId.trim() : current.malClientId,
-		animeProviderPriority: normalizePriority(
-			config.animeProviderPriority ?? current.animeProviderPriority
-		)
+		animeEnrichmentEnabled:
+			typeof config.animeEnrichmentEnabled === 'boolean'
+				? config.animeEnrichmentEnabled
+				: current.animeEnrichmentEnabled
 	};
 
 	await db

--- a/src/lib/server/metadata/providers/anilist.ts
+++ b/src/lib/server/metadata/providers/anilist.ts
@@ -20,6 +20,7 @@ interface AniListMedia {
 	startDate?: { year?: number | null } | null;
 	genres?: string[] | null;
 	status?: string | null;
+	isAdult?: boolean | null;
 	studios?: { nodes?: Array<{ name?: string | null } | null> | null } | null;
 }
 
@@ -76,6 +77,7 @@ export class AniListProvider implements MetadataProvider {
                 startDate { year }
                 coverImage { large }
                 status
+                isAdult
                 studios(isMain: true) { nodes { name } }
               }
             }
@@ -121,6 +123,7 @@ export class AniListProvider implements MetadataProvider {
               bannerImage
               genres
               status
+              isAdult
               studios(isMain: true) { nodes { name } }
             }
           }
@@ -144,6 +147,7 @@ export class AniListProvider implements MetadataProvider {
 			backdropUrl: media.bannerImage ?? null,
 			genres: media.genres ?? undefined,
 			status: mapAniListStatus(media.status),
+			isAdult: media.isAdult === true,
 			studios:
 				media.studios?.nodes
 					?.map((node) => node?.name?.trim())

--- a/src/lib/server/metadata/providers/mal.ts
+++ b/src/lib/server/metadata/providers/mal.ts
@@ -5,100 +5,161 @@ import type {
 	MetadataSearchResult
 } from './types.js';
 
-interface MalNode {
-	id: number;
+// Jikan v4 shapes (unofficial MAL mirror, no auth required)
+interface JikanTitle {
+	type: string;
 	title: string;
-	main_picture?: { large?: string; medium?: string };
-	synopsis?: string;
-	start_date?: string;
-	genres?: Array<{ name: string }>;
-	status?: string;
-	studios?: Array<{ name: string }>;
 }
 
-interface MalSearchItem {
-	node: MalNode;
+interface JikanImage {
+	jpg?: { large_image_url?: string | null };
+}
+
+interface JikanGenre {
+	name: string;
+}
+
+interface JikanStudio {
+	name: string;
+}
+
+interface JikanAired {
+	from?: string | null;
+	prop?: { from?: { year?: number | null } };
+}
+
+interface JikanAnime {
+	mal_id: number;
+	title: string;
+	title_english?: string | null;
+	title_japanese?: string | null;
+	titles?: JikanTitle[];
+	images?: JikanImage;
+	synopsis?: string | null;
+	year?: number | null;
+	aired?: JikanAired;
+	genres?: JikanGenre[];
+	explicit_genres?: JikanGenre[];
+	studios?: JikanStudio[];
+	status?: string | null;
+	rating?: string | null;
+}
+
+interface JikanSearchResponse {
+	data?: JikanAnime[];
+}
+
+interface JikanDetailsResponse {
+	data?: JikanAnime;
+}
+
+// Jikan enforces ~3 req/s; track last request time and throttle if needed.
+let lastRequestAt = 0;
+const JIKAN_MIN_INTERVAL_MS = 350;
+
+async function jikanFetch(url: string): Promise<Response> {
+	const now = Date.now();
+	const wait = JIKAN_MIN_INTERVAL_MS - (now - lastRequestAt);
+	if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+	lastRequestAt = Date.now();
+	return fetch(url, { headers: { accept: 'application/json' } });
+}
+
+function mapStatus(status?: string | null): string | undefined {
+	switch (status) {
+		case 'Finished Airing':
+			return 'Ended';
+		case 'Currently Airing':
+			return 'Returning Series';
+		case 'Not yet aired':
+			return 'Planned';
+		default:
+			return undefined;
+	}
+}
+
+function extractYear(anime: JikanAnime): number | null {
+	if (anime.year) return anime.year;
+	if (anime.aired?.prop?.from?.year) return anime.aired.prop.from.year;
+	if (anime.aired?.from) {
+		const y = Number.parseInt(anime.aired.from.slice(0, 4), 10);
+		return Number.isFinite(y) ? y : null;
+	}
+	return null;
+}
+
+function isHentai(anime: JikanAnime): boolean {
+	if (anime.rating === 'Rx - Hentai') return true;
+	const explicitNames = (anime.explicit_genres ?? []).map((g) => g.name.toLowerCase());
+	return explicitNames.includes('hentai') || explicitNames.includes('erotica');
+}
+
+function collectGenres(anime: JikanAnime): string[] {
+	const names = new Set<string>();
+	for (const g of anime.genres ?? []) names.add(g.name);
+	for (const g of anime.explicit_genres ?? []) names.add(g.name);
+	return [...names];
 }
 
 export class MalProvider implements MetadataProvider {
 	readonly id = 'mal' as const;
-	readonly name = 'MyAnimeList';
-	readonly description = 'MyAnimeList official API using client-id header.';
+	readonly name = 'MyAnimeList (Jikan)';
+	readonly description = 'Jikan v4 - unofficial public MAL mirror, no authentication required.';
 
-	constructor(private readonly clientId: string) {}
+	constructor(private readonly enabled: boolean) {}
 
 	isConfigured(): boolean {
-		return this.clientId.length > 0;
-	}
-
-	private getHeaders(): HeadersInit {
-		return {
-			'content-type': 'application/json',
-			'X-MAL-CLIENT-ID': this.clientId
-		};
-	}
-
-	private mapStatus(status?: string): string | undefined {
-		switch (status) {
-			case 'finished_airing':
-				return 'Ended';
-			case 'currently_airing':
-				return 'Returning Series';
-			case 'not_yet_aired':
-				return 'Planned';
-			default:
-				return undefined;
-		}
+		return this.enabled;
 	}
 
 	async searchTitle(query: string, _type: MetadataMediaType): Promise<MetadataSearchResult[]> {
-		if (!this.isConfigured() || !query.trim()) return [];
+		if (!this.enabled || !query.trim()) return [];
 
-		const url = new URL('https://api.myanimelist.net/v2/anime');
+		const url = new URL('https://api.jikan.moe/v4/anime');
 		url.searchParams.set('q', query.trim());
 		url.searchParams.set('limit', '10');
-		url.searchParams.set('fields', 'id,title,main_picture,synopsis,start_date');
+		url.searchParams.set('sfw', 'false');
 
-		const res = await fetch(url.toString(), { headers: this.getHeaders() });
-		if (!res.ok) return [];
-		const data = (await res.json()) as { data?: MalSearchItem[] };
-		const items = data.data ?? [];
+		const res = await jikanFetch(url.toString()).catch(() => null);
+		if (!res?.ok) return [];
+		const body = (await res.json().catch(() => null)) as JikanSearchResponse | null;
+		const items = body?.data ?? [];
 
 		return items.map((item) => ({
-			id: String(item.node.id),
-			title: item.node.title,
-			overview: item.node.synopsis ?? undefined,
-			year: item.node.start_date ? Number.parseInt(item.node.start_date.slice(0, 4), 10) : null,
-			posterUrl: item.node.main_picture?.large ?? item.node.main_picture?.medium ?? null,
+			id: String(item.mal_id),
+			title: item.title_english ?? item.title,
+			originalTitle: item.title_japanese ?? undefined,
+			overview: item.synopsis ?? undefined,
+			year: extractYear(item),
+			posterUrl: item.images?.jpg?.large_image_url ?? null,
 			mediaType: 'anime',
 			provider: this.id
 		}));
 	}
 
 	async getDetails(id: string): Promise<MetadataDetails | null> {
-		if (!this.isConfigured()) return null;
+		if (!this.enabled) return null;
 		const parsedId = Number.parseInt(id, 10);
 		if (!Number.isFinite(parsedId) || parsedId <= 0) return null;
 
-		const url = new URL(`https://api.myanimelist.net/v2/anime/${parsedId}`);
-		url.searchParams.set(
-			'fields',
-			'id,title,main_picture,synopsis,start_date,genres,status,studios,alternative_titles'
-		);
-
-		const res = await fetch(url.toString(), { headers: this.getHeaders() });
-		if (!res.ok) return null;
-		const item = (await res.json()) as MalNode;
+		const url = `https://api.jikan.moe/v4/anime/${parsedId}/full`;
+		const res = await jikanFetch(url).catch(() => null);
+		if (!res?.ok) return null;
+		const body = (await res.json().catch(() => null)) as JikanDetailsResponse | null;
+		const item = body?.data;
+		if (!item) return null;
 
 		return {
-			id: String(item.id),
-			title: item.title,
+			id: String(item.mal_id),
+			title: item.title_english ?? item.title,
+			originalTitle: item.title_japanese ?? undefined,
 			overview: item.synopsis ?? undefined,
-			year: item.start_date ? Number.parseInt(item.start_date.slice(0, 4), 10) : null,
-			posterUrl: item.main_picture?.large ?? item.main_picture?.medium ?? null,
-			genres: item.genres?.map((genre) => genre.name) ?? undefined,
-			status: this.mapStatus(item.status),
-			studios: item.studios?.map((studio) => studio.name) ?? undefined,
+			year: extractYear(item),
+			posterUrl: item.images?.jpg?.large_image_url ?? null,
+			genres: collectGenres(item),
+			status: mapStatus(item.status),
+			studios: item.studios?.map((s) => s.name) ?? undefined,
+			isAdult: isHentai(item),
 			mediaType: 'anime',
 			provider: this.id
 		};

--- a/src/lib/server/metadata/providers/tmdb.ts
+++ b/src/lib/server/metadata/providers/tmdb.ts
@@ -68,6 +68,7 @@ export class TmdbMetadataProvider implements MetadataProvider {
 					? `https://image.tmdb.org/t/p/w780${movie.backdrop_path}`
 					: null,
 				genres: movie.genres?.map((genre) => genre.name) ?? undefined,
+				isAdult: movie.adult === true,
 				mediaType: 'movie',
 				provider: this.id
 			};

--- a/src/lib/server/metadata/providers/types.ts
+++ b/src/lib/server/metadata/providers/types.ts
@@ -24,6 +24,8 @@ export interface MetadataDetails {
 	genres?: string[];
 	status?: string;
 	studios?: string[];
+	/** Whether this title is flagged as adult/hentai by the provider. */
+	isAdult?: boolean;
 	mediaType: MetadataMediaType;
 	provider: MetadataProviderId;
 }
@@ -38,7 +40,6 @@ export interface MetadataProvider {
 }
 
 export interface MetadataProviderConfig {
-	anilistEnabled: boolean;
-	malClientId: string;
-	animeProviderPriority: Array<Extract<MetadataProviderId, 'mal' | 'anilist' | 'tmdb'>>;
+	/** When true, AniList and Jikan run automatically for anime titles to supply alt titles and adult flag. Default: true. */
+	animeEnrichmentEnabled: boolean;
 }

--- a/src/lib/server/monitoring/search/MonitoringSearchService.ts
+++ b/src/lib/server/monitoring/search/MonitoringSearchService.ts
@@ -16,7 +16,8 @@ import {
 	episodes,
 	episodeFiles,
 	scoringProfiles,
-	downloadQueue
+	downloadQueue,
+	settings
 } from '$lib/server/db/schema.js';
 import { eq, and, lte, gte, inArray } from 'drizzle-orm';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
@@ -185,6 +186,17 @@ export class MonitoringSearchService {
 	// Cache for season episode counts to avoid N+1 queries
 	// Key: `${seriesId}-${seasonNumber}`, Value: episode count
 	private seasonEpisodeCountCache: Map<string, number> = new Map();
+
+	private async getGlobalIncludeAdult(): Promise<boolean> {
+		try {
+			const row = await db.query.settings.findFirst({ where: eq(settings.key, 'global_filters') });
+			if (!row?.value) return false;
+			const parsed = JSON.parse(row.value);
+			return parsed?.include_adult === true;
+		} catch {
+			return false;
+		}
+	}
 
 	/**
 	 * Select the best existing file to use as the upgrade baseline.
@@ -964,7 +976,10 @@ export class MonitoringSearchService {
 		const episodeIds = missingEpisodes.map((e) => e.id);
 
 		try {
-			const indexerManager = await getIndexerManager();
+			const [indexerManager, globalIncludeAdult] = await Promise.all([
+				getIndexerManager(),
+				this.getGlobalIncludeAdult()
+			]);
 
 			// Get episode count for the target season (for season pack size validation)
 			const seasonEpisodeCount = await this.getSeasonEpisodeCount(seriesData.id, seasonNumber);
@@ -980,7 +995,8 @@ export class MonitoringSearchService {
 				tvdbId: seriesData.tvdbId ?? undefined,
 				imdbId: seriesData.imdbId ?? undefined,
 				season: seasonNumber,
-				searchTitles
+				searchTitles,
+				isAdult: globalIncludeAdult && (seriesData.adult ?? false) ? true : undefined
 				// Note: No episode number - this will return season packs
 			};
 
@@ -1572,7 +1588,10 @@ export class MonitoringSearchService {
 		}
 
 		try {
-			const indexerManager = await getIndexerManager();
+			const [indexerManager, globalIncludeAdult] = await Promise.all([
+				getIndexerManager(),
+				this.getGlobalIncludeAdult()
+			]);
 
 			// Get all search titles (primary + original + alternates)
 			const searchTitles = await getMovieSearchTitles(movie.id);
@@ -1584,7 +1603,8 @@ export class MonitoringSearchService {
 				tmdbId: movie.tmdbId,
 				imdbId: movie.imdbId ?? undefined,
 				year: movie.year ?? undefined,
-				searchTitles
+				searchTitles,
+				isAdult: globalIncludeAdult && (movie.adult ?? false) ? true : undefined
 			};
 
 			// Perform enriched search (automatic - background monitoring)
@@ -1925,7 +1945,10 @@ export class MonitoringSearchService {
 		}
 
 		try {
-			const indexerManager = await getIndexerManager();
+			const [indexerManager, globalIncludeAdult] = await Promise.all([
+				getIndexerManager(),
+				this.getGlobalIncludeAdult()
+			]);
 
 			// Get episode count for the target season (for season pack size validation)
 			const seasonEpisodeCount = await this.getSeasonEpisodeCount(
@@ -1945,7 +1968,8 @@ export class MonitoringSearchService {
 				imdbId: seriesData.imdbId ?? undefined,
 				season: episode.seasonNumber,
 				episode: episode.episodeNumber,
-				searchTitles
+				searchTitles,
+				isAdult: globalIncludeAdult && (seriesData.adult ?? false) ? true : undefined
 			};
 
 			// Perform enriched search (automatic - background monitoring)
@@ -2378,7 +2402,10 @@ export class MonitoringSearchService {
 				};
 			}
 
-			const indexerManager = await getIndexerManager();
+			const [indexerManager, globalIncludeAdult] = await Promise.all([
+				getIndexerManager(),
+				this.getGlobalIncludeAdult()
+			]);
 
 			// Get all search titles (primary + original + alternates)
 			const searchTitles = await getMovieSearchTitles(movie.id);
@@ -2390,7 +2417,8 @@ export class MonitoringSearchService {
 				tmdbId: movie.tmdbId,
 				imdbId: movie.imdbId ?? undefined,
 				year: movie.year ?? undefined,
-				searchTitles
+				searchTitles,
+				isAdult: globalIncludeAdult && (movie.adult ?? false) ? true : undefined
 			};
 
 			// Perform enriched search (automatic - background monitoring)
@@ -2537,7 +2565,10 @@ export class MonitoringSearchService {
 				};
 			}
 
-			const indexerManager = await getIndexerManager();
+			const [indexerManager, globalIncludeAdult] = await Promise.all([
+				getIndexerManager(),
+				this.getGlobalIncludeAdult()
+			]);
 
 			// Get episode count for the target season (for season pack size validation)
 			const seasonEpisodeCount = await this.getSeasonEpisodeCount(
@@ -2557,7 +2588,8 @@ export class MonitoringSearchService {
 				imdbId: seriesData.imdbId ?? undefined,
 				season: episode.seasonNumber,
 				episode: episode.episodeNumber,
-				searchTitles
+				searchTitles,
+				isAdult: globalIncludeAdult && (seriesData.adult ?? false) ? true : undefined
 			};
 
 			// Perform enriched search (automatic - background monitoring)

--- a/src/lib/server/services/AlternateTitleService.ts
+++ b/src/lib/server/services/AlternateTitleService.ts
@@ -117,7 +117,7 @@ export function cleanTitle(title: string): string {
 	return clean;
 }
 
-function pushUniqueSearchTitle(
+function _pushUniqueSearchTitle(
 	titles: string[],
 	seen: Set<string>,
 	title: string | null | undefined
@@ -132,6 +132,29 @@ function pushUniqueSearchTitle(
 
 	seen.add(normalized);
 	titles.push(trimmed);
+}
+
+function containsCjk(text: string): boolean {
+	// CJK Unified Ideographs, Hiragana, Katakana, Bopomofo, Hangul, etc.
+	return /[⺀-鿿豈-﫿︰-﹏＀-￯]/u.test(text);
+}
+
+/**
+ * Reorder a list of alternate titles so romanized (Latin-script) titles appear
+ * before CJK-script (Japanese/Chinese/Korean) titles.
+ * Order within each group is preserved.
+ */
+function sortTitlesByScript(titles: string[]): string[] {
+	const latin: string[] = [];
+	const cjk: string[] = [];
+	for (const t of titles) {
+		if (containsCjk(t)) {
+			cjk.push(t);
+		} else {
+			latin.push(t);
+		}
+	}
+	return [...latin, ...cjk];
 }
 
 /**
@@ -157,15 +180,11 @@ export async function getMovieSearchTitles(
 
 	if (!movie) return [];
 
-	const titles: string[] = [];
 	const seen = new Set<string>();
-
-	// Display title first - user's preferred language, most likely to match standard trackers.
-	pushUniqueSearchTitle(titles, seen, movie.title);
-	// Original title second - needed for non-English films on origin-language trackers.
-	if (movie.originalTitle && movie.originalTitle !== movie.title) {
-		pushUniqueSearchTitle(titles, seen, movie.originalTitle);
-	}
+	// Display title always goes first (user's preferred language, most likely to match standard trackers).
+	const displayTitle = movie.title;
+	seen.add(cleanTitle(displayTitle));
+	const candidatesSeen = new Set<string>(seen);
 
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'movie'), eq(alternateTitles.mediaId, movieId)),
@@ -183,10 +202,26 @@ export async function getMovieSearchTitles(
 			]
 		: [alternates, []];
 
+	// Collect remaining candidates (original title + alternates), then sort so
+	// romanized (Latin-script) titles appear before CJK-script titles.
+	const remaining: string[] = [];
+	const pushCandidate = (t: string | null | undefined) => {
+		if (!t) return;
+		const norm = cleanTitle(t.trim());
+		if (!norm || candidatesSeen.has(norm)) return;
+		candidatesSeen.add(norm);
+		remaining.push(t.trim());
+	};
+
+	if (movie.originalTitle && movie.originalTitle !== displayTitle) {
+		pushCandidate(movie.originalTitle);
+	}
 	for (const alt of [...langAlts, ...otherAlts]) {
-		pushUniqueSearchTitle(titles, seen, alt.title);
+		pushCandidate(alt.title);
 	}
 
+	const sorted = sortTitlesByScript(remaining);
+	const titles = [displayTitle, ...sorted];
 	return titles.slice(0, 5);
 }
 
@@ -205,15 +240,10 @@ export async function getSeriesSearchTitles(
 
 	if (!show) return [];
 
-	const titles: string[] = [];
-	const seen = new Set<string>();
-
-	// Display title first - user's preferred language, most likely to match standard trackers.
-	pushUniqueSearchTitle(titles, seen, show.title);
-	// Original title second - needed for non-English shows on origin-language trackers.
-	if (show.originalTitle && show.originalTitle !== show.title) {
-		pushUniqueSearchTitle(titles, seen, show.originalTitle);
-	}
+	const candidatesSeen = new Set<string>();
+	// Display title always goes first (user's preferred language).
+	const displayTitle = show.title;
+	candidatesSeen.add(cleanTitle(displayTitle));
 
 	const alternates = await db.query.alternateTitles.findMany({
 		where: and(eq(alternateTitles.mediaType, 'series'), eq(alternateTitles.mediaId, seriesId)),
@@ -230,10 +260,26 @@ export async function getSeriesSearchTitles(
 			]
 		: [alternates, []];
 
+	// Collect remaining candidates, then sort so romanized (Latin-script) titles
+	// appear before CJK-script titles. This puts romaji before kanji/kana.
+	const remaining: string[] = [];
+	const pushCandidate = (t: string | null | undefined) => {
+		if (!t) return;
+		const norm = cleanTitle(t.trim());
+		if (!norm || candidatesSeen.has(norm)) return;
+		candidatesSeen.add(norm);
+		remaining.push(t.trim());
+	};
+
+	if (show.originalTitle && show.originalTitle !== displayTitle) {
+		pushCandidate(show.originalTitle);
+	}
 	for (const alt of [...langAlts, ...otherAlts]) {
-		pushUniqueSearchTitle(titles, seen, alt.title);
+		pushCandidate(alt.title);
 	}
 
+	const sorted = sortTitlesByScript(remaining);
+	const titles = [displayTitle, ...sorted];
 	return titles.slice(0, 5);
 }
 

--- a/src/lib/types/library.ts
+++ b/src/lib/types/library.ts
@@ -72,9 +72,7 @@ export interface LibraryMovie {
 	id: string;
 	tmdbId: number;
 	imdbId: string | null;
-	metadataProvider?: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
 	providerRefs?: Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null;
-	pinnedExternal?: { provider: 'tmdb' | 'anilist' | 'mal'; id: string } | null;
 	title: string;
 	originalTitle: string | null;
 	year: number | null;
@@ -112,9 +110,7 @@ export interface LibrarySeries {
 	tmdbId: number;
 	tvdbId: number | null;
 	imdbId: string | null;
-	metadataProvider?: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
 	providerRefs?: Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null;
-	pinnedExternal?: { provider: 'tmdb' | 'anilist' | 'mal'; id: string } | null;
 	title: string;
 	originalTitle: string | null;
 	year: number | null;

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -614,7 +614,6 @@ export const libraryCreateSchema = z.object({
 	defaultMonitored: z.boolean().default(true),
 	defaultSearchOnAdd: z.boolean().default(true),
 	defaultWantsSubtitles: z.boolean().default(true),
-	metadataProvider: metadataProviderSelectionSchema.default('auto'),
 	sortOrder: z.number().int().min(0).default(100)
 });
 
@@ -1437,7 +1436,6 @@ export const movieUpdateSchema = z.object({
 	scoringProfileId: z.string().nullable().optional(),
 	minimumAvailability: z.string().min(1).optional(),
 	availabilityDelay: z.number().int().min(0).max(365).optional(),
-	metadataProvider: metadataProviderSelectionSchema.optional(),
 	providerRefs: z.partialRecord(z.enum(['tmdb', 'anilist', 'mal']), z.string().min(1)).optional(),
 	rootFolderId: z.string().optional(),
 	moveFilesOnRootChange: z.boolean().optional(),
@@ -1462,7 +1460,6 @@ export const seriesUpdateSchema = z.object({
 	scoringProfileId: z.string().nullable().optional(),
 	seasonFolder: z.boolean().optional(),
 	seriesType: z.enum(['standard', 'anime', 'daily']).optional(),
-	metadataProvider: metadataProviderSelectionSchema.optional(),
 	providerRefs: z.partialRecord(z.enum(['tmdb', 'anilist', 'mal']), z.string().min(1)).optional(),
 	rootFolderId: z.string().optional(),
 	wantsSubtitles: z.boolean().optional(),

--- a/src/routes/api/indexers/jackett/connection/+server.ts
+++ b/src/routes/api/indexers/jackett/connection/+server.ts
@@ -6,7 +6,8 @@ import {
 	saveJackettConnection,
 	deleteJackettConnection,
 	fetchJackettIndexers,
-	normalizeJackettUrl
+	normalizeJackettUrl,
+	propagateJackettApiKey
 } from '$lib/server/indexers/jackett/JackettConnectionService.js';
 import { z } from 'zod';
 import { createChildLogger } from '$lib/logging';
@@ -121,6 +122,12 @@ export const PUT: RequestHandler = async (event) => {
 		lastSyncResult: existing?.url === url ? (existing.lastSyncResult ?? null) : null,
 		lastSyncError: existing?.url === url ? (existing.lastSyncError ?? null) : null
 	});
+
+	// If the API key changed, push the new key to all existing Jackett-sourced
+	// indexers immediately so they don't 401 until the next scheduled sync.
+	if (newKey && newKey !== existing?.apiKey) {
+		propagateJackettApiKey(newKey).catch(() => {});
+	}
 
 	return json({ success: true });
 };

--- a/src/routes/api/indexers/prowlarr/connection/+server.ts
+++ b/src/routes/api/indexers/prowlarr/connection/+server.ts
@@ -6,7 +6,8 @@ import {
 	saveProwlarrConnection,
 	deleteProwlarrConnection,
 	fetchProwlarrIndexers,
-	normalizeProwlarrUrl
+	normalizeProwlarrUrl,
+	propagateProwlarrApiKey
 } from '$lib/server/indexers/prowlarr/ProwlarrConnectionService.js';
 import { z } from 'zod';
 
@@ -111,6 +112,12 @@ export const PUT: RequestHandler = async (event) => {
 		lastSyncResult: existing?.url === url ? (existing.lastSyncResult ?? null) : null,
 		lastSyncError: existing?.url === url ? (existing.lastSyncError ?? null) : null
 	});
+
+	// If the API key changed, push the new key to all existing Prowlarr-sourced
+	// indexers immediately so they don't 401 until the next scheduled sync.
+	if (newKey && newKey !== existing?.apiKey) {
+		propagateProwlarrApiKey(newKey).catch(() => {});
+	}
 
 	return json({ success: true });
 };

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -91,7 +91,10 @@ function toFriendlyTestError(rawMessage: string, apiStandard?: ApiStandard): str
 		lower.includes('unauthorized') ||
 		lower.includes('forbidden')
 	) {
-		return 'Authentication failed. Check your credentials/cookies.';
+		const usesApiKey = apiStandard === 'torznab' || apiStandard === 'newznab';
+		return usesApiKey
+			? 'Authentication failed. Check your API key.'
+			: 'Authentication failed. Check your credentials/cookies.';
 	}
 
 	if (lower.includes('cloudflare')) {

--- a/src/routes/api/library/movies/[id]/+server.ts
+++ b/src/routes/api/library/movies/[id]/+server.ts
@@ -35,7 +35,6 @@ import { getLibraryEntityService } from '$lib/server/library/LibraryEntityServic
 import { getLibraryScheduler } from '$lib/server/library/library-scheduler.js';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
-import { buildMetadataProviderRegistry } from '$lib/server/metadata/provider-registry.js';
 
 function isAnimeMovieSignal(input: {
 	rootFolderPath: string | null;
@@ -60,9 +59,7 @@ export const GET: RequestHandler = async ({ params }) => {
 				id: movies.id,
 				tmdbId: movies.tmdbId,
 				imdbId: movies.imdbId,
-				metadataProvider: movies.metadataProvider,
 				providerRefs: movies.providerRefs,
-				pinnedExternal: movies.pinnedExternal,
 				title: movies.title,
 				originalTitle: movies.originalTitle,
 				year: movies.year,
@@ -121,42 +118,18 @@ export const GET: RequestHandler = async ({ params }) => {
 				title: movie.title
 			}),
 			configured: {
-				anilist: providerConfig.anilistEnabled,
-				mal: Boolean(providerConfig.malClientId)
+				anilist: providerConfig.animeEnrichmentEnabled,
+				mal: providerConfig.animeEnrichmentEnabled
 			},
 			existingRefs:
 				(movie.providerRefs as Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null) ??
 				undefined
 		});
-		let studios: string[] | null = null;
-		const selectedMovieProvider = movie.metadataProvider as
-			| 'auto'
-			| 'tmdb'
-			| 'anilist'
-			| 'mal'
-			| null;
-		if (selectedMovieProvider === 'anilist' || selectedMovieProvider === 'mal') {
-			const providerRef = enrichedProviderRefs[selectedMovieProvider];
-			if (providerRef) {
-				const { providers } = await buildMetadataProviderRegistry();
-				const provider = providers.get(selectedMovieProvider);
-				if (provider?.isConfigured()) {
-					try {
-						const details = await provider.getDetails(providerRef, 'anime');
-						studios = details?.studios ?? null;
-					} catch {
-						studios = null;
-					}
-				}
-			}
-		}
-
 		return json({
 			success: true,
 			movie: {
 				...movie,
 				providerRefs: enrichedProviderRefs,
-				studios,
 				tmdbStatus: releaseInfo?.status ?? null,
 				releaseDate: releaseInfo?.release_date ?? null,
 				files: files.map((f) => ({
@@ -215,7 +188,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		scoringProfileId,
 		minimumAvailability,
 		availabilityDelay,
-		metadataProvider,
 		providerRefs,
 		rootFolderId,
 		moveFilesOnRootChange,
@@ -261,9 +233,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	}
 	if (availabilityDelay !== undefined) {
 		updateData.availabilityDelay = availabilityDelay;
-	}
-	if (metadataProvider !== undefined) {
-		updateData.metadataProvider = metadataProvider;
 	}
 	if (providerRefs !== undefined) {
 		updateData.providerRefs = providerRefs;

--- a/src/routes/api/library/movies/[id]/refresh/+server.ts
+++ b/src/routes/api/library/movies/[id]/refresh/+server.ts
@@ -8,12 +8,11 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
-import { movies, libraries } from '$lib/server/db/schema.js';
+import { movies } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import { logger } from '$lib/logging';
-import { resolveProviderWithFallback } from '$lib/server/metadata/provider-resolution.js';
-import { resolveAnimeProviderRef } from '$lib/server/metadata/provider-ref-resolver.js';
+import { enrichAnimeMetadata } from '$lib/server/metadata/provider-resolution.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import {
 	startRefresh,
@@ -41,7 +40,7 @@ export const POST: RequestHandler = async ({ params }) => {
 	startRefresh(refreshId, { movieId: id });
 
 	try {
-		// Fetch fresh data from TMDB
+		// Fetch fresh data from TMDB (canonical identity/overview/genres)
 		const [tmdbMovie, externalIds] = await Promise.all([
 			tmdb.getMovie(movieData.tmdbId),
 			tmdb.getMovieExternalIds(movieData.tmdbId).catch((err) => {
@@ -56,13 +55,7 @@ export const POST: RequestHandler = async ({ params }) => {
 			})
 		]);
 
-		const [libraryRow] = movieData.libraryId
-			? await db
-					.select({ metadataProvider: libraries.metadataProvider })
-					.from(libraries)
-					.where(eq(libraries.id, movieData.libraryId))
-					.limit(1)
-			: [];
+		// Determine anime classification from TMDB metadata
 		const animeSignal = isLikelyAnimeMedia({
 			genres: tmdbMovie.genres,
 			originalLanguage: tmdbMovie.original_language,
@@ -71,80 +64,65 @@ export const POST: RequestHandler = async ({ params }) => {
 			title: tmdbMovie.title,
 			originalTitle: tmdbMovie.original_title
 		});
-		const mediaType = animeSignal ? 'anime' : 'movie';
-		const providerResolution = await resolveProviderWithFallback({
-			mediaType,
-			seriesProvider: (movieData.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ?? 'auto',
-			libraryProvider:
-				(libraryRow?.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ?? 'auto'
-		});
+
+		// Fetch supplementary anime enrichment (alt titles, adult flag) from AniList + Jikan.
+		// Runs in parallel; failures are silently skipped.
 		const providerRefs = (movieData.providerRefs ?? {}) as Record<string, string>;
-		const pinnedExternal = movieData.pinnedExternal as {
-			provider: 'tmdb' | 'anilist' | 'mal';
-			id: string;
-		} | null;
-		let resolvedProviderRef: string | undefined =
-			pinnedExternal?.provider === providerResolution.selectedProviderId
-				? pinnedExternal.id
-				: providerRefs[providerResolution.selectedProviderId];
-		let providerDetails: {
-			id: string;
-			title: string;
-			originalTitle?: string;
-			overview?: string;
-			year?: number | null;
-			genres?: string[];
-			status?: string;
-			studios?: string[];
-		} | null = null;
-		if (providerResolution.selectedProviderId !== 'tmdb') {
-			if (!resolvedProviderRef) {
-				resolvedProviderRef = await resolveAnimeProviderRef({
-					providerId: providerResolution.selectedProviderId,
-					title: tmdbMovie.title,
+		let adultFromEnrichment = false;
+		const adultSources: string[] = [];
+		if (animeSignal) {
+			const enrichment = await enrichAnimeMetadata(
+				{
+					tmdbTitle: tmdbMovie.title,
 					aliases: [tmdbMovie.original_title ?? '', movieData.title, movieData.originalTitle ?? ''],
 					year: tmdbMovie.release_date
 						? new Date(tmdbMovie.release_date).getFullYear()
 						: movieData.year
-				});
-			}
-			if (resolvedProviderRef) {
-				providerDetails = await providerResolution.provider.getDetails(
-					resolvedProviderRef,
-					mediaType
-				);
+				},
+				'anime'
+			);
+			Object.assign(providerRefs, enrichment.refs);
+			for (const [pid, details] of Object.entries(enrichment.details)) {
+				if (details.isAdult) {
+					adultFromEnrichment = true;
+					adultSources.push(pid);
+				}
 			}
 		}
+		// TMDB adult flag (authoritative for non-anime too)
+		if (tmdbMovie.adult === true) {
+			adultFromEnrichment = true;
+			adultSources.push('tmdb');
+		}
+		// Sticky-OR: once adult, always adult
+		const newAdult = (movieData.adult ?? false) || adultFromEnrichment;
+		const newAdultSource =
+			adultSources.length > 0 ? adultSources.join(',') : (movieData.adultSource ?? null);
+		const newAdultConfidence = adultFromEnrichment
+			? 'provider'
+			: (movieData.adultConfidence ?? null);
 
-		// Update movie metadata
+		// Update movie metadata - TMDB is canonical for identity/overview/genres
 		await db
 			.update(movies)
 			.set({
-				// Keep canonical identity from TMDB to avoid provider switches renaming media.
 				title: tmdbMovie.title,
 				originalTitle: tmdbMovie.original_title,
-				overview: providerDetails?.overview ?? tmdbMovie.overview,
+				overview: tmdbMovie.overview,
 				posterPath: tmdbMovie.poster_path,
 				backdropPath: tmdbMovie.backdrop_path,
 				runtime: tmdbMovie.runtime,
-				genres: providerDetails?.genres ?? tmdbMovie.genres?.map((g) => g.name),
-				metadataProvider:
-					movieData.metadataProvider ??
-					(libraryRow?.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ??
-					'auto',
-				providerRefs:
-					providerResolution.selectedProviderId !== 'tmdb' && resolvedProviderRef
-						? {
-								...providerRefs,
-								[providerResolution.selectedProviderId]: resolvedProviderRef
-							}
-						: providerRefs,
+				genres: tmdbMovie.genres?.map((g) => g.name),
+				providerRefs,
 				year: tmdbMovie.release_date
 					? new Date(tmdbMovie.release_date).getFullYear()
 					: movieData.year,
 				imdbId: externalIds?.imdb_id || movieData.imdbId,
 				tmdbCollectionId: tmdbMovie.belongs_to_collection?.id ?? movieData.tmdbCollectionId,
-				collectionName: tmdbMovie.belongs_to_collection?.name ?? movieData.collectionName
+				collectionName: tmdbMovie.belongs_to_collection?.name ?? movieData.collectionName,
+				adult: newAdult,
+				adultSource: newAdultSource,
+				adultConfidence: newAdultConfidence
 			})
 			.where(eq(movies.id, id));
 

--- a/src/routes/api/library/series/[id]/+server.ts
+++ b/src/routes/api/library/series/[id]/+server.ts
@@ -66,9 +66,7 @@ export const GET: RequestHandler = async ({ params }) => {
 				monitored: series.monitored,
 				seasonFolder: series.seasonFolder,
 				seriesType: series.seriesType,
-				metadataProvider: series.metadataProvider,
 				providerRefs: series.providerRefs,
-				pinnedExternal: series.pinnedExternal,
 				added: series.added,
 				episodeCount: series.episodeCount,
 				episodeFileCount: series.episodeFileCount,
@@ -137,8 +135,8 @@ export const GET: RequestHandler = async ({ params }) => {
 			year: seriesItem.year,
 			isAnime: (seriesItem.seriesType ?? '').toLowerCase() === 'anime',
 			configured: {
-				anilist: providerConfig.anilistEnabled,
-				mal: Boolean(providerConfig.malClientId)
+				anilist: providerConfig.animeEnrichmentEnabled,
+				mal: providerConfig.animeEnrichmentEnabled
 			},
 			existingRefs:
 				(seriesItem.providerRefs as Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null) ??
@@ -222,7 +220,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 			scoringProfileId,
 			seasonFolder,
 			seriesType,
-			metadataProvider,
 			providerRefs,
 			rootFolderId,
 			wantsSubtitles,
@@ -275,9 +272,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		}
 		if (seriesType !== undefined) {
 			updateData.seriesType = seriesType;
-		}
-		if (metadataProvider !== undefined) {
-			updateData.metadataProvider = metadataProvider;
 		}
 		if (providerRefs !== undefined) {
 			updateData.providerRefs = providerRefs;

--- a/src/routes/api/library/series/[id]/refresh/+server.ts
+++ b/src/routes/api/library/series/[id]/refresh/+server.ts
@@ -12,12 +12,11 @@ import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createSSEOperationStream } from '$lib/server/sse';
 import { db } from '$lib/server/db/index.js';
-import { series, seasons, episodes, libraries } from '$lib/server/db/schema.js';
+import { series, seasons, episodes } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import { logger } from '$lib/logging';
-import { resolveProviderWithFallback } from '$lib/server/metadata/provider-resolution.js';
-import { resolveAnimeProviderRef } from '$lib/server/metadata/provider-ref-resolver.js';
+import { enrichAnimeMetadata } from '$lib/server/metadata/provider-resolution.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
 import {
@@ -75,20 +74,13 @@ export const POST: RequestHandler = async ({ params, request }) => {
 			};
 
 			try {
-				// Fetch fresh data from TMDB
+				// Fetch fresh data from TMDB (canonical identity/overview/genres)
 				const [tmdbSeries, externalIds] = await Promise.all([
 					tmdb.getTVShow(seriesData.tmdbId),
 					tmdb.getTvExternalIds(seriesData.tmdbId).catch(() => null)
 				]);
 
-				// Resolve configured metadata provider chain for textual anime metadata enrichment
-				const [libraryRow] = seriesData.libraryId
-					? await db
-							.select({ metadataProvider: libraries.metadataProvider })
-							.from(libraries)
-							.where(eq(libraries.id, seriesData.libraryId))
-							.limit(1)
-					: [];
+				// Determine anime classification from TMDB metadata
 				const animeSignal = isLikelyAnimeMedia({
 					genres: tmdbSeries.genres,
 					originalLanguage: tmdbSeries.original_language,
@@ -97,39 +89,17 @@ export const POST: RequestHandler = async ({ params, request }) => {
 					title: tmdbSeries.name,
 					originalTitle: tmdbSeries.original_name
 				});
-				const mediaType = seriesData.seriesType === 'anime' || animeSignal ? 'anime' : 'tv';
-				const providerResolution = await resolveProviderWithFallback({
-					mediaType,
-					seriesProvider:
-						(seriesData.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ?? 'auto',
-					libraryProvider:
-						(libraryRow?.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ?? 'auto'
-				});
+				const isAnime = seriesData.seriesType === 'anime' || animeSignal;
 
+				// Fetch supplementary anime enrichment (alt titles, adult flag) from AniList + Jikan.
+				// Runs in parallel; failures are silently skipped.
 				const providerRefs = (seriesData.providerRefs ?? {}) as Record<string, string>;
-				const pinnedExternal = seriesData.pinnedExternal as {
-					provider: 'tmdb' | 'anilist' | 'mal';
-					id: string;
-				} | null;
-				let resolvedProviderRef: string | undefined =
-					pinnedExternal?.provider === providerResolution.selectedProviderId
-						? pinnedExternal.id
-						: providerRefs[providerResolution.selectedProviderId];
-				let providerDetails: {
-					id: string;
-					title: string;
-					originalTitle?: string;
-					overview?: string;
-					year?: number | null;
-					genres?: string[];
-					status?: string;
-					studios?: string[];
-				} | null = null;
-				if (providerResolution.selectedProviderId !== 'tmdb') {
-					if (!resolvedProviderRef) {
-						resolvedProviderRef = await resolveAnimeProviderRef({
-							providerId: providerResolution.selectedProviderId,
-							title: tmdbSeries.name,
+				let adultFromEnrichment = false;
+				const adultSources: string[] = [];
+				if (isAnime) {
+					const enrichment = await enrichAnimeMetadata(
+						{
+							tmdbTitle: tmdbSeries.name,
 							aliases: [
 								tmdbSeries.original_name ?? '',
 								seriesData.title,
@@ -138,46 +108,46 @@ export const POST: RequestHandler = async ({ params, request }) => {
 							year: tmdbSeries.first_air_date
 								? parseInt(tmdbSeries.first_air_date.split('-')[0], 10)
 								: seriesData.year
-						});
-					}
-
-					if (resolvedProviderRef) {
-						providerDetails = await providerResolution.provider.getDetails(
-							resolvedProviderRef,
-							mediaType
-						);
+						},
+						'anime'
+					);
+					Object.assign(providerRefs, enrichment.refs);
+					for (const [pid, details] of Object.entries(enrichment.details)) {
+						if (details.isAdult) {
+							adultFromEnrichment = true;
+							adultSources.push(pid);
+						}
 					}
 				}
+				// Sticky-OR: once adult, always adult
+				const newAdult = (seriesData.adult ?? false) || adultFromEnrichment;
+				const newAdultSource =
+					adultSources.length > 0 ? adultSources.join(',') : (seriesData.adultSource ?? null);
+				const newAdultConfidence = adultFromEnrichment
+					? 'provider'
+					: (seriesData.adultConfidence ?? null);
 
-				// Update series metadata
+				// Update series metadata - TMDB is canonical for identity/overview/genres
 				await db
 					.update(series)
 					.set({
 						posterPath: tmdbSeries.poster_path,
 						backdropPath: tmdbSeries.backdrop_path,
-						status: providerDetails?.status ?? tmdbSeries.status,
-						network: providerDetails?.studios?.[0] ?? tmdbSeries.networks?.[0]?.name,
-						metadataProvider:
-							seriesData.metadataProvider ??
-							(libraryRow?.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal') ??
-							'auto',
-						providerRefs:
-							providerResolution.selectedProviderId !== 'tmdb' && resolvedProviderRef
-								? {
-										...providerRefs,
-										[providerResolution.selectedProviderId]: resolvedProviderRef
-									}
-								: providerRefs,
-						// Keep canonical identity from TMDB to avoid provider switches renaming media.
+						status: tmdbSeries.status,
+						network: tmdbSeries.networks?.[0]?.name,
+						providerRefs,
 						title: tmdbSeries.name,
 						originalTitle: tmdbSeries.original_name,
-						overview: providerDetails?.overview ?? tmdbSeries.overview,
+						overview: tmdbSeries.overview,
 						year: tmdbSeries.first_air_date
 							? parseInt(tmdbSeries.first_air_date.split('-')[0], 10)
 							: seriesData.year,
-						genres: providerDetails?.genres ?? tmdbSeries.genres?.map((g) => g.name),
+						genres: tmdbSeries.genres?.map((g) => g.name),
 						tvdbId: externalIds?.tvdb_id || seriesData.tvdbId,
-						imdbId: externalIds?.imdb_id || seriesData.imdbId
+						imdbId: externalIds?.imdb_id || seriesData.imdbId,
+						adult: newAdult,
+						adultSource: newAdultSource,
+						adultConfidence: newAdultConfidence
 					})
 					.where(eq(series.id, id));
 
@@ -273,8 +243,6 @@ export const POST: RequestHandler = async ({ params, request }) => {
 											.where(eq(episodes.id, existingEpisode.id));
 									} else {
 										// Create new episode - respect monitorNewItems setting
-										// New episodes inherit monitored status from their season,
-										// but only if monitorNewItems is 'all'
 										const shouldMonitorNewEpisode =
 											seriesData.monitorNewItems === 'all' ? seasonMonitored : false;
 

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -2,7 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager';
 import type { SearchCriteria } from '$lib/server/indexers/types';
-import { getCategoriesForSearchType } from '$lib/server/indexers/types';
+import {
+	getCategoriesForSearchType,
+	expandCategoriesForClassification
+} from '$lib/server/indexers/types';
 import { searchQuerySchema } from '$lib/validation/schemas';
 import { qualityFilter, type EnrichmentOptions } from '$lib/server/quality';
 import { logger } from '$lib/logging';
@@ -97,24 +100,29 @@ export const GET: RequestHandler = async ({ url }) => {
 		: (categories ?? getCategoriesForSearchType(searchType));
 	const effectiveLimit = isMultiSeasonPackTvSearch ? (limit ?? 200) : limit;
 
-	// Resolve language preference:
-	// 1. Explicit query param (e.g., ?language=fr) takes precedence
-	// 2. Fall back to global TMDB language filter (e.g., 'fr-FR' -> 'fr')
+	// Resolve language preference and global adult toggle from settings.
+	// Explicit ?language= param takes precedence over the stored language preference.
 	let effectiveLanguage: string | undefined = language;
-	if (!effectiveLanguage) {
-		try {
-			const filtersSetting = await db.query.settings.findFirst({
-				where: eq(settings.key, 'global_filters')
-			});
-			if (filtersSetting?.value) {
-				const globalFilters = JSON.parse(filtersSetting.value);
-				if (globalFilters?.language && typeof globalFilters.language === 'string') {
-					effectiveLanguage = globalFilters.language.toLowerCase().split('-')[0];
-				}
+	let globalIncludeAdult = false;
+	try {
+		const filtersSetting = await db.query.settings.findFirst({
+			where: eq(settings.key, 'global_filters')
+		});
+		if (filtersSetting?.value) {
+			const globalFilters = JSON.parse(filtersSetting.value);
+			if (
+				!effectiveLanguage &&
+				globalFilters?.language &&
+				typeof globalFilters.language === 'string'
+			) {
+				effectiveLanguage = globalFilters.language.toLowerCase().split('-')[0];
 			}
-		} catch {
-			// If settings are unavailable, proceed without language preference
+			if (globalFilters?.include_adult === true) {
+				globalIncludeAdult = true;
+			}
 		}
+	} catch {
+		// If settings are unavailable, proceed without language/adult preference
 	}
 
 	let criteria: SearchCriteria;
@@ -141,6 +149,7 @@ export const GET: RequestHandler = async ({ url }) => {
 			imdbId,
 			tmdbId,
 			tvdbId,
+			year,
 			season,
 			episode,
 			language: effectiveLanguage
@@ -171,17 +180,18 @@ export const GET: RequestHandler = async ({ url }) => {
 		);
 	}
 
-	// Populate searchTitles from alternate titles in the library database
-	// This enables multi-title text fallback search and title relevance filtering
+	// Populate searchTitles from alternate titles in the library database and
+	// compute content classification (isAnime, isAdult) for category expansion.
 	if (tmdbId && (searchType === 'movie' || searchType === 'tv')) {
 		try {
 			let searchTitles: string[] | undefined;
 			if (searchType === 'movie') {
 				const movie = await db.query.movies.findFirst({
 					where: eq(movies.tmdbId, tmdbId),
-					columns: { id: true }
+					columns: { id: true, adult: true }
 				});
 				if (movie) {
+					if (globalIncludeAdult && movie.adult) criteria.isAdult = true;
 					searchTitles = await getMovieSearchTitles(movie.id, effectiveLanguage);
 					if (searchTitles.length <= 1) {
 						fetchAndStoreMovieAlternateTitles(movie.id, tmdbId).catch(() => {});
@@ -191,9 +201,17 @@ export const GET: RequestHandler = async ({ url }) => {
 			} else {
 				const show = await db.query.series.findFirst({
 					where: eq(series.tmdbId, tmdbId),
-					columns: { id: true }
+					columns: { id: true, seriesType: true, adult: true }
 				});
 				if (show) {
+					const isAnime = (show.seriesType ?? '').toLowerCase() === 'anime';
+					criteria.isAnime = isAnime || undefined;
+					// For interactive search: if the user has adult content enabled AND this is
+					// an anime series, include XXX categories immediately - don't wait for a
+					// refresh to set adult=true in the DB, since hentai anime may never be
+					// flagged by TMDB and the user already opted in via the global toggle.
+					if (globalIncludeAdult && (show.adult || isAnime)) criteria.isAdult = true;
+
 					searchTitles = await getSeriesSearchTitles(show.id, effectiveLanguage);
 					if (searchTitles.length <= 1) {
 						fetchAndStoreSeriesAlternateTitles(show.id, tmdbId).catch(() => {});
@@ -211,8 +229,20 @@ export const GET: RequestHandler = async ({ url }) => {
 					searchType,
 					error: error instanceof Error ? error.message : String(error)
 				},
-				'[SearchAPI] Failed to look up alternate titles'
+				'[SearchAPI] Failed to look up alternate titles or classify content'
 			);
+		}
+
+		// Expand categories based on classification (isAnime, isAdult).
+		// isAdult requires the global include_adult toggle to be on; the adult column
+		// lands in WP-Q so criteria.isAdult is always false until then.
+		if (criteria.isAnime || criteria.isAdult) {
+			const base = criteria.categories ?? getCategoriesForSearchType(searchType as 'movie' | 'tv');
+			const expanded = expandCategoriesForClassification(base, {
+				isAnime: criteria.isAnime,
+				isAdult: criteria.isAdult
+			});
+			criteria.categories = expanded.length > 0 ? expanded : undefined;
 		}
 	}
 
@@ -292,6 +322,7 @@ export const GET: RequestHandler = async ({ url }) => {
 				totalResults: searchResult.totalResults,
 				afterDedup: searchResult.afterDedup,
 				afterFiltering: searchResult.afterFiltering,
+				filterBreakdown: searchResult.filterBreakdown,
 				afterEnrichment: searchResult.afterEnrichment,
 				rejectedCount: searchResult.rejectedCount,
 				searchTimeMs: searchResult.searchTimeMs,

--- a/src/routes/api/settings/metadata-providers/+server.ts
+++ b/src/routes/api/settings/metadata-providers/+server.ts
@@ -9,9 +9,7 @@ import {
 } from '$lib/server/metadata/provider-settings.js';
 
 const settingsSchema = z.object({
-	anilistEnabled: z.boolean().optional(),
-	malClientId: z.string().optional(),
-	animeProviderPriority: z.array(z.enum(['mal', 'anilist', 'tmdb'])).optional()
+	animeEnrichmentEnabled: z.boolean().optional()
 });
 
 export const GET: RequestHandler = async (event) => {
@@ -19,12 +17,7 @@ export const GET: RequestHandler = async (event) => {
 	if (authError) return authError;
 
 	const config = await getMetadataProviderConfig();
-	return json({
-		success: true,
-		...config,
-		hasMalClientId: Boolean(config.malClientId),
-		hasAniListEnabled: config.anilistEnabled
-	});
+	return json({ success: true, ...config });
 };
 
 export const PUT: RequestHandler = async (event) => {
@@ -34,10 +27,5 @@ export const PUT: RequestHandler = async (event) => {
 	const parsed = await parseBody(event.request, settingsSchema);
 	const config = await setMetadataProviderConfig(parsed);
 
-	return json({
-		success: true,
-		...config,
-		hasMalClientId: Boolean(config.malClientId),
-		hasAniListEnabled: config.anilistEnabled
-	});
+	return json({ success: true, ...config });
 };

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -5,8 +5,7 @@ import {
 	rootFolders,
 	scoringProfiles,
 	downloadQueue,
-	subtitles,
-	settings
+	subtitles
 } from '$lib/server/db/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
@@ -18,7 +17,7 @@ import { logger } from '$lib/logging';
 import { isMovieSearching } from '$lib/server/library/ActiveSearchTracker.js';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
-import { buildMetadataProviderRegistry } from '$lib/server/metadata/provider-registry.js';
+import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 
 export interface QueueItemInfo {
 	id: string;
@@ -76,9 +75,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 			id: movies.id,
 			tmdbId: movies.tmdbId,
 			imdbId: movies.imdbId,
-			metadataProvider: movies.metadataProvider,
 			providerRefs: movies.providerRefs,
-			pinnedExternal: movies.pinnedExternal,
 			title: movies.title,
 			originalTitle: movies.originalTitle,
 			year: movies.year,
@@ -157,8 +154,6 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 
 	const movieWithFiles: LibraryMovie = {
 		...movie,
-		metadataProvider:
-			(movie.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal' | null) ?? 'auto',
 		tmdbStatus: releaseInfo?.status ?? null,
 		releaseDate: releaseInfo?.release_date ?? null,
 		// Ensure added is always a string
@@ -273,27 +268,11 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 	}
 
 	const isSearching = isMovieSearching(id);
-	let configuredMetadataProviders = {
-		anilist: false,
-		mal: false
+	const providerConfig = await getMetadataProviderConfig();
+	const configuredMetadataProviders = {
+		anilist: providerConfig.animeEnrichmentEnabled,
+		mal: providerConfig.animeEnrichmentEnabled
 	};
-	const settingsRow = await db.query.settings.findFirst({
-		where: eq(settings.key, 'metadata_providers')
-	});
-	if (settingsRow) {
-		try {
-			const parsed = JSON.parse(settingsRow.value) as {
-				anilistEnabled?: boolean;
-				malClientId?: string;
-			};
-			configuredMetadataProviders = {
-				anilist: parsed.anilistEnabled === true,
-				mal: Boolean(parsed.malClientId)
-			};
-		} catch {
-			// ignore malformed settings
-		}
-	}
 
 	const enrichedProviderRefs = await resolveMissingAnimeProviderRefs({
 		title: movieWithFiles.title,
@@ -310,22 +289,6 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 			undefined
 	});
 	movieWithFiles.providerRefs = enrichedProviderRefs;
-	const selectedMovieProvider = movieWithFiles.metadataProvider;
-	if (selectedMovieProvider === 'anilist' || selectedMovieProvider === 'mal') {
-		const providerRef = enrichedProviderRefs[selectedMovieProvider];
-		if (providerRef) {
-			const { providers } = await buildMetadataProviderRegistry();
-			const provider = providers.get(selectedMovieProvider);
-			if (provider?.isConfigured()) {
-				try {
-					const details = await provider.getDetails(providerRef, 'anime');
-					movieWithFiles.studios = details?.studios ?? null;
-				} catch {
-					movieWithFiles.studios = null;
-				}
-			}
-		}
-	}
 
 	return {
 		movie: movieWithFiles,

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -247,8 +247,6 @@
 	const providerLinkRows = $derived.by(() => {
 		const isAnimeItem =
 			(movie.rootFolderPath ?? '').toLowerCase().includes('/anime/') ||
-			movie.metadataProvider === 'anilist' ||
-			movie.metadataProvider === 'mal' ||
 			Boolean(movie.providerRefs?.anilist) ||
 			Boolean(movie.providerRefs?.mal);
 		if (!isAnimeItem) return [];
@@ -299,8 +297,7 @@
 		return rows;
 	});
 	const usesAnimeMetadataProvider = $derived(
-		(movie.metadataProvider === 'anilist' && Boolean(movie.providerRefs?.anilist)) ||
-			(movie.metadataProvider === 'mal' && Boolean(movie.providerRefs?.mal))
+		Boolean(movie.providerRefs?.anilist) || Boolean(movie.providerRefs?.mal)
 	);
 
 	function buildProviderSearchLink(provider: 'anilist' | 'mal'): string {
@@ -481,7 +478,6 @@
 	async function handleEditSave(editData: MovieEditData) {
 		isSaving = true;
 		try {
-			const previousMetadataProvider = movie.metadataProvider ?? 'auto';
 			const result = await updateMovie(movie.id, editData as unknown as Record<string, unknown>);
 
 			// Update local state
@@ -490,7 +486,6 @@
 			movie.minimumAvailability = editData.minimumAvailability;
 			movie.availabilityDelay = editData.availabilityDelay;
 			movie.wantsSubtitles = editData.wantsSubtitles;
-			movie.metadataProvider = editData.metadataProvider;
 
 			if (result?.moveQueued) {
 				toasts.success(m.library_movieDetail_moveQueued());
@@ -501,15 +496,6 @@
 			}
 
 			isEditModalOpen = false;
-
-			if (previousMetadataProvider !== editData.metadataProvider) {
-				try {
-					await fetch(`/api/library/movies/${movie.id}/refresh`, { method: 'POST' });
-				} catch {
-					// Ignore refresh trigger errors and fallback to normal state refresh
-				}
-				await refreshMovieFromApi();
-			}
 		} catch (error) {
 			showActionError(m.toast_library_movieDetail_failedToUpdate(), error);
 		} finally {

--- a/src/routes/library/tv/[id]/+page.server.ts
+++ b/src/routes/library/tv/[id]/+page.server.ts
@@ -7,8 +7,7 @@ import {
 	rootFolders,
 	scoringProfiles,
 	downloadQueue,
-	subtitles,
-	settings
+	subtitles
 } from '$lib/server/db/schema.js';
 import { eq, asc, inArray, and } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
@@ -20,6 +19,7 @@ import type { TVShowDetails } from '$lib/types/tmdb';
 import { tmdb } from '$lib/server/tmdb.js';
 import { logger } from '$lib/logging';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
+import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 
 export interface SeasonWithEpisodes {
 	id: string;
@@ -111,9 +111,7 @@ export interface LibrarySeriesPageData {
 		tmdbId: number;
 		tvdbId: number | null;
 		imdbId: string | null;
-		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal' | null;
 		providerRefs: Partial<Record<'tmdb' | 'anilist' | 'mal', string>> | null;
-		pinnedExternal: { provider: 'tmdb' | 'anilist' | 'mal'; id: string } | null;
 		title: string;
 		originalTitle: string | null;
 		year: number | null;
@@ -165,9 +163,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 			tmdbId: series.tmdbId,
 			tvdbId: series.tvdbId,
 			imdbId: series.imdbId,
-			metadataProvider: series.metadataProvider,
 			providerRefs: series.providerRefs,
-			pinnedExternal: series.pinnedExternal,
 			title: series.title,
 			originalTitle: series.originalTitle,
 			year: series.year,
@@ -387,27 +383,11 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 
 	// Check if a search is currently running for this series
 	const isSearching = isSeriesSearching(id);
-	let configuredMetadataProviders = {
-		anilist: false,
-		mal: false
+	const providerConfig = await getMetadataProviderConfig();
+	const configuredMetadataProviders = {
+		anilist: providerConfig.animeEnrichmentEnabled,
+		mal: providerConfig.animeEnrichmentEnabled
 	};
-	const settingsRow = await db.query.settings.findFirst({
-		where: eq(settings.key, 'metadata_providers')
-	});
-	if (settingsRow) {
-		try {
-			const parsed = JSON.parse(settingsRow.value) as {
-				anilistEnabled?: boolean;
-				malClientId?: string;
-			};
-			configuredMetadataProviders = {
-				anilist: parsed.anilistEnabled === true,
-				mal: Boolean(parsed.malClientId)
-			};
-		} catch {
-			// ignore malformed settings
-		}
-	}
 
 	const enrichedProviderRefs = await resolveMissingAnimeProviderRefs({
 		title: seriesData.title,
@@ -436,8 +416,6 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 		series: {
 			...seriesData,
 			providerRefs: enrichedProviderRefs,
-			metadataProvider:
-				(seriesData.metadataProvider as 'auto' | 'tmdb' | 'anilist' | 'mal' | null) ?? 'auto',
 			added: seriesData.added ?? new Date().toISOString(),
 			percentComplete
 		},

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -676,7 +676,6 @@
 	async function handleEditSave(editData: SeriesEditData) {
 		isSaving = true;
 		try {
-			const previousMetadataProvider = series.metadataProvider ?? 'auto';
 			const result = await updateSeries(series.id, editData as unknown as Record<string, unknown>);
 
 			series.monitored = editData.monitored;
@@ -684,7 +683,6 @@
 			series.seasonFolder = editData.seasonFolder;
 			series.seriesType = editData.seriesType;
 			series.wantsSubtitles = editData.wantsSubtitles;
-			series.metadataProvider = editData.metadataProvider;
 
 			if (result?.moveQueued) {
 				toasts.success(
@@ -697,10 +695,6 @@
 			}
 
 			isEditModalOpen = false;
-
-			if (previousMetadataProvider !== editData.metadataProvider) {
-				void handleRefresh();
-			}
 		} catch (error) {
 			showActionError(m.toast_library_tvDetail_failedToUpdate(), error);
 		} finally {

--- a/src/routes/settings/general/libraries/+page.svelte
+++ b/src/routes/settings/general/libraries/+page.svelte
@@ -26,7 +26,6 @@
 		name: string;
 		mediaType: RootFolderMediaType;
 		mediaSubType: RootFolderMediaSubType;
-		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
 		rootFolderIds: string[];
 		defaultMonitored: boolean;
 		defaultSearchOnAdd: boolean;
@@ -63,7 +62,6 @@
 		name: '',
 		mediaType: 'movie',
 		mediaSubType: 'standard',
-		metadataProvider: 'auto',
 		rootFolderIds: [],
 		defaultMonitored: true,
 		defaultSearchOnAdd: true,
@@ -96,7 +94,6 @@
 			name: '',
 			mediaType: 'movie',
 			mediaSubType: 'standard',
-			metadataProvider: 'auto',
 			rootFolderIds: [],
 			defaultMonitored: true,
 			defaultSearchOnAdd: true,
@@ -113,7 +110,6 @@
 			name: library.name,
 			mediaType: library.mediaType,
 			mediaSubType: library.mediaSubType,
-			metadataProvider: library.metadataProvider ?? 'auto',
 			rootFolderIds: library.rootFolders?.map((folder: RootFolderRef) => folder.id) ?? [],
 			defaultMonitored: library.defaultMonitored ?? true,
 			defaultSearchOnAdd: library.defaultSearchOnAdd ?? true,
@@ -385,22 +381,6 @@
 					>
 						<option value="standard">{m.settings_general_standard()}</option>
 						<option value="anime">{m.settings_general_badgeAnime()}</option>
-					</select>
-				</div>
-
-				<div class="form-control">
-					<label class="label py-1" for="library-metadata-provider">
-						<span class="label-text">Metadata provider (Anime)</span>
-					</label>
-					<select
-						id="library-metadata-provider"
-						class="select-bordered select select-sm"
-						bind:value={libraryForm.metadataProvider}
-					>
-						<option value="auto">Auto</option>
-						<option value="tmdb">TMDB</option>
-						<option value="anilist">AniList</option>
-						<option value="mal">MyAnimeList</option>
 					</select>
 				</div>
 

--- a/src/routes/settings/general/status/+page.svelte
+++ b/src/routes/settings/general/status/+page.svelte
@@ -63,7 +63,6 @@
 		name: string;
 		mediaType: RootFolderMediaType;
 		mediaSubType: RootFolderMediaSubType;
-		metadataProvider: 'auto' | 'tmdb' | 'anilist' | 'mal';
 		rootFolderIds: string[];
 		defaultMonitored: boolean;
 		defaultSearchOnAdd: boolean;
@@ -85,7 +84,6 @@
 		name: '',
 		mediaType: 'movie',
 		mediaSubType: 'standard',
-		metadataProvider: 'auto',
 		rootFolderIds: [],
 		defaultMonitored: true,
 		defaultSearchOnAdd: true,
@@ -211,7 +209,6 @@
 			name: library.name,
 			mediaType: library.mediaType,
 			mediaSubType: library.mediaSubType,
-			metadataProvider: library.metadataProvider ?? 'auto',
 			rootFolderIds: library.rootFolders?.map((folder: RootFolderRef) => folder.id) ?? [],
 			defaultMonitored: library.defaultMonitored ?? true,
 			defaultSearchOnAdd: library.defaultSearchOnAdd ?? true,
@@ -438,22 +435,6 @@
 					>
 						<option value="standard">{m.settings_general_standard()}</option>
 						<option value="anime">{m.settings_general_badgeAnime()}</option>
-					</select>
-				</div>
-
-				<div class="form-control">
-					<label class="label py-1" for="status-library-metadata-provider">
-						<span class="label-text">Metadata provider (Anime)</span>
-					</label>
-					<select
-						id="status-library-metadata-provider"
-						class="select-bordered select select-sm"
-						bind:value={libraryForm.metadataProvider}
-					>
-						<option value="auto">Auto</option>
-						<option value="tmdb">TMDB</option>
-						<option value="anilist">AniList</option>
-						<option value="mal">MyAnimeList</option>
 					</select>
 				</div>
 

--- a/src/routes/settings/system/+layout.server.ts
+++ b/src/routes/settings/system/+layout.server.ts
@@ -6,6 +6,7 @@ import { getSystemSettingsService } from '$lib/server/settings/SystemSettingsSer
 import { db } from '$lib/server/db';
 import { settings } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
+import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 
 export const load: LayoutServerLoad = async ({ request, locals }) => {
 	// Require authentication
@@ -24,27 +25,8 @@ export const load: LayoutServerLoad = async ({ request, locals }) => {
 		const apiKeySetting = await db.query.settings.findFirst({
 			where: eq(settings.key, 'tmdb_api_key')
 		});
-		const metadataProviderSetting = await db.query.settings.findFirst({
-			where: eq(settings.key, 'metadata_providers')
-		});
-		let metadataProviders = {
-			hasMalClientId: false,
-			hasAniListEnabled: false
-		};
-		if (metadataProviderSetting) {
-			try {
-				const parsed = JSON.parse(metadataProviderSetting.value) as {
-					malClientId?: string;
-					anilistEnabled?: boolean;
-				};
-				metadataProviders = {
-					hasMalClientId: Boolean(parsed.malClientId),
-					hasAniListEnabled: Boolean(parsed.anilistEnabled)
-				};
-			} catch {
-				// Ignore malformed setting and return defaults
-			}
-		}
+
+		const metadataConfig = await getMetadataProviderConfig();
 
 		return {
 			mainApiKey,
@@ -54,7 +36,9 @@ export const load: LayoutServerLoad = async ({ request, locals }) => {
 				hasApiKey: !!apiKeySetting,
 				configured: !!apiKeySetting
 			},
-			metadataProviders
+			metadataProviders: {
+				animeEnrichmentEnabled: metadataConfig.animeEnrichmentEnabled
+			}
 		};
 	} catch (err) {
 		logger.error({ err, component: 'SystemSettingsPage' }, 'Error loading system settings');
@@ -64,8 +48,7 @@ export const load: LayoutServerLoad = async ({ request, locals }) => {
 			externalUrl: null,
 			tmdb: { hasApiKey: false, configured: false },
 			metadataProviders: {
-				hasMalClientId: false,
-				hasAniListEnabled: false
+				animeEnrichmentEnabled: true
 			},
 			error: 'Failed to load system settings'
 		};

--- a/src/routes/settings/system/metadata-providers/+page.svelte
+++ b/src/routes/settings/system/metadata-providers/+page.svelte
@@ -7,11 +7,7 @@
 	import { page } from '$app/state';
 	import { ModalWrapper, ModalHeader, ModalFooter } from '$lib/components/ui/modal';
 	import { SettingsPage, SettingsSection } from '$lib/components/ui/settings';
-	import {
-		updateMetadataProviderSettings,
-		updateTmdbSettings,
-		type MetadataProviderSettingsPayload
-	} from '$lib/api/settings.js';
+	import { updateMetadataProviderSettings, updateTmdbSettings } from '$lib/api/settings.js';
 
 	let { data }: { data: LayoutData } = $props();
 
@@ -22,11 +18,14 @@
 	let tmdbApiKey = $state('');
 	let tmdbSaving = $state(false);
 	let tmdbError = $state<string | null>(null);
-	let providerModalOpen = $state<null | 'anilist' | 'mal'>(null);
-	let providerSaving = $state(false);
-	let providerError = $state<string | null>(null);
-	let anilistEnabled = $state(false);
-	let malClientId = $state('');
+
+	// =====================
+	// Anime Enrichment State
+	// =====================
+	let enrichmentModalOpen = $state(false);
+	let enrichmentSaving = $state(false);
+	let enrichmentError = $state<string | null>(null);
+	let animeEnrichmentEnabled = $state(false);
 
 	function openTmdbModal() {
 		tmdbApiKey = '';
@@ -45,16 +44,15 @@
 		}
 	}
 
-	function openProviderModal(provider: 'anilist' | 'mal') {
-		providerError = null;
-		providerModalOpen = provider;
-		anilistEnabled = data.metadataProviders?.hasAniListEnabled ?? false;
-		malClientId = '';
+	function openEnrichmentModal() {
+		enrichmentError = null;
+		animeEnrichmentEnabled = data.metadataProviders?.animeEnrichmentEnabled ?? true;
+		enrichmentModalOpen = true;
 	}
 
-	function closeProviderModal() {
-		providerError = null;
-		providerModalOpen = null;
+	function closeEnrichmentModal() {
+		enrichmentError = null;
+		enrichmentModalOpen = false;
 	}
 
 	async function handleTmdbSave() {
@@ -75,26 +73,19 @@
 		}
 	}
 
-	async function handleProviderSave(provider: 'anilist' | 'mal') {
-		providerSaving = true;
-		providerError = null;
+	async function handleEnrichmentSave() {
+		enrichmentSaving = true;
+		enrichmentError = null;
 		try {
-			let payload: MetadataProviderSettingsPayload;
-			if (provider === 'anilist') {
-				payload = { anilistEnabled };
-			} else {
-				payload = { malClientId };
-			}
-
-			await updateMetadataProviderSettings(payload);
+			await updateMetadataProviderSettings({ animeEnrichmentEnabled });
 			await invalidateAll();
-			toasts.success('Metadata provider settings saved');
-			closeProviderModal();
+			toasts.success('Anime enrichment settings saved');
+			closeEnrichmentModal();
 		} catch (error) {
-			providerError =
+			enrichmentError =
 				error instanceof Error ? error.message : m.settings_integrations_tmdbFailedToSave();
 		} finally {
-			providerSaving = false;
+			enrichmentSaving = false;
 		}
 	}
 
@@ -157,72 +148,30 @@
 	</SettingsSection>
 
 	<SettingsSection
-		title="AniList"
-		description="Public AniList metadata for anime (no OAuth required for this integration)."
+		title="Anime Metadata Enrichment"
+		description="When enabled, AniList and MyAnimeList (via Jikan) automatically enrich anime titles with alternate titles and adult classification. No account or API key required."
 	>
 		<div class="flex items-center gap-3">
-			{#if data.metadataProviders?.hasAniListEnabled}
+			{#if data.metadataProviders?.animeEnrichmentEnabled}
 				<div class="badge gap-1 badge-success">
 					<CheckCircle class="h-3 w-3" />
-					{m.settings_integrations_configured()}
+					Enabled
 				</div>
 			{:else}
 				<div class="badge gap-1 badge-warning">
 					<AlertCircle class="h-3 w-3" />
-					{m.settings_integrations_notConfigured()}
+					Disabled
 				</div>
 			{/if}
-			<button onclick={() => openProviderModal('anilist')} class="btn gap-1 btn-sm btn-primary">
-				{data.metadataProviders?.hasAniListEnabled ? m.action_update() : m.action_configure()}
+			<button onclick={openEnrichmentModal} class="btn gap-1 btn-sm btn-primary">
+				Configure
 				<ChevronRight class="h-4 w-4" />
 			</button>
 		</div>
-		{#if !data.metadataProviders?.hasAniListEnabled}
-			<div class="alert alert-info">
-				<AlertCircle class="h-5 w-5" />
-				<div>
-					<p class="text-sm">
-						AniList does not require OAuth for this integration. Enable the provider and save.
-					</p>
-				</div>
-			</div>
-		{/if}
-	</SettingsSection>
-
-	<SettingsSection
-		title="MyAnimeList"
-		description="MAL metadata via official API (client id only for metadata lookups)."
-	>
-		<div class="flex items-center gap-3">
-			{#if data.metadataProviders?.hasMalClientId}
-				<div class="badge gap-1 badge-success">
-					<CheckCircle class="h-3 w-3" />
-					{m.settings_integrations_configured()}
-				</div>
-			{:else}
-				<div class="badge gap-1 badge-warning">
-					<AlertCircle class="h-3 w-3" />
-					{m.settings_integrations_notConfigured()}
-				</div>
-			{/if}
-			<button onclick={() => openProviderModal('mal')} class="btn gap-1 btn-sm btn-primary">
-				{data.metadataProviders?.hasMalClientId ? m.action_update() : m.action_configure()}
-				<ChevronRight class="h-4 w-4" />
-			</button>
-		</div>
-		{#if !data.metadataProviders?.hasMalClientId}
-			<div class="alert alert-info">
-				<AlertCircle class="h-5 w-5" />
-				<div>
-					<p class="text-sm">
-						Create a MAL app to get a Client ID:
-						<a href="https://myanimelist.net/apiconfig" target="_blank" class="link link-primary">
-							myanimelist.net/apiconfig
-						</a>.
-					</p>
-				</div>
-			</div>
-		{/if}
+		<p class="text-sm text-base-content/70">
+			Enrichment data is supplementary only - TMDB remains the canonical source for title, overview,
+			and display metadata.
+		</p>
 	</SettingsSection>
 </SettingsPage>
 
@@ -267,69 +216,33 @@
 	</form>
 </ModalWrapper>
 
-<ModalWrapper open={providerModalOpen === 'anilist'} onClose={closeProviderModal} maxWidth="md">
-	<ModalHeader title="Configure AniList" onClose={closeProviderModal} />
+<!-- Anime Enrichment Toggle Modal -->
+<ModalWrapper open={enrichmentModalOpen} onClose={closeEnrichmentModal} maxWidth="md">
+	<ModalHeader title="Anime Metadata Enrichment" onClose={closeEnrichmentModal} />
 	<form
 		onsubmit={async (event) => {
 			event.preventDefault();
-			await handleProviderSave('anilist');
+			await handleEnrichmentSave();
 		}}
 	>
 		<div class="space-y-4 p-4">
 			<p class="text-sm text-base-content/70">
-				AniList does not require OAuth for this integration. Enable it to allow AniList metadata
-				lookups.
-				<a
-					href="https://anilist.gitbook.io/anilist-apiv2-docs/"
-					target="_blank"
-					class="link link-primary"
-				>
-					AniList API docs
-				</a>.
+				When enabled, Cinephage automatically queries AniList and MyAnimeList (via Jikan) for anime
+				titles during metadata refresh. This supplies alternate and romaji titles for better indexer
+				search coverage, and the adult classification used for XXX category searches.
 			</p>
 			<label class="label cursor-pointer justify-start gap-3">
-				<input type="checkbox" class="checkbox" bind:checked={anilistEnabled} />
-				<span class="label-text">Enable AniList metadata provider</span>
+				<input type="checkbox" class="checkbox" bind:checked={animeEnrichmentEnabled} />
+				<span class="label-text">Enable anime metadata enrichment</span>
 			</label>
-			{#if providerError}
-				<div class="alert alert-error"><span>{providerError}</span></div>
+			{#if enrichmentError}
+				<div class="alert alert-error"><span>{enrichmentError}</span></div>
 			{/if}
 		</div>
 		<ModalFooter
-			onCancel={closeProviderModal}
-			onSave={() => handleProviderSave('anilist')}
-			saving={providerSaving}
-		/>
-	</form>
-</ModalWrapper>
-
-<ModalWrapper open={providerModalOpen === 'mal'} onClose={closeProviderModal} maxWidth="md">
-	<ModalHeader title="Configure MyAnimeList" onClose={closeProviderModal} />
-	<form
-		onsubmit={async (event) => {
-			event.preventDefault();
-			await handleProviderSave('mal');
-		}}
-	>
-		<div class="space-y-4 p-4">
-			<p class="text-sm text-base-content/70">
-				Create a MAL app and paste the Client ID here.
-				<a href="https://myanimelist.net/apiconfig" target="_blank" class="link link-primary">
-					myanimelist.net/apiconfig
-				</a>.
-			</p>
-			<div class="form-control w-full">
-				<label class="label" for="malClientId"><span class="label-text">Client ID</span></label>
-				<input id="malClientId" class="input-bordered input w-full" bind:value={malClientId} />
-			</div>
-			{#if providerError}
-				<div class="alert alert-error"><span>{providerError}</span></div>
-			{/if}
-		</div>
-		<ModalFooter
-			onCancel={closeProviderModal}
-			onSave={() => handleProviderSave('mal')}
-			saving={providerSaving}
+			onCancel={closeEnrichmentModal}
+			onSave={handleEnrichmentSave}
+			saving={enrichmentSaving}
 		/>
 	</form>
 </ModalWrapper>


### PR DESCRIPTION
## Summary

Fix anime episode and season search filtering by handling absolute-numbered releases and unparsed packs; add per-step filter breakdown in the pipeline UI; wire adult/anime classification into category filtering; retire the per-provider metadata dropdowns in favour of a single AniList/TMDB toggle with Jikan v4 as the anime supplement; add DB migrations for provider-choice column removal and adult flag.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Add `ANIME_EPISODE_FORMATS` so anime episode searches send both `S01E01` and zero-padded absolute (`01`) query variants; fix `generateEpisodeFormat` to zero-pad the absolute case; wire `Episode.Absolute` into TemplateEngine
- Add `animeAbsoluteMatches` to accept releases where `absoluteEpisode === targetEpisode` (e.g. `Kegareboshi - 01`); add `animeUnparsedFallback` to surface `[01-08 END]`-style range packs the parser cannot classify
- Season searches now return only season packs; episode searches return only individual episodes with virtual pointers from packs when no individual file exists
- `filterByCategoryMatch` accepts XXX (6xxx) and Movie (2xxx) categories when `criteria.isAdult=true`; wire `isAnime`/`isAdult` from library metadata into search criteria
- Merge `filterByTitleRelevance` into `filterByIdOrTitleMatch` as the single relevance gate; fix `yearMatch` to only reject when both sides carry a year; run title filter in the non-enhanced `search()` path
- Add `FilterBreakdown` tracking per-step counts; expose in `/api/search` response; highlight culprit step in red in the Pipeline panel
- Replace MAL transport with Jikan v4 (no API key required); retire `resolveProviderWithFallback`; collapse provider selection to one AniList-or-TMDB toggle; strip provider UI
- Add `propagateProwlarrApiKey` / `propagateJackettApiKey` to re-sync credentials on connection update; search timeouts no longer record a failure in the status tracker
- Migration 095: drop `animeMetadataProvider`, `movieMetadataProvider`, `tvMetadataProvider` columns; Migration 096: add `adult` boolean to `movies` and `series`

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
