### PR TITLE
feat: library redesign, discover media hero, and dashboard improvements

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1039,6 +1039,7 @@
 	"library_movieFilesTab_searchDownloads": "Search for Downloads",
 	"library_movieFilesTab_unknownTotalSize": "Unknown total size",
 	"library_movieHeader_autoGrab": "Auto-grab",
+	"library_movieHeader_backToLibrary": "Back to Library",
 	"library_movieHeader_autoGrabTooltip": "Automatically search and grab movie",
 	"library_movieHeader_failed": "Failed",
 	"library_movieHeader_grabbed": "Grabbed",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1039,7 +1039,7 @@
 	"library_movieFilesTab_searchDownloads": "Search for Downloads",
 	"library_movieFilesTab_unknownTotalSize": "Unknown total size",
 	"library_movieHeader_autoGrab": "Auto-grab",
-	"library_movieHeader_backToLibrary": "Back to Library",
+	"library_movieHeader_backToLibrary": "Back to ",
 	"library_movieHeader_autoGrabTooltip": "Automatically search and grab movie",
 	"library_movieHeader_failed": "Failed",
 	"library_movieHeader_grabbed": "Grabbed",

--- a/src/lib/components/dashboard/DashboardStatsGrid.svelte
+++ b/src/lib/components/dashboard/DashboardStatsGrid.svelte
@@ -8,7 +8,9 @@
 		CheckCircle,
 		FileQuestion,
 		Calendar,
-		HardDrive
+		HardDrive,
+		ChevronDown,
+		ChevronUp
 	} from 'lucide-svelte';
 	import Skeleton from '$lib/components/ui/Skeleton.svelte';
 	import { resolve } from '$app/paths';
@@ -27,6 +29,11 @@
 		const parts: string[] = [m.dashboard_stats_filesCount({ count: stats.movies.withFile })];
 		if (stats.movies.missing > 0)
 			parts.push(m.dashboard_stats_missingCount({ count: stats.movies.missing }));
+		return parts.join(' · ');
+	});
+
+	const movieDetails = $derived.by(() => {
+		const parts: string[] = [];
 		if (stats.movies.inCinemas > 0)
 			parts.push(m.dashboard_stats_inTheatersCount({ count: stats.movies.inCinemas }));
 		if (stats.movies.unreleased > 0)
@@ -40,6 +47,11 @@
 		const parts: string[] = [m.dashboard_stats_filesCount({ count: stats.episodes.withFile })];
 		if (stats.episodes.missing > 0)
 			parts.push(m.dashboard_stats_missingCount({ count: stats.episodes.missing }));
+		return parts.join(' · ');
+	});
+
+	const episodeDetails = $derived.by(() => {
+		const parts: string[] = [];
 		if (stats.episodes.unaired > 0)
 			parts.push(m.dashboard_stats_unairedCount({ count: stats.episodes.unaired }));
 		if (stats.episodes.unmonitoredMissing > 0)
@@ -63,18 +75,67 @@
 		return parts.length > 0 ? parts.join(' · ') : m.dashboard_stats_noActiveDownloads();
 	});
 
-	const storageSummary = $derived.by(() => {
-		const parts: string[] = [];
-		if (stats.storage.movieBytes > 0)
-			parts.push(`${formatBytes(stats.storage.movieBytes)} ${m.dashboard_stats_movies()}`);
-		if (stats.storage.tvBytes > 0)
-			parts.push(`${formatBytes(stats.storage.tvBytes)} ${m.dashboard_stats_tvShows()}`);
-		if (stats.storage.freeBytes > 0)
-			parts.push(m.dashboard_stats_freeSpace({ size: formatBytes(stats.storage.freeBytes) }));
-		return parts.length > 0 ? parts.join(' · ') : m.dashboard_stats_noFilesOnDisk();
-	});
+	const storageMovieBytes = $derived(
+		stats.storage.movieBytes > 0 ? formatBytes(stats.storage.movieBytes) : null
+	);
+	const storageTvBytes = $derived(
+		stats.storage.tvBytes > 0 ? formatBytes(stats.storage.tvBytes) : null
+	);
+	const storageFreeSpace = $derived(
+		stats.storage.freeBytes > 0
+			? m.dashboard_stats_freeSpace({ size: formatBytes(stats.storage.freeBytes) })
+			: null
+	);
 
 	const storageCapacity = $derived(stats.storage.totalBytes + stats.storage.freeBytes);
+
+	let movieSummaryEl = $state<HTMLElement | null>(null);
+	let movieTruncated = $state(false);
+	let movieExpanded = $state(false);
+
+	let episodeSummaryEl = $state<HTMLElement | null>(null);
+	let episodeTruncated = $state(false);
+	let episodeExpanded = $state(false);
+
+	let storageSummaryEl = $state<HTMLElement | null>(null);
+	let storageTruncated = $state(false);
+	let storageExpanded = $state(false);
+
+	$effect(() => {
+		const el = movieSummaryEl;
+		if (!el) return;
+		const check = () => {
+			movieTruncated = el.scrollWidth > el.clientWidth;
+		};
+		check();
+		const ro = new ResizeObserver(check);
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
+
+	$effect(() => {
+		const el = episodeSummaryEl;
+		if (!el) return;
+		const check = () => {
+			episodeTruncated = el.scrollWidth > el.clientWidth;
+		};
+		check();
+		const ro = new ResizeObserver(check);
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
+
+	$effect(() => {
+		const el = storageSummaryEl;
+		if (!el) return;
+		const check = () => {
+			storageTruncated = el.scrollWidth > el.clientWidth;
+		};
+		check();
+		const ro = new ResizeObserver(check);
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
 </script>
 
 <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] items-start gap-3 sm:gap-4">
@@ -92,8 +153,31 @@
 				<span class="text-xl font-bold">{stats.movies.total}</span>
 				<span class="text-sm text-base-content/60">{m.dashboard_stats_movies()}</span>
 			</div>
-			<div class="truncate text-xs text-base-content/50" title={movieSummary}>
-				{movieSummary}
+			<div class="relative flex min-w-0 items-start">
+				<span
+					bind:this={movieSummaryEl}
+					class="text-xs text-base-content/50 {movieExpanded ? 'wrap-break-word' : 'truncate'}"
+					>{movieSummary}{movieDetails ? ` · ${movieDetails}` : ''}</span
+				>
+				{#if movieTruncated && !movieExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							movieExpanded = true;
+						}}
+						aria-label="Show full stats"><ChevronDown class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{:else if movieExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							movieExpanded = false;
+						}}
+						aria-label="Collapse stats"><ChevronUp class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{/if}
 			</div>
 			{#if stats.movies.total > 0}
 				<progress
@@ -121,8 +205,31 @@
 				<span class="text-xl font-bold">{stats.series.total}</span>
 				<span class="text-sm text-base-content/60">{m.dashboard_stats_tvShows()}</span>
 			</div>
-			<div class="truncate text-xs text-base-content/50" title={episodeSummary}>
-				{episodeSummary}
+			<div class="relative flex min-w-0 items-start">
+				<span
+					bind:this={episodeSummaryEl}
+					class="text-xs text-base-content/50 {episodeExpanded ? 'wrap-break-word' : 'truncate'}"
+					>{episodeSummary}{episodeDetails ? ` · ${episodeDetails}` : ''}</span
+				>
+				{#if episodeTruncated && !episodeExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							episodeExpanded = true;
+						}}
+						aria-label="Show full stats"><ChevronDown class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{:else if episodeExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							episodeExpanded = false;
+						}}
+						aria-label="Collapse stats"><ChevronUp class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{/if}
 			</div>
 			{#if stats.episodes.total > 0}
 				<progress
@@ -204,10 +311,9 @@
 					<span class="text-sm text-base-content/60">{m.dashboard_stats_unmatched()}</span>
 				</div>
 				<div class="truncate text-xs text-base-content/50">
-					{m.dashboard_stats_filesNeedAttention()}
-					{#if stats.missingRootFolders > 0}
-						· {m.dashboard_stats_rootFolderIssues()}
-					{/if}
+					{m.dashboard_stats_filesNeedAttention()}{stats.missingRootFolders > 0
+						? ` · ${m.dashboard_stats_rootFolderIssues()}`
+						: ''}
 				</div>
 				<div class="h-1"></div>
 			</div>
@@ -256,10 +362,59 @@
 					<HardDrive class="h-5 w-5 text-info" />
 				</div>
 				<span class="text-xl font-bold">{formatBytes(stats.storage.totalBytes)}</span>
-				<span class="text-sm text-base-content/60">{m.dashboard_stats_storage()}</span>
+				<span class="text-sm text-base-content/60">Storage</span>
 			</div>
-			<div class="truncate text-xs text-base-content/50" title={storageSummary}>
-				{storageSummary}
+			<div class="relative flex min-w-0 items-start">
+				<span
+					bind:this={storageSummaryEl}
+					class="flex min-w-0 items-center gap-1 text-xs text-base-content/50 {storageExpanded
+						? 'flex-wrap gap-y-0.5'
+						: 'overflow-hidden'}"
+				>
+					{#if storageMovieBytes}
+						<span class="flex shrink-0 items-center gap-0.5 {!storageExpanded ? 'min-w-0' : ''}">
+							<Clapperboard class="h-3 w-3 shrink-0" /><span
+								class={!storageExpanded ? 'truncate' : ''}>{storageMovieBytes}</span
+							>
+						</span>
+					{/if}
+					{#if storageTvBytes}
+						{#if storageMovieBytes}<span class="shrink-0 text-base-content/30">·</span>{/if}
+						<span class="flex shrink-0 items-center gap-0.5">
+							<Tv class="h-3 w-3 shrink-0" /><span>{storageTvBytes}</span>
+						</span>
+					{/if}
+					{#if storageFreeSpace}
+						{#if storageMovieBytes || storageTvBytes}<span class="shrink-0 text-base-content/30"
+								>·</span
+							>{/if}
+						<span class="shrink-0">{storageFreeSpace}</span>
+					{/if}
+					{#if !storageMovieBytes && !storageTvBytes}
+						{m.dashboard_stats_noFilesOnDisk()}
+					{/if}
+				</span>
+				{#if storageTruncated && !storageExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							storageExpanded = true;
+						}}
+						aria-label="Show full storage breakdown"
+						><ChevronDown class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{:else if storageExpanded}
+					<button
+						class="relative z-10 ml-0.5 shrink-0 p-1 text-base-content/30 hover:text-base-content/60 sm:p-0"
+						onclick={(e) => {
+							e.preventDefault();
+							storageExpanded = false;
+						}}
+						aria-label="Collapse storage breakdown"
+						><ChevronUp class="h-3.5 w-3.5 sm:h-3 sm:w-3" /></button
+					>
+				{/if}
 			</div>
 			{#if storageCapacity > 0}
 				<progress

--- a/src/lib/components/dashboard/QuickActions.svelte
+++ b/src/lib/components/dashboard/QuickActions.svelte
@@ -4,7 +4,7 @@
 		Compass,
 		Download,
 		Activity,
-		TrendingUp,
+		DatabaseSearch,
 		ListTodo,
 		AlertTriangle,
 		Search,
@@ -43,7 +43,7 @@
 					href={resolve('/settings/integrations/indexers')}
 					class="btn min-w-34 justify-center border-warning bg-warning text-warning-content btn-sm hover:border-warning hover:bg-warning/90"
 				>
-					<TrendingUp class="h-4 w-4" />
+					<DatabaseSearch class="h-4 w-4" />
 					{m.dashboard_quickActions_addIndexer()}
 				</a>
 				<a
@@ -104,13 +104,13 @@
 						href={resolve('/settings/integrations/indexers')}
 						class="btn min-w-34 justify-center border-accent bg-accent text-accent-content btn-sm hover:border-accent hover:bg-accent/90"
 					>
-						<TrendingUp class="h-4 w-4" />
+						<DatabaseSearch class="h-4 w-4" />
 						{m.dashboard_quickActions_indexers()}
 					</a>
 				{/if}
 				{#if hasMissingEpisodes}
 					<a
-						href={resolve('/activity')}
+						href={resolve('/settings/tasks')}
 						class="btn min-w-34 justify-center border-warning bg-warning text-warning-content btn-sm hover:border-warning hover:bg-warning/90"
 					>
 						<Search class="h-4 w-4" />

--- a/src/lib/components/discover/SectionRow.svelte
+++ b/src/lib/components/discover/SectionRow.svelte
@@ -123,7 +123,7 @@
 	<div class="group/carousel relative">
 		{#if showLeftArrow}
 			<button
-				class="btn absolute top-1/2 left-0 z-20 btn-circle -translate-x-1/2 -translate-y-1/2 border-none bg-base-100/80 opacity-0 shadow-lg backdrop-blur-sm transition-all duration-300 btn-sm btn-neutral group-hover/carousel:opacity-100"
+				class="btn absolute top-1/2 left-0 z-20 btn-circle -translate-x-1/2 -translate-y-1/2 border-none bg-base-content text-base-100 opacity-0 shadow-lg transition-all duration-300 btn-sm group-hover/carousel:opacity-100"
 				onclick={() => scroll('left')}
 				transition:fade
 				aria-label={m.sectionRow_scrollLeft()}
@@ -174,7 +174,7 @@
 
 		{#if showRightArrow}
 			<button
-				class="btn absolute top-1/2 right-0 z-20 btn-circle translate-x-1/2 -translate-y-1/2 border-none bg-base-100/80 opacity-0 shadow-lg backdrop-blur-sm transition-all duration-300 btn-sm btn-neutral group-hover/carousel:opacity-100"
+				class="btn absolute top-1/2 right-0 z-20 btn-circle translate-x-1/2 -translate-y-1/2 border-none bg-base-content text-base-100 opacity-0 shadow-lg transition-all duration-300 btn-sm group-hover/carousel:opacity-100"
 				onclick={() => scroll('right')}
 				transition:fade
 				aria-label={m.sectionRow_scrollRight()}

--- a/src/lib/components/discover/SectionRow.svelte
+++ b/src/lib/components/discover/SectionRow.svelte
@@ -148,7 +148,7 @@
 		<div
 			bind:this={container}
 			onscroll={handleScroll}
-			class="flex snap-x snap-mandatory [scrollbar-width:none] gap-3 overflow-x-auto scroll-smooth px-1 pb-4 sm:gap-4 [&::-webkit-scrollbar]:hidden"
+			class="flex snap-x snap-mandatory scrollbar-none gap-3 overflow-x-auto scroll-smooth px-1 pb-4 sm:gap-4 [&::-webkit-scrollbar]:hidden"
 		>
 			{#each displayedItems as item (item.id)}
 				<div class={`flex-none snap-start ${resolvedItemClass}`}>

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -73,6 +73,8 @@
 
 	interface Props {
 		movie: LibraryMovie;
+		librarySlug?: string | null;
+		libraryName?: string | null;
 		tmdbMovie?: MovieDetails | null;
 		defaultRegion?: string;
 		configuredProviders?: { anilist: boolean; mal: boolean };
@@ -92,6 +94,8 @@
 
 	let {
 		movie,
+		librarySlug = null,
+		libraryName = null,
 		tmdbMovie = null,
 		defaultRegion = TMDB.DEFAULT_REGION,
 		configuredProviders = { anilist: false, mal: false },
@@ -258,11 +262,15 @@
 	<!-- Top action bar -->
 	<div class="flex items-center justify-between gap-2">
 		<a
-			href={resolvePath('/library/movies')}
+			href={resolvePath(librarySlug ? `/library/movies?library=${librarySlug}` : '/library/movies')}
 			class="btn btn-ghost btn-sm gap-1.5 text-base-content/60"
 		>
 			<ArrowLeft size={16} />
-			<span class="hidden sm:inline">{m.library_movieHeader_backToLibrary()}</span>
+			<span class="sm:inline"
+				>{libraryName
+					? `${m.library_movieHeader_backToLibrary()} ${libraryName}`
+					: m.library_movieHeader_backToLibrary()}</span
+			>
 		</a>
 		<div class="flex shrink-0 items-center gap-1 sm:gap-2">
 			<MonitorToggle monitored={movie.monitored ?? false} onToggle={onMonitorToggle} size="md" />

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -624,7 +624,7 @@
 							{/if}
 						</div>
 						<div
-							class="flex w-full items-center gap-1 overflow-x-auto pb-0.5 border-t border-base-content/10 pt-2 sm:w-auto sm:shrink-0 sm:border-0 sm:pt-0 sm:overflow-x-visible sm:pb-0"
+							class="flex w-full items-center gap-1 overflow-x-auto border-t border-base-content/10 pt-2 pb-0.5 sm:w-auto sm:shrink-0 sm:border-0 sm:pt-0 sm:overflow-x-visible sm:pb-0"
 						>
 							{#if movie.tmdbId}
 								<a

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -35,6 +35,7 @@
 	import { TMDB } from '$lib/config/constants.js';
 	import { extractReleaseDates } from '$lib/utils/extractReleaseDates.js';
 	import { getSmartReleaseLine } from '$lib/utils/smartReleaseLine.js';
+	import { formatReleaseLine } from '$lib/utils/releaseLineText.js';
 
 	const SOURCE_LABELS: Record<string, string> = {
 		bluray: 'Bluray',
@@ -346,7 +347,7 @@
 										? 'text-primary'
 										: ''}"
 						>
-							{smartRelease.text}
+							{formatReleaseLine(smartRelease)}
 						</div>
 					{:else}
 						<div class="font-medium">{tmdbMovie.status}</div>

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -20,15 +20,14 @@
 		Zap,
 		Ban,
 		Play,
-		MoreHorizontal
+		MoreHorizontal,
+		ArrowLeft,
+		Eye,
+		EyeOff
 	} from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages.js';
-	import {
-		formatBytes,
-		formatCurrency,
-		formatLanguage,
-		formatDisplayDateShort
-	} from '$lib/utils/format.js';
+	import { formatBytes, formatLanguage, formatDisplayDateShort } from '$lib/utils/format.js';
+	import { resolvePath } from '$lib/utils/routing.js';
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { blockMedia } from '$lib/api/settings.js';
@@ -36,8 +35,28 @@
 	import { TMDB } from '$lib/config/constants.js';
 	import { extractReleaseDates } from '$lib/utils/extractReleaseDates.js';
 	import { getSmartReleaseLine } from '$lib/utils/smartReleaseLine.js';
-	import { formatReleaseLine } from '$lib/utils/releaseLineText.js';
-	import { releaseTypeLabel } from '$lib/utils/releaseTypeLabel.js';
+
+	const SOURCE_LABELS: Record<string, string> = {
+		bluray: 'Bluray',
+		webdl: 'WEB-DL',
+		webrip: 'WEBRip',
+		hdtv: 'HDTV',
+		dvd: 'DVD',
+		unknown: 'Unknown'
+	};
+
+	function formatSource(source: string): string {
+		return SOURCE_LABELS[source.toLowerCase()] ?? source.charAt(0).toUpperCase() + source.slice(1);
+	}
+
+	const RELEASE_TYPE_LABELS: Record<number, () => string> = {
+		1: () => m.hero_releaseType_premiere(),
+		2: () => m.hero_releaseType_limitedTheatrical(),
+		3: () => m.hero_releaseType_theatrical(),
+		4: () => m.hero_releaseType_digital(),
+		5: () => m.hero_releaseType_physical(),
+		6: () => m.hero_releaseType_tv()
+	};
 
 	interface AutoSearchResult {
 		found: boolean;
@@ -152,6 +171,19 @@
 			physicalReleaseDate: movie.physicalReleaseDate
 		})
 	);
+	const showUnreleasedBadge = $derived(
+		!movie.hasFile && Boolean(movie.monitored) && movieAvailability !== 'released'
+	);
+	const unreleasedLabel = $derived.by(() => {
+		if (movieAvailability === 'announced') return m.common_unreleased();
+		if (movieAvailability === 'inCinemas') return m.common_inTheaters();
+		return m.common_unreleased();
+	});
+	const unreleasedBadgeStyle = $derived(
+		movieAvailability === 'inCinemas'
+			? 'bg-info/5 text-info/80 ring-info/25'
+			: 'bg-error/5 text-error/80 ring-error/25'
+	);
 	const statusQualityText = $derived.by(() => {
 		if (isStreamerProfile && movie.hasFile) return 'Auto';
 		if (!bestQuality.quality) return null;
@@ -184,23 +216,23 @@
 			}
 		}
 
-		const priorityOrder = [3, 4, 5, 2, 6, 1];
-		const releases: Array<{ type: string; date: string; isPast: boolean }> = [];
 		const now = new Date();
-
-		for (const typeNum of priorityOrder) {
+		function toEntry(typeNum: number) {
 			const release = releasesByType.get(typeNum);
-			if (release) {
-				const releaseDate = new Date(release.release_date);
-				releases.push({
-					type: releaseTypeLabel(typeNum),
-					date: formatDisplayDateShort(release.release_date),
-					isPast: releaseDate <= now
-				});
-			}
+			if (!release) return null;
+			return {
+				label: RELEASE_TYPE_LABELS[typeNum]!(),
+				date: formatDisplayDateShort(release.release_date),
+				isPast: new Date(release.release_date) <= now
+			};
 		}
 
-		return { certification, releases };
+		return {
+			certification,
+			theatrical: toEntry(3),
+			digital: toEntry(4),
+			physical: toEntry(5)
+		};
 	});
 
 	const smartRelease = $derived.by(() => {
@@ -210,53 +242,9 @@
 			releaseDate: dates.theatricalDate,
 			digitalReleaseDate: dates.digitalReleaseDate,
 			physicalReleaseDate: dates.physicalReleaseDate,
-			tvReleaseDate: dates.tvReleaseDate,
 			status: tmdbMovie.status
 		});
 	});
-
-	// Badge state derives from the same release stage as the status line so the
-	// two can never contradict each other. Falls back to the stored-row
-	// availability level only when TMDB release data is not loaded yet.
-	type BadgeKind = 'hidden' | 'inTheaters' | 'comingSoon' | 'unreleased';
-	const badgeKind = $derived.by((): BadgeKind => {
-		if (smartRelease) {
-			switch (smartRelease.key) {
-				case 'availableDigital':
-				case 'availablePhysical':
-					return 'hidden';
-				case 'inTheaters':
-				case 'digitalInDays':
-				case 'physicalInDays':
-					return 'inTheaters';
-				case 'comingToTheaters':
-					return 'comingSoon';
-				case 'announced':
-					return 'unreleased';
-			}
-		}
-		switch (movieAvailability) {
-			case 'released':
-				return 'hidden';
-			case 'inCinemas':
-				return 'inTheaters';
-			default:
-				return 'unreleased';
-		}
-	});
-	const showUnreleasedBadge = $derived(
-		!movie.hasFile && Boolean(movie.monitored) && badgeKind !== 'hidden'
-	);
-	const unreleasedLabel = $derived.by(() => {
-		if (badgeKind === 'inTheaters') return m.common_inTheaters();
-		if (badgeKind === 'comingSoon') return m.common_comingSoon();
-		return m.common_unreleased();
-	});
-	const unreleasedBadgeStyle = $derived(
-		badgeKind === 'inTheaters' || badgeKind === 'comingSoon'
-			? 'bg-info/5 text-info/80 ring-info/25'
-			: 'bg-error/5 text-error/80 ring-error/25'
-	);
 
 	function formatRuntime(minutes: number | null): string {
 		if (!minutes) return '';
@@ -266,41 +254,139 @@
 	}
 </script>
 
-<div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
-	<!-- Backdrop -->
-	<div class="absolute inset-0 h-full w-full">
-		{#if movie.backdropPath}
-			<TmdbImage
-				path={movie.backdropPath}
-				size="original"
-				alt={movie.title}
-				class="h-full w-full object-cover opacity-40 blur-sm"
-			/>
-		{/if}
-		<div class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/80 to-transparent"></div>
-		<div class="absolute inset-0 bg-linear-to-r from-base-200 via-base-200/60 to-transparent"></div>
+<div class="flex flex-col gap-4">
+	<!-- Top action bar -->
+	<div class="flex items-center justify-between gap-2">
+		<a
+			href={resolvePath('/library/movies')}
+			class="btn btn-ghost btn-sm gap-1.5 text-base-content/60"
+		>
+			<ArrowLeft size={16} />
+			<span class="hidden sm:inline">{m.library_movieHeader_backToLibrary()}</span>
+		</a>
+		<div class="flex shrink-0 items-center gap-1 sm:gap-2">
+			<MonitorToggle monitored={movie.monitored ?? false} onToggle={onMonitorToggle} size="md" />
+			<button
+				class="btn btn-primary btn-sm gap-1.5"
+				onclick={onAutoSearch}
+				disabled={autoSearching}
+			>
+				{#if autoSearching}
+					<span class="loading loading-xs loading-spinner"></span>
+				{:else}
+					<Zap size={14} />
+				{/if}
+				<span class="hidden sm:inline">{m.library_movieHeader_autoGrab()}</span>
+			</button>
+			<button class="btn btn-ghost btn-sm gap-1.5 hidden sm:flex" onclick={onSearch}>
+				<Search size={14} />
+				{m.library_movieHeader_manual()}
+			</button>
+			{#if onImport}
+				<button class="btn btn-ghost btn-sm gap-1.5 hidden sm:flex" onclick={onImport}>
+					<Download size={14} />
+					{m.action_import()}
+				</button>
+			{/if}
+			<div class="dropdown dropdown-end">
+				<button tabindex="0" class="btn btn-ghost btn-sm">
+					<MoreHorizontal size={18} />
+				</button>
+				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+				<ul
+					tabindex="0"
+					class="dropdown-content menu z-50 w-52 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+				>
+					<li class="sm:hidden">
+						<button onclick={onSearch}>
+							<Search size={16} />
+							{m.library_movieHeader_manual()}
+						</button>
+					</li>
+					{#if onImport}
+						<li class="sm:hidden">
+							<button onclick={onImport}>
+								<Download size={16} />
+								{m.action_import()}
+							</button>
+						</li>
+					{/if}
+					<div class="divider my-1 sm:hidden"></div>
+					<li>
+						<button onclick={onEdit}>
+							<Settings size={16} />
+							{m.action_edit()}
+						</button>
+					</li>
+					<li>
+						<button class="text-error" onclick={onDelete}>
+							<Trash2 size={16} />
+							{m.action_delete()}
+						</button>
+					</li>
+					<li>
+						<button class="text-error" onclick={() => (showBlockConfirm = true)}>
+							<Ban size={16} />
+							{m.library_blockMediaTooltip()}
+						</button>
+					</li>
+				</ul>
+			</div>
+		</div>
 	</div>
 
-	<!-- Content -->
-	<div class="relative z-10">
-		<!-- Main content -->
-		<div class="flex flex-col gap-6 p-6 md:flex-row md:p-8">
-			<!-- Poster -->
-			<div class="hidden shrink-0 sm:block">
-				<div class="w-32 overflow-hidden rounded-lg shadow-lg md:w-40">
-					<TmdbImage
-						path={movie.posterPath}
-						size="w342"
-						alt={movie.title}
-						class="h-auto w-full object-cover"
-					/>
-				</div>
-			</div>
+	<!-- Hero card -->
+	<div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
+		<!-- Backdrop -->
+		<div class="absolute inset-0 h-full w-full">
+			{#if movie.backdropPath}
+				<TmdbImage
+					path={movie.backdropPath}
+					size="original"
+					alt={movie.title}
+					class="h-full w-full object-cover opacity-40 blur-sm"
+				/>
+			{/if}
+			<div
+				class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/80 to-transparent"
+			></div>
+			<div
+				class="absolute inset-0 bg-linear-to-r from-base-200 via-base-200/60 to-transparent"
+			></div>
+		</div>
 
-			<!-- Main Info -->
-			<div class="flex min-w-0 flex-1 flex-col gap-4">
-				<!-- Title and actions -->
-				<div class="flex items-start justify-between gap-2">
+		<!-- Content -->
+		<div class="relative z-10">
+			<div class="flex flex-col gap-6 p-6 md:flex-row md:p-8">
+				<!-- Poster -->
+				<div class="hidden shrink-0 flex-col gap-2 sm:flex">
+					<div class="w-48 overflow-hidden rounded-lg shadow-lg md:w-56">
+						<TmdbImage
+							path={movie.posterPath}
+							size="w342"
+							alt={movie.title}
+							class="h-auto w-full object-cover"
+						/>
+					</div>
+					<button
+						class="flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-medium transition-colors
+							{movie.monitored
+							? 'bg-success/10 text-success hover:bg-success/20'
+							: 'bg-base-content/5 text-base-content/40 hover:bg-base-content/10'}"
+						onclick={() => onMonitorToggle?.(!movie.monitored)}
+					>
+						{#if movie.monitored}
+							<Eye size={13} />
+							Monitored
+						{:else}
+							<EyeOff size={13} />
+							Unmonitored
+						{/if}
+					</button>
+				</div>
+
+				<!-- Main Info -->
+				<div class="flex min-w-0 flex-1 flex-col gap-4">
 					<div class="min-w-0">
 						<h1 class="text-2xl font-bold md:text-3xl">
 							{movie.title}
@@ -308,7 +394,6 @@
 								<span class="font-normal text-base-content/60">({movie.year})</span>
 							{/if}
 						</h1>
-
 						<div
 							class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-base-content/70"
 						>
@@ -318,9 +403,7 @@
 								</span>
 							{/if}
 							{#if movie.runtime}
-								{#if tmdbMovie?.vote_average}
-									<span class="hidden sm:inline">•</span>
-								{/if}
+								{#if tmdbMovie?.vote_average}<span class="hidden sm:inline">•</span>{/if}
 								<span>{formatRuntime(movie.runtime)}</span>
 							{/if}
 							{#if movie.genres && movie.genres.length > 0}
@@ -329,257 +412,256 @@
 							{/if}
 						</div>
 					</div>
-					<div class="flex shrink-0 items-center gap-1">
-						<MonitorToggle
-							monitored={movie.monitored ?? false}
-							onToggle={onMonitorToggle}
-							size="md"
-						/>
-						<div class="dropdown dropdown-end">
-							<button tabindex="0" class="btn btn-ghost btn-sm">
-								<MoreHorizontal size={18} />
-							</button>
-							<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-							<ul
-								tabindex="0"
-								class="dropdown-content menu z-50 w-52 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
-							>
-								<li>
-									<button onclick={onAutoSearch} disabled={autoSearching}>
-										<Zap size={16} />
-										{m.library_movieHeader_autoGrab()}
-									</button>
-								</li>
-								<li>
-									<button onclick={onSearch}>
-										<Search size={16} />
-										{m.library_movieHeader_manual()}
-									</button>
-								</li>
-								{#if onImport}
-									<li>
-										<button onclick={onImport}>
-											<Download size={16} />
-											{m.action_import()}
-										</button>
-									</li>
-								{/if}
-								<div class="divider my-1"></div>
-								<li>
-									<button onclick={onEdit}>
-										<Settings size={16} />
-										{m.action_edit()}
-									</button>
-								</li>
-								<li>
-									<button class="text-error" onclick={onDelete}>
-										<Trash2 size={16} />
-										{m.action_delete()}
-									</button>
-								</li>
-								<li>
-									<button class="text-error" onclick={() => (showBlockConfirm = true)}>
-										<Ban size={16} />
-										{m.library_blockMediaTooltip()}
-									</button>
-								</li>
-							</ul>
-						</div>
-					</div>
-				</div>
 
-				{#if tmdbMovie?.tagline}
-					<p class="text-base text-base-content/50 italic">"{tmdbMovie.tagline}"</p>
-				{/if}
+					{#if tmdbMovie?.tagline}
+						<p class="border-l-2 border-primary pl-3 text-base text-base-content/50 italic">
+							{tmdbMovie.tagline}
+						</p>
+					{/if}
 
-				{#if overview}
-					<p class="text-base leading-relaxed text-base-content/90">{overview}</p>
-				{/if}
+					{#if overview}
+						<p class="text-base leading-relaxed text-base-content/90">{overview}</p>
+					{/if}
 
-				{#if tmdbMovie?.credits?.crew?.length}
-					<div class="text-sm">
-						<CrewList crew={tmdbMovie.credits.crew} />
-					</div>
-				{/if}
-
-				<!-- Status and external links -->
-				<div class="mt-auto flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-					<div class="flex flex-wrap items-center gap-2 sm:gap-4">
-						<StatusIndicator status={fileStatus} qualityText={statusQualityText} />
-						{#if showUnreleasedBadge}
-							<div
-								class="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm ring-1 {unreleasedBadgeStyle}"
-							>
-								<Clock size={16} />
-								<span class="font-medium">{unreleasedLabel}</span>
-							</div>
-						{/if}
-						{#if movie.hasFile && totalSize > 0}
-							<span class="badge badge-sm badge-info">
-								{formatBytes(totalSize)}
-							</span>
-						{/if}
-						{#if movie.hasFile && movie.files.length > 0}
-							{#if isStreamerProfile}
-								<span class="badge badge-sm badge-secondary">{m.status_streaming()}</span>
-							{:else}
-								<QualityBadge
-									quality={movie.files[0].quality}
-									mediaInfo={movie.files[0].mediaInfo}
-									size="md"
-								/>
-							{/if}
-							{#if !isStreamerProfile}
-								<ScoreBadge
-									score={scoreInfo?.score ?? null}
-									isAtCutoff={scoreInfo?.isAtCutoff ?? false}
-									upgradesAllowed={scoreInfo?.upgradesAllowed ?? true}
-									loading={scoreLoading}
-									size="md"
-									onclick={onScoreClick}
-								/>
-							{/if}
-						{/if}
-					</div>
-
-					<!-- External links -->
-					<div class="flex items-center gap-2 sm:shrink-0">
-						{#if movie.tmdbId}
-							<a
-								href="https://www.themoviedb.org/movie/{movie.tmdbId}"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="btn gap-1 btn-ghost btn-xs"
-							>
-								{m.library_movieHeader_tmdbLink()}
-								<ExternalLink size={12} />
-							</a>
-						{/if}
-						{#if movie.imdbId}
-							<a
-								href="https://www.imdb.com/title/{movie.imdbId}"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="btn gap-1 btn-ghost btn-xs"
-							>
-								{m.library_movieHeader_imdbLink()}
-								<ExternalLink size={12} />
-							</a>
-						{/if}
-						{#each providerLinks as providerLink (providerLink.label)}
-							<a
-								href={providerLink.href}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="btn gap-1 btn-ghost btn-xs"
-							>
-								{providerLink.label}
-								<ExternalLink size={12} />
-							</a>
-						{/each}
-						{#if hasTrailer}
-							<button class="btn gap-1 btn-ghost btn-xs" onclick={openTrailer}>
-								<Play size={12} />
-								{m.hero_trailer()}
-							</button>
-						{/if}
-					</div>
-				</div>
-			</div>
-
-			<!-- Right side metadata panel -->
-			{#if tmdbMovie}
-				<div
-					class="hidden w-64 shrink-0 rounded-lg bg-base-100/30 p-4 backdrop-blur-sm md:block lg:w-80 lg:p-5"
-				>
-					<div class="grid grid-cols-2 gap-x-4 gap-y-2 lg:gap-x-6 lg:gap-y-3">
-						{#if smartRelease}
-							<div class="col-span-2">
-								<div class="text-sm text-base-content/50">{m.hero_metadata_status()}</div>
-								<div
-									class="font-medium {smartRelease.variant === 'released'
-										? 'text-success'
-										: smartRelease.variant === 'theaters'
-											? 'text-info'
-											: smartRelease.variant === 'upcoming'
-												? 'text-primary'
-												: ''}"
-								>
-									{formatReleaseLine(smartRelease)}
-								</div>
-							</div>
-						{:else}
-							<div>
-								<div class="text-sm text-base-content/50">{m.hero_metadata_status()}</div>
-								<div class="font-medium">{tmdbMovie.status}</div>
-							</div>
-						{/if}
-
-						<div>
-							<div class="text-sm text-base-content/50">{m.hero_metadata_language()}</div>
-							<div class="font-medium">{formatLanguage(tmdbMovie.original_language)}</div>
-						</div>
-
-						{#if releaseInfo?.certification}
-							<div>
-								<div class="text-sm text-base-content/50">{m.hero_metadata_rated()}</div>
-								<div>
-									<span class="badge badge-outline badge-sm">{releaseInfo.certification}</span>
-								</div>
-							</div>
-						{/if}
-
-						{#if releaseInfo?.releases && releaseInfo.releases.length > 0}
-							{#each releaseInfo.releases as release (release.type)}
-								<div>
-									<div class="text-sm text-base-content/50">{release.type}</div>
-									<div class="font-medium {release.isPast ? '' : 'text-primary'}">
-										{release.date}
-									</div>
-								</div>
-							{/each}
-						{:else}
-							<div>
-								<div class="text-sm text-base-content/50">
-									{m.hero_releaseType_theatrical()}
-								</div>
-								<div class="font-medium">{formatDisplayDateShort(tmdbMovie.release_date)}</div>
-							</div>
-						{/if}
-
-						{#if tmdbMovie.budget > 0}
-							<div>
-								<div class="text-sm text-base-content/50">{m.hero_metadata_budget()}</div>
-								<div class="font-medium">{formatCurrency(tmdbMovie.budget)}</div>
-							</div>
-						{/if}
-
-						{#if tmdbMovie.revenue > 0}
-							<div>
-								<div class="text-sm text-base-content/50">{m.hero_metadata_revenue()}</div>
-								<div class="font-medium">{formatCurrency(tmdbMovie.revenue)}</div>
-							</div>
-						{/if}
-
-						{#if tmdbMovie.production_companies && tmdbMovie.production_companies.length > 0}
-							<div class="col-span-2">
-								<div class="text-sm text-base-content/50">{m.hero_metadata_studio()}</div>
-								<div class="font-medium">{tmdbMovie.production_companies[0].name}</div>
-							</div>
-						{/if}
-					</div>
-
-					{#if tmdbMovie['watch/providers']}
-						<div class="mt-4 border-t border-base-content/10 pt-4">
-							<div class="mb-2 text-sm text-base-content/50">{m.hero_metadata_whereToWatch()}</div>
-							<WatchProviders
-								providers={tmdbMovie['watch/providers']}
-								countryCode={defaultRegion}
-							/>
+					{#if tmdbMovie?.credits?.crew?.length}
+						<div class="text-sm">
+							<CrewList crew={tmdbMovie.credits.crew} />
 						</div>
 					{/if}
+
+					{#if tmdbMovie?.credits?.cast?.length}
+						<div>
+							<div class="mb-2 text-xs font-medium uppercase tracking-wider text-base-content/40">
+								Cast
+							</div>
+							<div class="flex gap-3 overflow-x-auto pb-1">
+								{#each tmdbMovie.credits.cast.slice(0, 8) as actor (actor.id)}
+									<div class="flex shrink-0 flex-col items-center gap-1.5 w-16">
+										<div class="h-14 w-14 overflow-hidden rounded-full bg-base-300">
+											{#if actor.profile_path}
+												<TmdbImage
+													path={actor.profile_path}
+													size="w185"
+													alt={actor.name}
+													class="h-full w-full object-cover"
+												/>
+											{:else}
+												<div
+													class="flex h-full w-full items-center justify-center text-lg text-base-content/30"
+												>
+													{actor.name.charAt(0)}
+												</div>
+											{/if}
+										</div>
+										<div class="text-center">
+											<div class="text-xs font-medium leading-tight line-clamp-2">{actor.name}</div>
+											{#if actor.character}
+												<div class="text-xs text-base-content/50 leading-tight line-clamp-1">
+													{actor.character}
+												</div>
+											{/if}
+										</div>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
+
+					<!-- Status badges and external links -->
+					<div class="border-t border-base-content/10 pt-3"></div>
+					<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+						<div class="flex flex-wrap items-center gap-2 sm:gap-4">
+							<StatusIndicator status={fileStatus} qualityText={statusQualityText} />
+							{#if showUnreleasedBadge}
+								<div
+									class="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm ring-1 {unreleasedBadgeStyle}"
+								>
+									<Clock size={16} />
+									<span class="font-medium">{unreleasedLabel}</span>
+								</div>
+							{/if}
+							{#if movie.hasFile && movie.files.length > 0}
+								{#if isStreamerProfile}
+									<span class="badge badge-sm badge-secondary">{m.status_streaming()}</span>
+								{:else}
+									<QualityBadge
+										quality={movie.files[0].quality}
+										mediaInfo={movie.files[0].mediaInfo}
+										size="md"
+									/>
+								{/if}
+								{#if !isStreamerProfile}
+									<ScoreBadge
+										score={scoreInfo?.score ?? null}
+										isAtCutoff={scoreInfo?.isAtCutoff ?? false}
+										upgradesAllowed={scoreInfo?.upgradesAllowed ?? true}
+										loading={scoreLoading}
+										size="md"
+										onclick={onScoreClick}
+									/>
+								{/if}
+							{/if}
+						</div>
+						<div class="flex w-full items-center gap-2 border-t border-base-content/10 pt-2 sm:w-auto sm:border-0 sm:pt-0">
+							{#if movie.tmdbId}
+								<a
+									href="https://www.themoviedb.org/movie/{movie.tmdbId}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn gap-1 btn-ghost btn-xs"
+								>
+									{m.library_movieHeader_tmdbLink()}<ExternalLink size={12} />
+								</a>
+							{/if}
+							{#if movie.imdbId}
+								<a
+									href="https://www.imdb.com/title/{movie.imdbId}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn gap-1 btn-ghost btn-xs"
+								>
+									{m.library_movieHeader_imdbLink()}<ExternalLink size={12} />
+								</a>
+							{/if}
+							{#each providerLinks as providerLink (providerLink.label)}
+								<a
+									href={providerLink.href}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn gap-1 btn-ghost btn-xs"
+								>
+									{providerLink.label}<ExternalLink size={12} />
+								</a>
+							{/each}
+							{#if hasTrailer}
+								<button class="btn gap-1 btn-ghost btn-xs" onclick={openTrailer}>
+									<Play size={12} />{m.hero_trailer()}
+								</button>
+							{/if}
+						</div>
+					</div>
 				</div>
-			{/if}
+
+				<!-- Right side metadata panel -->
+				{#if tmdbMovie}
+					<div
+						class="hidden w-56 shrink-0 rounded-lg bg-base-100/30 p-4 backdrop-blur-sm md:block lg:w-64 lg:p-5"
+					>
+						<div class="grid grid-cols-2 gap-x-4 gap-y-3">
+							<div class="col-span-2">
+								<div class="text-xs text-base-content/50">{m.hero_metadata_status()}</div>
+								{#if smartRelease}
+									<div
+										class="font-medium {smartRelease.variant === 'released'
+											? 'text-success'
+											: smartRelease.variant === 'theaters'
+												? 'text-info'
+												: smartRelease.variant === 'upcoming'
+													? 'text-primary'
+													: ''}"
+									>
+										{smartRelease.text}
+									</div>
+								{:else}
+									<div class="font-medium">{tmdbMovie.status}</div>
+								{/if}
+							</div>
+
+							<!-- Row: Added | Language -->
+							{#if movie.added}
+								<div>
+									<div class="text-xs text-base-content/50">{m.common_added()}</div>
+									<div class="font-medium">{formatDisplayDateShort(movie.added)}</div>
+								</div>
+							{/if}
+							<div>
+								<div class="text-xs text-base-content/50">{m.hero_metadata_language()}</div>
+								<div class="font-medium">{formatLanguage(tmdbMovie.original_language)}</div>
+							</div>
+
+							<!-- Row: Rated | Theatrical -->
+							{#if releaseInfo?.certification}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_metadata_rated()}</div>
+									<div class="font-medium">{releaseInfo.certification}</div>
+								</div>
+							{/if}
+							{#if releaseInfo?.theatrical}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
+									<div class="font-medium {releaseInfo.theatrical.isPast ? '' : 'text-primary'}">
+										{releaseInfo.theatrical.date}
+									</div>
+								</div>
+							{:else if tmdbMovie.release_date}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
+									<div class="font-medium">{formatDisplayDateShort(tmdbMovie.release_date)}</div>
+								</div>
+							{/if}
+
+							<!-- Row: Digital | Physical -->
+							{#if releaseInfo?.digital}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_releaseType_digital()}</div>
+									<div class="font-medium {releaseInfo.digital.isPast ? '' : 'text-primary'}">
+										{releaseInfo.digital.date}
+									</div>
+								</div>
+							{/if}
+							{#if releaseInfo?.physical}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_releaseType_physical()}</div>
+									<div class="font-medium {releaseInfo.physical.isPast ? '' : 'text-primary'}">
+										{releaseInfo.physical.date}
+									</div>
+								</div>
+							{/if}
+
+							{#if tmdbMovie.belongs_to_collection}
+								<div class="col-span-2">
+									<div class="text-xs text-base-content/50">Collection</div>
+									<div class="font-medium">{tmdbMovie.belongs_to_collection.name}</div>
+								</div>
+							{/if}
+
+							{#if tmdbMovie.production_companies && tmdbMovie.production_companies.length > 0}
+								<div class="col-span-2">
+									<div class="text-xs text-base-content/50">{m.hero_metadata_studio()}</div>
+									<div class="font-medium">{tmdbMovie.production_companies[0].name}</div>
+								</div>
+							{/if}
+
+							{#if movie.hasFile && movie.files[0]?.quality?.source}
+								<div>
+									<div class="text-xs text-base-content/50">Source</div>
+									<div class="font-medium">{formatSource(movie.files[0].quality.source)}</div>
+								</div>
+							{/if}
+
+							{#if movie.hasFile && totalSize > 0}
+								<div>
+									<div class="text-xs text-base-content/50">Size</div>
+									<div class="font-medium">{formatBytes(totalSize)}</div>
+								</div>
+							{/if}
+						</div>
+
+						{#if tmdbMovie['watch/providers']}
+							<div class="mt-4 border-t border-base-content/10 pt-4">
+								<div class="mb-2 text-xs text-base-content/50">
+									{m.hero_metadata_whereToWatch()}
+								</div>
+								<WatchProviders
+									providers={tmdbMovie['watch/providers']}
+									countryCode={defaultRegion}
+									limit={6}
+								/>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/library/LibraryMovieHeader.svelte
+++ b/src/lib/components/library/LibraryMovieHeader.svelte
@@ -114,6 +114,7 @@
 	}: Props = $props();
 
 	let showBlockConfirm = $state(false);
+	let overviewExpanded = $state(false);
 
 	async function handleBlock() {
 		try {
@@ -273,9 +274,11 @@
 			>
 		</a>
 		<div class="flex shrink-0 items-center gap-1 sm:gap-2">
-			<MonitorToggle monitored={movie.monitored ?? false} onToggle={onMonitorToggle} size="md" />
+			<div class="hidden sm:block">
+				<MonitorToggle monitored={movie.monitored ?? false} onToggle={onMonitorToggle} size="md" />
+			</div>
 			<button
-				class="btn btn-primary btn-sm gap-1.5"
+				class="btn btn-primary btn-sm gap-1.5 hidden sm:flex"
 				onclick={onAutoSearch}
 				disabled={autoSearching}
 			>
@@ -284,7 +287,7 @@
 				{:else}
 					<Zap size={14} />
 				{/if}
-				<span class="hidden sm:inline">{m.library_movieHeader_autoGrab()}</span>
+				{m.library_movieHeader_autoGrab()}
 			</button>
 			<button class="btn btn-ghost btn-sm gap-1.5 hidden sm:flex" onclick={onSearch}>
 				<Search size={14} />
@@ -296,7 +299,7 @@
 					{m.action_import()}
 				</button>
 			{/if}
-			<div class="dropdown dropdown-end">
+			<div class="dropdown dropdown-end hidden sm:block">
 				<button tabindex="0" class="btn btn-ghost btn-sm">
 					<MoreHorizontal size={18} />
 				</button>
@@ -305,22 +308,7 @@
 					tabindex="0"
 					class="dropdown-content menu z-50 w-52 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
 				>
-					<li class="sm:hidden">
-						<button onclick={onSearch}>
-							<Search size={16} />
-							{m.library_movieHeader_manual()}
-						</button>
-					</li>
-					{#if onImport}
-						<li class="sm:hidden">
-							<button onclick={onImport}>
-								<Download size={16} />
-								{m.action_import()}
-							</button>
-						</li>
-					{/if}
-					<div class="divider my-1 sm:hidden"></div>
-					<li>
+					<li class="hidden sm:flex">
 						<button onclick={onEdit}>
 							<Settings size={16} />
 							{m.action_edit()}
@@ -343,6 +331,118 @@
 		</div>
 	</div>
 
+	{#snippet metaPanel()}
+		{#if tmdbMovie}
+			<div class="grid grid-cols-2 gap-x-4 gap-y-3">
+				<div class="col-span-2">
+					<div class="text-xs text-base-content/50">{m.hero_metadata_status()}</div>
+					{#if smartRelease}
+						<div
+							class="font-medium {smartRelease.variant === 'released'
+								? 'text-success'
+								: smartRelease.variant === 'theaters'
+									? 'text-info'
+									: smartRelease.variant === 'upcoming'
+										? 'text-primary'
+										: ''}"
+						>
+							{smartRelease.text}
+						</div>
+					{:else}
+						<div class="font-medium">{tmdbMovie.status}</div>
+					{/if}
+				</div>
+
+				{#if movie.added}
+					<div>
+						<div class="text-xs text-base-content/50">{m.common_added()}</div>
+						<div class="font-medium">{formatDisplayDateShort(movie.added)}</div>
+					</div>
+				{/if}
+				<div>
+					<div class="text-xs text-base-content/50">{m.hero_metadata_language()}</div>
+					<div class="font-medium">{formatLanguage(tmdbMovie.original_language)}</div>
+				</div>
+
+				{#if releaseInfo?.certification}
+					<div>
+						<div class="text-xs text-base-content/50">{m.hero_metadata_rated()}</div>
+						<div class="font-medium">{releaseInfo.certification}</div>
+					</div>
+				{/if}
+				{#if releaseInfo?.theatrical}
+					<div>
+						<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
+						<div class="font-medium {releaseInfo.theatrical.isPast ? '' : 'text-primary'}">
+							{releaseInfo.theatrical.date}
+						</div>
+					</div>
+				{:else if tmdbMovie.release_date}
+					<div>
+						<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
+						<div class="font-medium">{formatDisplayDateShort(tmdbMovie.release_date)}</div>
+					</div>
+				{/if}
+
+				{#if releaseInfo?.digital}
+					<div>
+						<div class="text-xs text-base-content/50">{m.hero_releaseType_digital()}</div>
+						<div class="font-medium {releaseInfo.digital.isPast ? '' : 'text-primary'}">
+							{releaseInfo.digital.date}
+						</div>
+					</div>
+				{/if}
+				{#if releaseInfo?.physical}
+					<div>
+						<div class="text-xs text-base-content/50">{m.hero_releaseType_physical()}</div>
+						<div class="font-medium {releaseInfo.physical.isPast ? '' : 'text-primary'}">
+							{releaseInfo.physical.date}
+						</div>
+					</div>
+				{/if}
+
+				{#if tmdbMovie.belongs_to_collection}
+					<div class="col-span-2">
+						<div class="text-xs text-base-content/50">Collection</div>
+						<div class="font-medium">{tmdbMovie.belongs_to_collection.name}</div>
+					</div>
+				{/if}
+
+				{#if tmdbMovie.production_companies && tmdbMovie.production_companies.length > 0}
+					<div class="col-span-2">
+						<div class="text-xs text-base-content/50">{m.hero_metadata_studio()}</div>
+						<div class="font-medium">{tmdbMovie.production_companies[0].name}</div>
+					</div>
+				{/if}
+
+				{#if movie.hasFile && movie.files[0]?.quality?.source}
+					<div>
+						<div class="text-xs text-base-content/50">Source</div>
+						<div class="font-medium">{formatSource(movie.files[0].quality.source)}</div>
+					</div>
+				{/if}
+
+				{#if movie.hasFile && totalSize > 0}
+					<div>
+						<div class="text-xs text-base-content/50">Size</div>
+						<div class="font-medium">{formatBytes(totalSize)}</div>
+					</div>
+				{/if}
+			</div>
+
+			{#if tmdbMovie['watch/providers']}
+				<div class="mt-4 border-t border-base-content/10 pt-4">
+					<div class="mb-2 text-xs text-base-content/50">{m.hero_metadata_whereToWatch()}</div>
+					<WatchProviders
+						providers={tmdbMovie['watch/providers']}
+						countryCode={defaultRegion}
+						limit={6}
+					/>
+				</div>
+			{/if}
+		{/if}
+	{/snippet}
+
 	<!-- Hero card -->
 	<div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
 		<!-- Backdrop -->
@@ -352,11 +452,11 @@
 					path={movie.backdropPath}
 					size="original"
 					alt={movie.title}
-					class="h-full w-full object-cover opacity-40 blur-sm"
+					class="h-full w-full object-cover opacity-40"
 				/>
 			{/if}
 			<div
-				class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/80 to-transparent"
+				class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/60 to-transparent"
 			></div>
 			<div
 				class="absolute inset-0 bg-linear-to-r from-base-200 via-base-200/60 to-transparent"
@@ -415,8 +515,8 @@
 								<span>{formatRuntime(movie.runtime)}</span>
 							{/if}
 							{#if movie.genres && movie.genres.length > 0}
-								<span class="hidden sm:inline">•</span>
-								<span class="hidden sm:inline">{movie.genres.slice(0, 3).join(', ')}</span>
+								<span>•</span>
+								<span>{movie.genres.slice(0, 3).join(', ')}</span>
 							{/if}
 						</div>
 					</div>
@@ -428,7 +528,21 @@
 					{/if}
 
 					{#if overview}
-						<p class="text-base leading-relaxed text-base-content/90">{overview}</p>
+						<div>
+							<p
+								class="text-base leading-relaxed text-base-content/90 {overviewExpanded
+									? ''
+									: 'line-clamp-3 sm:line-clamp-none'}"
+							>
+								{overview}
+							</p>
+							<button
+								class="mt-1 text-sm text-primary/70 hover:text-primary sm:hidden"
+								onclick={() => (overviewExpanded = !overviewExpanded)}
+							>
+								{overviewExpanded ? 'Read less' : 'Read more'}
+							</button>
+						</div>
 					{/if}
 
 					{#if tmdbMovie?.credits?.crew?.length}
@@ -439,9 +553,7 @@
 
 					{#if tmdbMovie?.credits?.cast?.length}
 						<div>
-							<div class="mb-2 text-xs font-medium uppercase tracking-wider text-base-content/40">
-								Cast
-							</div>
+							<div class="mb-2 text-sm text-base-content/60">Cast</div>
 							<div class="flex gap-3 overflow-x-auto pb-1">
 								{#each tmdbMovie.credits.cast.slice(0, 8) as actor (actor.id)}
 									<div class="flex shrink-0 flex-col items-center gap-1.5 w-16">
@@ -476,9 +588,10 @@
 					{/if}
 
 					<!-- Status badges and external links -->
-					<div class="border-t border-base-content/10 pt-3"></div>
-					<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-						<div class="flex flex-wrap items-center gap-2 sm:gap-4">
+					<div
+						class="flex flex-col gap-2 border-t border-base-content/10 pt-3 sm:flex-row sm:items-center sm:justify-between"
+					>
+						<div class="flex flex-wrap items-center gap-2">
 							<StatusIndicator status={fileStatus} qualityText={statusQualityText} />
 							{#if showUnreleasedBadge}
 								<div
@@ -510,13 +623,15 @@
 								{/if}
 							{/if}
 						</div>
-						<div class="flex w-full items-center gap-2 border-t border-base-content/10 pt-2 sm:w-auto sm:border-0 sm:pt-0">
+						<div
+							class="flex w-full items-center gap-1 overflow-x-auto pb-0.5 border-t border-base-content/10 pt-2 sm:w-auto sm:shrink-0 sm:border-0 sm:pt-0 sm:overflow-x-visible sm:pb-0"
+						>
 							{#if movie.tmdbId}
 								<a
 									href="https://www.themoviedb.org/movie/{movie.tmdbId}"
 									target="_blank"
 									rel="noopener noreferrer"
-									class="btn gap-1 btn-ghost btn-xs"
+									class="btn btn-ghost btn-xs shrink-0 gap-1"
 								>
 									{m.library_movieHeader_tmdbLink()}<ExternalLink size={12} />
 								</a>
@@ -526,7 +641,7 @@
 									href="https://www.imdb.com/title/{movie.imdbId}"
 									target="_blank"
 									rel="noopener noreferrer"
-									class="btn gap-1 btn-ghost btn-xs"
+									class="btn btn-ghost btn-xs shrink-0 gap-1"
 								>
 									{m.library_movieHeader_imdbLink()}<ExternalLink size={12} />
 								</a>
@@ -536,13 +651,13 @@
 									href={providerLink.href}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="btn gap-1 btn-ghost btn-xs"
+									class="btn btn-ghost btn-xs shrink-0 gap-1"
 								>
 									{providerLink.label}<ExternalLink size={12} />
 								</a>
 							{/each}
 							{#if hasTrailer}
-								<button class="btn gap-1 btn-ghost btn-xs" onclick={openTrailer}>
+								<button class="btn btn-ghost btn-xs shrink-0 gap-1" onclick={openTrailer}>
 									<Play size={12} />{m.hero_trailer()}
 								</button>
 							{/if}
@@ -550,123 +665,12 @@
 					</div>
 				</div>
 
-				<!-- Right side metadata panel -->
+				<!-- Right side metadata panel (desktop) -->
 				{#if tmdbMovie}
 					<div
 						class="hidden w-56 shrink-0 rounded-lg bg-base-100/30 p-4 backdrop-blur-sm md:block lg:w-64 lg:p-5"
 					>
-						<div class="grid grid-cols-2 gap-x-4 gap-y-3">
-							<div class="col-span-2">
-								<div class="text-xs text-base-content/50">{m.hero_metadata_status()}</div>
-								{#if smartRelease}
-									<div
-										class="font-medium {smartRelease.variant === 'released'
-											? 'text-success'
-											: smartRelease.variant === 'theaters'
-												? 'text-info'
-												: smartRelease.variant === 'upcoming'
-													? 'text-primary'
-													: ''}"
-									>
-										{smartRelease.text}
-									</div>
-								{:else}
-									<div class="font-medium">{tmdbMovie.status}</div>
-								{/if}
-							</div>
-
-							<!-- Row: Added | Language -->
-							{#if movie.added}
-								<div>
-									<div class="text-xs text-base-content/50">{m.common_added()}</div>
-									<div class="font-medium">{formatDisplayDateShort(movie.added)}</div>
-								</div>
-							{/if}
-							<div>
-								<div class="text-xs text-base-content/50">{m.hero_metadata_language()}</div>
-								<div class="font-medium">{formatLanguage(tmdbMovie.original_language)}</div>
-							</div>
-
-							<!-- Row: Rated | Theatrical -->
-							{#if releaseInfo?.certification}
-								<div>
-									<div class="text-xs text-base-content/50">{m.hero_metadata_rated()}</div>
-									<div class="font-medium">{releaseInfo.certification}</div>
-								</div>
-							{/if}
-							{#if releaseInfo?.theatrical}
-								<div>
-									<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
-									<div class="font-medium {releaseInfo.theatrical.isPast ? '' : 'text-primary'}">
-										{releaseInfo.theatrical.date}
-									</div>
-								</div>
-							{:else if tmdbMovie.release_date}
-								<div>
-									<div class="text-xs text-base-content/50">{m.hero_releaseType_theatrical()}</div>
-									<div class="font-medium">{formatDisplayDateShort(tmdbMovie.release_date)}</div>
-								</div>
-							{/if}
-
-							<!-- Row: Digital | Physical -->
-							{#if releaseInfo?.digital}
-								<div>
-									<div class="text-xs text-base-content/50">{m.hero_releaseType_digital()}</div>
-									<div class="font-medium {releaseInfo.digital.isPast ? '' : 'text-primary'}">
-										{releaseInfo.digital.date}
-									</div>
-								</div>
-							{/if}
-							{#if releaseInfo?.physical}
-								<div>
-									<div class="text-xs text-base-content/50">{m.hero_releaseType_physical()}</div>
-									<div class="font-medium {releaseInfo.physical.isPast ? '' : 'text-primary'}">
-										{releaseInfo.physical.date}
-									</div>
-								</div>
-							{/if}
-
-							{#if tmdbMovie.belongs_to_collection}
-								<div class="col-span-2">
-									<div class="text-xs text-base-content/50">Collection</div>
-									<div class="font-medium">{tmdbMovie.belongs_to_collection.name}</div>
-								</div>
-							{/if}
-
-							{#if tmdbMovie.production_companies && tmdbMovie.production_companies.length > 0}
-								<div class="col-span-2">
-									<div class="text-xs text-base-content/50">{m.hero_metadata_studio()}</div>
-									<div class="font-medium">{tmdbMovie.production_companies[0].name}</div>
-								</div>
-							{/if}
-
-							{#if movie.hasFile && movie.files[0]?.quality?.source}
-								<div>
-									<div class="text-xs text-base-content/50">Source</div>
-									<div class="font-medium">{formatSource(movie.files[0].quality.source)}</div>
-								</div>
-							{/if}
-
-							{#if movie.hasFile && totalSize > 0}
-								<div>
-									<div class="text-xs text-base-content/50">Size</div>
-									<div class="font-medium">{formatBytes(totalSize)}</div>
-								</div>
-							{/if}
-						</div>
-
-						{#if tmdbMovie['watch/providers']}
-							<div class="mt-4 border-t border-base-content/10 pt-4">
-								<div class="mb-2 text-xs text-base-content/50">
-									{m.hero_metadata_whereToWatch()}
-								</div>
-								<WatchProviders
-									providers={tmdbMovie['watch/providers']}
-									countryCode={defaultRegion}
-									limit={6}
-								/>
-							</div>
-						{/if}
+						{@render metaPanel()}
 					</div>
 				{/if}
 			</div>
@@ -683,3 +687,98 @@
 	confirmLabel={m.blockedMedia_confirmBlockLabel()}
 	confirmVariant="error"
 />
+
+<!-- Mobile action bar -->
+<div
+	class="fixed bottom-0 left-0 right-0 z-40 border-t border-base-content/6 bg-base-100/75 backdrop-blur-xl sm:hidden"
+	style="padding-bottom: env(safe-area-inset-bottom)"
+>
+	<div class="flex items-stretch justify-around">
+		<!-- Monitor -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 transition-colors
+				{movie.monitored ? 'text-success' : 'text-base-content/55'}"
+			onclick={() => onMonitorToggle?.(!movie.monitored)}
+		>
+			{#if movie.monitored}
+				<Eye size={20} />
+			{:else}
+				<EyeOff size={20} />
+			{/if}
+			<span class="text-[10px] tracking-wide">{movie.monitored ? 'Monitored' : 'Off'}</span>
+		</button>
+
+		<!-- Auto-grab -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 transition-colors
+				{autoSearching ? 'text-primary/40' : 'text-primary'}"
+			onclick={onAutoSearch}
+			disabled={autoSearching}
+		>
+			{#if autoSearching}
+				<span class="loading loading-xs loading-spinner"></span>
+			{:else}
+				<Zap size={20} />
+			{/if}
+			<span class="text-[10px] tracking-wide">{m.library_movieHeader_autoGrab()}</span>
+		</button>
+
+		<!-- Manual -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 text-base-content/55 transition-colors active:text-base-content/90"
+			onclick={onSearch}
+		>
+			<Search size={20} />
+			<span class="text-[10px] tracking-wide">{m.library_movieHeader_manual()}</span>
+		</button>
+
+		{#if onImport}
+			<!-- Import -->
+			<button
+				class="flex flex-1 flex-col items-center gap-1 py-3 text-base-content/55 transition-colors active:text-base-content/90"
+				onclick={onImport}
+			>
+				<Download size={20} />
+				<span class="text-[10px] tracking-wide">{m.action_import()}</span>
+			</button>
+		{/if}
+
+		<!-- Edit -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 text-base-content/55 transition-colors active:text-base-content/90"
+			onclick={onEdit}
+		>
+			<Settings size={20} />
+			<span class="text-[10px] tracking-wide">{m.action_edit()}</span>
+		</button>
+
+		<!-- Overflow -->
+		<div class="dropdown dropdown-top dropdown-end flex flex-1">
+			<button
+				tabindex="0"
+				class="flex flex-1 flex-col items-center gap-1 py-3 text-error/80 transition-colors active:text-error"
+			>
+				<MoreHorizontal size={20} />
+				<span class="text-[10px] tracking-wide">More</span>
+			</button>
+			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+			<ul
+				tabindex="0"
+				class="dropdown-content menu z-50 mb-2 w-52 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+			>
+				<li>
+					<button class="text-error" onclick={onDelete}>
+						<Trash2 size={16} />
+						{m.action_delete()}
+					</button>
+				</li>
+				<li>
+					<button class="text-error" onclick={() => (showBlockConfirm = true)}>
+						<Ban size={16} />
+						{m.library_blockMediaTooltip()}
+					</button>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/library/LibrarySeriesHeader.svelte
+++ b/src/lib/components/library/LibrarySeriesHeader.svelte
@@ -16,14 +16,23 @@
 		Ban,
 		Captions,
 		Play,
-		MoreHorizontal
+		MoreHorizontal,
+		ArrowLeft,
+		Eye,
+		EyeOff
 	} from 'lucide-svelte';
-	import { formatLanguage, formatDisplayDateShort, getStatusColor } from '$lib/utils/format.js';
+	import {
+		formatLanguage,
+		formatDisplayDateShort,
+		getStatusColor,
+		formatBytes
+	} from '$lib/utils/format.js';
 	import { formatSeriesStatus } from '$lib/utils/format-status.js';
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { blockMedia } from '$lib/api/settings.js';
 	import { TMDB } from '$lib/config/constants.js';
+	import { resolvePath } from '$lib/utils/routing.js';
 
 	interface SeriesData {
 		tmdbId: number;
@@ -63,12 +72,19 @@
 		tmdbSeries?: TVShowDetails | null;
 		defaultRegion?: string;
 		configuredProviders?: { anilist: boolean; mal: boolean };
+		librarySlug?: string | null;
+		libraryName?: string | null;
 		refreshing?: boolean;
 		refreshProgress?: RefreshProgress | null;
 		missingEpisodeCount?: number;
 		searchingMissing?: boolean;
 		missingSearchProgress?: MissingSearchProgress | null;
 		missingSearchResult?: MissingSearchResult | null;
+		episodeCount?: number | null;
+		episodeFileCount?: number | null;
+		percentComplete?: number;
+		totalSeriesSize?: number;
+		downloadingCount?: number;
 		onMonitorToggle?: (newValue: boolean) => void;
 		onSearch?: () => void;
 		onSearchMissing?: () => void;
@@ -85,12 +101,19 @@
 		tmdbSeries = null,
 		defaultRegion = TMDB.DEFAULT_REGION,
 		configuredProviders = { anilist: false, mal: false },
+		librarySlug = null,
+		libraryName = null,
 		refreshing = false,
 		refreshProgress: _refreshProgress = null,
 		missingEpisodeCount = 0,
 		searchingMissing = false,
 		missingSearchProgress: _missingSearchProgress = null,
 		missingSearchResult: _missingSearchResult = null,
+		episodeCount = null,
+		episodeFileCount = null,
+		percentComplete = 0,
+		totalSeriesSize = 0,
+		downloadingCount = 0,
 		onMonitorToggle,
 		onSearch,
 		onSearchMissing,
@@ -103,6 +126,7 @@
 	}: Props = $props();
 
 	let showBlockConfirm = $state(false);
+	let overviewExpanded = $state(false);
 
 	async function handleBlock() {
 		try {
@@ -148,6 +172,16 @@
 	});
 
 	const overview = $derived(tmdbSeries?.overview ?? series.overview);
+	const isAnimated = $derived(
+		series.genres?.some((g) => ['animation', 'anime'].includes(g.toLowerCase())) ||
+			Boolean(series.providerRefs?.anilist) ||
+			Boolean(series.providerRefs?.mal)
+	);
+	const avgEpisodeRuntime = $derived.by(() => {
+		const runtimes = tmdbSeries?.episode_run_time ?? [];
+		if (!runtimes.length) return null;
+		return Math.round(runtimes.reduce((a, b) => a + b, 0) / runtimes.length);
+	});
 	const hasTrailer = $derived(
 		tmdbSeries?.videos?.results?.some(
 			(v) => v.site === 'YouTube' && (v.type === 'Trailer' || v.type === 'Teaser')
@@ -163,41 +197,154 @@
 	});
 </script>
 
-<div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
-	<!-- Backdrop -->
-	<div class="absolute inset-0 h-full w-full">
-		{#if series.backdropPath}
-			<TmdbImage
-				path={series.backdropPath}
-				size="original"
-				alt={series.title}
-				class="h-full w-full object-cover opacity-40 blur-sm"
-			/>
-		{/if}
-		<div class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/80 to-transparent"></div>
-		<div class="absolute inset-0 bg-linear-to-r from-base-200 via-base-200/60 to-transparent"></div>
+<div class="flex flex-col gap-4">
+	<!-- Top action bar -->
+	<div class="flex items-center justify-between gap-2">
+		<a
+			href={resolvePath(librarySlug ? `/library/tv?library=${librarySlug}` : '/library/tv')}
+			class="btn btn-ghost btn-sm gap-1.5 text-base-content/60"
+		>
+			<ArrowLeft size={16} />
+			<span class="sm:inline">{libraryName ?? m.library_movieHeader_backToLibrary()}</span>
+		</a>
+		<div class="flex shrink-0 items-center gap-1 sm:gap-2">
+			<!-- MonitorToggle hidden on mobile (shown in bottom bar) -->
+			<div class="hidden sm:block">
+				<MonitorToggle monitored={series.monitored ?? false} onToggle={onMonitorToggle} size="md" />
+			</div>
+			<!-- Auto-grab (desktop) -->
+			<button
+				class="btn btn-primary btn-sm gap-1.5 hidden sm:flex"
+				onclick={onSearchMissing}
+				disabled={searchingMissing || missingEpisodeCount === 0}
+			>
+				{#if searchingMissing}
+					<span class="loading loading-xs loading-spinner"></span>
+				{:else}
+					<Zap size={14} />
+				{/if}
+				{m.library_seriesHeader_autoGrab()}
+				{#if missingEpisodeCount > 0}
+					<span class="badge badge-sm">{missingEpisodeCount}</span>
+				{/if}
+			</button>
+			<!-- Season Packs (desktop) -->
+			<button class="btn btn-ghost btn-sm gap-1.5 hidden sm:flex" onclick={onSearch}>
+				<Package size={14} />
+				{m.library_seriesHeader_seasonPacks()}
+			</button>
+			<!-- Overflow menu (desktop only) -->
+			<div class="dropdown dropdown-end hidden sm:block">
+				<button tabindex="0" class="btn btn-ghost btn-sm">
+					<MoreHorizontal size={18} />
+				</button>
+				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+				<ul
+					tabindex="0"
+					class="dropdown-content menu z-50 w-56 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+				>
+					{#if onImport}
+						<li>
+							<button onclick={onImport}>
+								<Download size={16} />
+								{m.action_import()}
+							</button>
+						</li>
+					{/if}
+					<li>
+						<button onclick={onRefresh} disabled={refreshing}>
+							<RefreshCw size={16} />
+							{#if refreshing}
+								{m.common_loading()}
+							{:else}
+								{m.library_seriesHeader_refreshTooltip()}
+							{/if}
+						</button>
+					</li>
+					{#if onSubtitleAutoSearch}
+						<li>
+							<button onclick={onSubtitleAutoSearch} disabled={subtitleAutoSearching}>
+								<Captions size={16} />
+								{m.library_seriesHeader_autoDownloadSubs()}
+							</button>
+						</li>
+					{/if}
+					<div class="divider my-1"></div>
+					<li>
+						<button onclick={onEdit}>
+							<Settings size={16} />
+							{m.action_edit()}
+						</button>
+					</li>
+					<li>
+						<button class="text-error" onclick={onDelete}>
+							<Trash2 size={16} />
+							{m.action_delete()}
+						</button>
+					</li>
+					<li>
+						<button class="text-error" onclick={() => (showBlockConfirm = true)}>
+							<Ban size={16} />
+							{m.library_blockMediaTooltip()}
+						</button>
+					</li>
+				</ul>
+			</div>
+		</div>
 	</div>
 
-	<!-- Content -->
-	<div class="relative z-10">
-		<!-- Main content -->
-		<div class="flex flex-col gap-6 p-6 md:flex-row md:p-8">
-			<!-- Poster -->
-			<div class="hidden shrink-0 sm:block">
-				<div class="w-32 overflow-hidden rounded-lg shadow-lg md:w-40">
-					<TmdbImage
-						path={series.posterPath}
-						size="w342"
-						alt={series.title}
-						class="h-auto w-full object-cover"
-					/>
-				</div>
-			</div>
+	<!-- Hero card -->
+	<div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
+		<!-- Backdrop -->
+		<div class="absolute inset-0 h-full w-full">
+			{#if series.backdropPath}
+				<TmdbImage
+					path={series.backdropPath}
+					size="original"
+					alt={series.title}
+					class="h-full w-full object-cover opacity-55"
+				/>
+			{/if}
+			<div
+				class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/60 to-transparent"
+			></div>
+			<div
+				class="absolute inset-0 hidden bg-linear-to-r from-base-200 via-base-200/60 to-transparent md:block"
+			></div>
+		</div>
 
-			<!-- Main Info -->
-			<div class="flex min-w-0 flex-1 flex-col gap-4">
-				<!-- Title and actions -->
-				<div class="flex items-start justify-between gap-2">
+		<!-- Content -->
+		<div class="relative z-10">
+			<div class="flex flex-col gap-6 p-6 md:flex-row md:p-8">
+				<!-- Poster -->
+				<div class="hidden shrink-0 flex-col gap-2 sm:flex">
+					<div class="w-48 overflow-hidden rounded-lg shadow-lg md:w-56">
+						<TmdbImage
+							path={series.posterPath}
+							size="w342"
+							alt={series.title}
+							class="h-auto w-full object-cover"
+						/>
+					</div>
+					<button
+						class="flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-medium transition-colors
+							{series.monitored
+							? 'bg-success/10 text-success hover:bg-success/20'
+							: 'bg-base-content/5 text-base-content/40 hover:bg-base-content/10'}"
+						onclick={() => onMonitorToggle?.(!series.monitored)}
+					>
+						{#if series.monitored}
+							<Eye size={13} />
+							Monitored
+						{:else}
+							<EyeOff size={13} />
+							Unmonitored
+						{/if}
+					</button>
+				</div>
+
+				<!-- Main Info -->
+				<div class="flex min-w-0 flex-1 flex-col gap-4">
 					<div class="min-w-0">
 						<h1 class="text-2xl font-bold md:text-3xl">
 							{series.title}
@@ -220,245 +367,274 @@
 								</span>
 							{/if}
 							{#if series.network}
-								<span class="hidden sm:inline">•</span>
-								<span class="hidden sm:inline">{series.network}</span>
+								<span>•</span>
+								<span>{series.network}</span>
 							{/if}
 							{#if series.genres && series.genres.length > 0}
-								<span class="hidden sm:inline">•</span>
-								<span class="hidden sm:inline">{series.genres.slice(0, 3).join(', ')}</span>
+								<span>•</span>
+								<span>{series.genres.slice(0, 3).join(', ')}</span>
 							{/if}
 						</div>
 					</div>
-					<div class="flex shrink-0 items-center gap-1">
-						<MonitorToggle
-							monitored={series.monitored ?? false}
-							onToggle={onMonitorToggle}
-							size="md"
-						/>
-						<div class="dropdown dropdown-end">
-							<button tabindex="0" class="btn btn-ghost btn-sm">
-								<MoreHorizontal size={18} />
-							</button>
-							<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-							<ul
-								tabindex="0"
-								class="dropdown-content menu z-50 w-56 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+
+					{#if tmdbSeries?.tagline}
+						<p class="border-l-2 border-primary pl-3 text-base text-base-content/50 italic">
+							{tmdbSeries.tagline}
+						</p>
+					{/if}
+
+					{#if overview}
+						<div>
+							<p
+								class="text-base leading-relaxed text-base-content/90 {overviewExpanded
+									? ''
+									: 'line-clamp-3 sm:line-clamp-none'}"
 							>
-								<li>
-									<button
-										onclick={onSearchMissing}
-										disabled={searchingMissing || missingEpisodeCount === 0}
-									>
-										<Zap size={16} />
-										{m.library_seriesHeader_autoGrab()}
-										{#if missingEpisodeCount > 0}
-											<span class="badge badge-sm badge-secondary">{missingEpisodeCount}</span>
-										{/if}
-									</button>
-								</li>
-								{#if onSubtitleAutoSearch}
-									<li>
-										<button onclick={onSubtitleAutoSearch} disabled={subtitleAutoSearching}>
-											<Captions size={16} />
-											{m.library_seriesHeader_autoDownloadSubs()}
-										</button>
-									</li>
-								{/if}
-								<li>
-									<button onclick={onSearch}>
-										<Package size={16} />
-										{m.library_seriesHeader_seasonPacks()}
-									</button>
-								</li>
-								{#if onImport}
-									<li>
-										<button onclick={onImport}>
-											<Download size={16} />
-											{m.action_import()}
-										</button>
-									</li>
-								{/if}
-								<li>
-									<button onclick={onRefresh} disabled={refreshing}>
-										<RefreshCw size={16} />
-										{#if refreshing}
-											{m.common_loading()}
-										{:else}
-											{m.library_seriesHeader_refreshTooltip()}
-										{/if}
-									</button>
-								</li>
-								<div class="divider my-1"></div>
-								<li>
-									<button onclick={onEdit}>
-										<Settings size={16} />
-										{m.action_edit()}
-									</button>
-								</li>
-								<li>
-									<button class="text-error" onclick={onDelete}>
-										<Trash2 size={16} />
-										{m.action_delete()}
-									</button>
-								</li>
-								<li>
-									<button class="text-error" onclick={() => (showBlockConfirm = true)}>
-										<Ban size={16} />
-										{m.library_blockMediaTooltip()}
-									</button>
-								</li>
-							</ul>
+								{overview}
+							</p>
+							<button
+								class="mt-1 text-sm text-primary/70 hover:text-primary sm:hidden"
+								onclick={() => (overviewExpanded = !overviewExpanded)}
+							>
+								{overviewExpanded ? 'Read less' : 'Read more'}
+							</button>
 						</div>
-					</div>
-				</div>
-
-				{#if tmdbSeries?.tagline}
-					<p class="text-base text-base-content/50 italic">"{tmdbSeries.tagline}"</p>
-				{/if}
-
-				{#if overview}
-					<p class="text-base leading-relaxed text-base-content/90">{overview}</p>
-				{/if}
-
-				{#if tmdbSeries?.credits?.crew?.length || tmdbSeries?.created_by?.length}
-					<div class="text-sm">
-						<CrewList
-							crew={tmdbSeries?.credits?.crew ?? []}
-							creators={tmdbSeries?.created_by ?? []}
-						/>
-					</div>
-				{/if}
-
-				<!-- External links -->
-				<div class="mt-auto flex flex-wrap items-center gap-2">
-					{#if series.tmdbId}
-						<a
-							href="https://www.themoviedb.org/tv/{series.tmdbId}"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="btn shrink-0 gap-1 btn-ghost btn-xs"
-						>
-							TMDB
-							<ExternalLink size={12} />
-						</a>
 					{/if}
-					{#if series.tvdbId}
-						<a
-							href="https://thetvdb.com/series/{series.tvdbId}"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="btn shrink-0 gap-1 btn-ghost btn-xs"
-						>
-							TVDB
-							<ExternalLink size={12} />
-						</a>
-					{/if}
-					{#if series.imdbId}
-						<a
-							href="https://www.imdb.com/title/{series.imdbId}"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="btn shrink-0 gap-1 btn-ghost btn-xs"
-						>
-							IMDb
-							<ExternalLink size={12} />
-						</a>
-					{/if}
-					{#each providerLinks as provider (provider.label)}
-						<a
-							href={provider.href}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="btn shrink-0 gap-1 btn-ghost btn-xs"
-						>
-							{provider.label}
-							<ExternalLink size={12} />
-						</a>
-					{/each}
-					{#if hasTrailer}
-						<button class="btn shrink-0 gap-1 btn-ghost btn-xs" onclick={openTrailer}>
-							<Play size={12} />
-							{m.hero_trailer()}
-						</button>
-					{/if}
-				</div>
-			</div>
 
-			<!-- Right side metadata panel -->
-			{#if tmdbSeries}
-				<div
-					class="hidden w-64 shrink-0 rounded-lg bg-base-100/30 p-4 backdrop-blur-sm md:block lg:w-80 lg:p-5"
-				>
-					<div class="grid grid-cols-2 gap-x-4 gap-y-2 lg:gap-x-6 lg:gap-y-3">
-						<div>
-							<div class="text-sm text-base-content/50">{m.hero_metadata_status()}</div>
-							<div class="font-medium">{tmdbSeries.status}</div>
-						</div>
-
-						<div>
-							<div class="text-sm text-base-content/50">{m.hero_metadata_language()}</div>
-							<div class="font-medium">{formatLanguage(tmdbSeries.original_language)}</div>
-						</div>
-
-						{#if contentRating}
-							<div>
-								<div class="text-sm text-base-content/50">{m.hero_metadata_rated()}</div>
-								<div>
-									<span class="badge badge-outline badge-sm">{contentRating}</span>
-								</div>
-							</div>
-						{/if}
-
-						<div>
-							<div class="text-sm text-base-content/50">{m.hero_metadata_released()}</div>
-							<div class="font-medium">{formatDisplayDateShort(tmdbSeries.first_air_date)}</div>
-						</div>
-
-						{#if tmdbSeries.last_air_date}
-							<div>
-								<div class="text-sm text-base-content/50">Last Aired</div>
-								<div class="font-medium">{formatDisplayDateShort(tmdbSeries.last_air_date)}</div>
-							</div>
-						{/if}
-
-						{#if tmdbSeries.type}
-							<div>
-								<div class="text-sm text-base-content/50">Type</div>
-								<div class="font-medium">{tmdbSeries.type}</div>
-							</div>
-						{/if}
-
-						{#if tmdbSeries.number_of_seasons}
-							<div>
-								<div class="text-sm text-base-content/50">Seasons</div>
-								<div class="font-medium">{tmdbSeries.number_of_seasons}</div>
-							</div>
-						{/if}
-
-						{#if tmdbSeries.networks && tmdbSeries.networks.length > 0}
-							<div class="col-span-2">
-								<div class="text-sm text-base-content/50">Network</div>
-								<div class="font-medium">
-									{tmdbSeries.networks
-										.slice(0, 2)
-										.map((n) => n.name)
-										.join(', ')}
-								</div>
-							</div>
-						{/if}
-					</div>
-
-					{#if tmdbSeries['watch/providers']}
-						<div class="mt-4 border-t border-base-content/10 pt-4">
-							<div class="mb-2 text-sm text-base-content/50">{m.hero_metadata_whereToWatch()}</div>
-							<WatchProviders
-								providers={tmdbSeries['watch/providers']}
-								countryCode={defaultRegion}
+					{#if tmdbSeries?.credits?.crew?.length || tmdbSeries?.created_by?.length}
+						<div class="text-sm">
+							<CrewList
+								crew={tmdbSeries?.credits?.crew ?? []}
+								creators={tmdbSeries?.created_by ?? []}
 							/>
 						</div>
 					{/if}
+
+					{#if tmdbSeries?.credits?.cast?.length}
+						<div>
+							<div class="mb-2 text-sm text-base-content/60">Cast</div>
+							<div class="flex gap-3 overflow-x-auto pb-1">
+								{#each tmdbSeries.credits.cast.slice(0, 8) as actor (actor.id)}
+									<div class="flex shrink-0 flex-col items-center gap-1.5 w-16">
+										<div class="h-14 w-14 overflow-hidden rounded-full bg-base-300">
+											{#if actor.profile_path}
+												<TmdbImage
+													path={actor.profile_path}
+													size="w185"
+													alt={actor.name}
+													class="h-full w-full object-cover"
+												/>
+											{:else}
+												<div
+													class="flex h-full w-full items-center justify-center text-lg text-base-content/30"
+												>
+													{actor.name.charAt(0)}
+												</div>
+											{/if}
+										</div>
+										<div class="text-center">
+											<div class="text-xs font-medium leading-tight line-clamp-2">{actor.name}</div>
+											{#if actor.character}
+												<div class="text-xs text-base-content/50 leading-tight line-clamp-1">
+													{actor.character}
+												</div>
+											{/if}
+										</div>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
+
+					<!-- Episode stats + external links -->
+					<div
+						class="flex flex-col gap-2 border-t border-base-content/10 pt-3 sm:flex-row sm:items-center sm:justify-between"
+					>
+						{#if episodeCount != null}
+							<div class="flex flex-wrap items-center gap-2">
+								<span class="text-sm text-base-content/70">
+									{episodeFileCount ?? 0} / {episodeCount}
+									{m.common_episodes()}
+								</span>
+								{#if percentComplete === 100}
+									<span class="badge badge-sm badge-success"
+										>{m.library_seriesHeader_complete()}</span
+									>
+								{:else if percentComplete > 0}
+									<span class="badge badge-sm badge-primary">{percentComplete}%</span>
+								{/if}
+								{#if totalSeriesSize > 0}
+									<span class="badge badge-sm badge-info">{formatBytes(totalSeriesSize)}</span>
+								{/if}
+								{#if downloadingCount > 0}
+									<span class="badge badge-sm font-semibold badge-success">
+										<Download size={12} class="animate-pulse" />
+										{downloadingCount}
+									</span>
+								{/if}
+							</div>
+						{/if}
+						<div
+							class="flex shrink-0 items-center gap-1 overflow-x-auto border-t border-base-content/10 pt-2 pb-0.5 sm:border-0 sm:pt-0 sm:overflow-x-visible sm:pb-0"
+						>
+							{#if series.tmdbId}
+								<a
+									href="https://www.themoviedb.org/tv/{series.tmdbId}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn shrink-0 gap-1 btn-ghost btn-xs"
+								>
+									TMDB
+									<ExternalLink size={12} />
+								</a>
+							{/if}
+							{#if series.tvdbId}
+								<a
+									href="https://thetvdb.com/series/{series.tvdbId}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn shrink-0 gap-1 btn-ghost btn-xs"
+								>
+									TVDB
+									<ExternalLink size={12} />
+								</a>
+							{/if}
+							{#if series.imdbId}
+								<a
+									href="https://www.imdb.com/title/{series.imdbId}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn shrink-0 gap-1 btn-ghost btn-xs"
+								>
+									IMDb
+									<ExternalLink size={12} />
+								</a>
+							{/if}
+							{#each providerLinks as provider (provider.label)}
+								<a
+									href={provider.href}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="btn shrink-0 gap-1 btn-ghost btn-xs"
+								>
+									{provider.label}
+									<ExternalLink size={12} />
+								</a>
+							{/each}
+							{#if hasTrailer}
+								<button class="btn shrink-0 gap-1 btn-ghost btn-xs" onclick={openTrailer}>
+									<Play size={12} />
+									{m.hero_trailer()}
+								</button>
+							{/if}
+						</div>
+					</div>
 				</div>
-			{/if}
+
+				<!-- Right side metadata panel -->
+				{#if tmdbSeries}
+					<div
+						class="hidden w-64 shrink-0 rounded-lg bg-base-100/30 p-4 backdrop-blur-sm md:block lg:w-80 lg:p-5"
+					>
+						<div class="grid grid-cols-2 gap-x-4 gap-y-2 lg:gap-x-6 lg:gap-y-3">
+							<div>
+								<div class="text-xs text-base-content/50">{m.hero_metadata_status()}</div>
+								<div class="font-medium">{tmdbSeries.status}</div>
+							</div>
+
+							<div>
+								<div class="text-xs text-base-content/50">{m.hero_metadata_language()}</div>
+								<div class="font-medium">{formatLanguage(tmdbSeries.original_language)}</div>
+							</div>
+
+							{#if contentRating}
+								<div>
+									<div class="text-xs text-base-content/50">{m.hero_metadata_rated()}</div>
+									<div>
+										<span class="badge badge-outline badge-sm">{contentRating}</span>
+									</div>
+								</div>
+							{/if}
+
+							<div>
+								<div class="text-xs text-base-content/50">{m.hero_metadata_released()}</div>
+								<div class="font-medium">{formatDisplayDateShort(tmdbSeries.first_air_date)}</div>
+							</div>
+
+							{#if tmdbSeries.last_air_date}
+								<div>
+									<div class="text-xs text-base-content/50">Last Aired</div>
+									<div class="font-medium">{formatDisplayDateShort(tmdbSeries.last_air_date)}</div>
+								</div>
+							{/if}
+
+							{#if tmdbSeries.type}
+								<div>
+									<div class="text-xs text-base-content/50">Type</div>
+									<div class="font-medium">{tmdbSeries.type}</div>
+								</div>
+							{/if}
+
+							{#if tmdbSeries.number_of_seasons}
+								<div>
+									<div class="text-xs text-base-content/50">Seasons</div>
+									<div class="font-medium">{tmdbSeries.number_of_seasons}</div>
+								</div>
+							{/if}
+
+							{#if tmdbSeries.networks && tmdbSeries.networks.length > 0}
+								<div>
+									<div class="text-xs text-base-content/50">Network</div>
+									<div class="font-medium">
+										{tmdbSeries.networks
+											.slice(0, 2)
+											.map((n) => n.name)
+											.join(', ')}
+									</div>
+								</div>
+							{/if}
+
+							{#if tmdbSeries.number_of_episodes}
+								<div>
+									<div class="text-xs text-base-content/50">Episodes</div>
+									<div class="font-medium">{tmdbSeries.number_of_episodes}</div>
+								</div>
+							{/if}
+
+							{#if avgEpisodeRuntime}
+								<div>
+									<div class="text-xs text-base-content/50">Runtime</div>
+									<div class="font-medium">{avgEpisodeRuntime}m / ep</div>
+								</div>
+							{/if}
+
+							{#if isAnimated && tmdbSeries.production_companies?.length}
+								<div class="col-span-2">
+									<div class="text-xs text-base-content/50">Studio</div>
+									<div class="font-medium">
+										{tmdbSeries.production_companies
+											.slice(0, 2)
+											.map((c) => c.name)
+											.join(', ')}
+									</div>
+								</div>
+							{/if}
+						</div>
+
+						{#if tmdbSeries['watch/providers']}
+							<div class="mt-4 border-t border-base-content/10 pt-4">
+								<div class="mb-2 text-xs text-base-content/50">
+									{m.hero_metadata_whereToWatch()}
+								</div>
+								<WatchProviders
+									providers={tmdbSeries['watch/providers']}
+									countryCode={defaultRegion}
+								/>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
 		</div>
 	</div>
 </div>
@@ -472,3 +648,113 @@
 	confirmLabel={m.blockedMedia_confirmBlockLabel()}
 	confirmVariant="error"
 />
+
+<!-- Mobile action bar -->
+<div
+	class="fixed bottom-0 left-0 right-0 z-40 border-t border-base-content/6 bg-base-100/75 backdrop-blur-xl sm:hidden"
+	style="padding-bottom: env(safe-area-inset-bottom)"
+>
+	<div class="flex items-stretch justify-around">
+		<!-- Monitor -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 transition-colors
+				{series.monitored ? 'text-success' : 'text-base-content/55'}"
+			onclick={() => onMonitorToggle?.(!series.monitored)}
+		>
+			{#if series.monitored}
+				<Eye size={20} />
+			{:else}
+				<EyeOff size={20} />
+			{/if}
+			<span class="text-[10px] tracking-wide">{series.monitored ? 'Monitored' : 'Off'}</span>
+		</button>
+
+		<!-- Auto-grab -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 transition-colors
+				{searchingMissing || missingEpisodeCount === 0 ? 'text-primary/40' : 'text-primary'}"
+			onclick={onSearchMissing}
+			disabled={searchingMissing || missingEpisodeCount === 0}
+		>
+			{#if searchingMissing}
+				<span class="loading loading-xs loading-spinner"></span>
+			{:else}
+				<Zap size={20} />
+			{/if}
+			<span class="text-[10px] tracking-wide">{m.library_seriesHeader_autoGrab()}</span>
+		</button>
+
+		<!-- Season Packs -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 text-base-content/55 transition-colors active:text-base-content/90"
+			onclick={onSearch}
+		>
+			<Package size={20} />
+			<span class="text-[10px] tracking-wide">{m.library_seriesHeader_seasonPacks()}</span>
+		</button>
+
+		<!-- Edit -->
+		<button
+			class="flex flex-1 flex-col items-center gap-1 py-3 text-base-content/55 transition-colors active:text-base-content/90"
+			onclick={onEdit}
+		>
+			<Settings size={20} />
+			<span class="text-[10px] tracking-wide">{m.action_edit()}</span>
+		</button>
+
+		<!-- Overflow (dropdown-top) -->
+		<div class="dropdown dropdown-top dropdown-end flex flex-1">
+			<button
+				tabindex="0"
+				class="flex flex-1 flex-col items-center gap-1 py-3 text-error/60 transition-colors active:text-error"
+			>
+				<MoreHorizontal size={20} />
+				<span class="text-[10px] tracking-wide">More</span>
+			</button>
+			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+			<ul
+				tabindex="0"
+				class="dropdown-content menu z-50 mb-2 w-52 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg"
+			>
+				<li>
+					<button onclick={onRefresh} disabled={refreshing}>
+						<RefreshCw size={16} />
+						{#if refreshing}
+							{m.common_loading()}
+						{:else}
+							{m.library_seriesHeader_refreshTooltip()}
+						{/if}
+					</button>
+				</li>
+				{#if onImport}
+					<li>
+						<button onclick={onImport}>
+							<Download size={16} />
+							{m.action_import()}
+						</button>
+					</li>
+				{/if}
+				{#if onSubtitleAutoSearch}
+					<li>
+						<button onclick={onSubtitleAutoSearch} disabled={subtitleAutoSearching}>
+							<Captions size={16} />
+							{m.library_seriesHeader_autoDownloadSubs()}
+						</button>
+					</li>
+				{/if}
+				<li>
+					<button class="text-error" onclick={onDelete}>
+						<Trash2 size={16} />
+						{m.action_delete()}
+					</button>
+				</li>
+				<li>
+					<button class="text-error" onclick={() => (showBlockConfirm = true)}>
+						<Ban size={16} />
+						{m.library_blockMediaTooltip()}
+					</button>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/library/SeasonAccordion.svelte
+++ b/src/lib/components/library/SeasonAccordion.svelte
@@ -254,7 +254,7 @@
 		class="flex w-full flex-col gap-3 p-4 transition-colors hover:bg-base-200 sm:flex-row sm:items-center sm:justify-between"
 	>
 		<!-- Clickable area for expand/collapse -->
-		<div class="flex w-full flex-wrap items-start gap-3 sm:flex-nowrap sm:items-center">
+		<div class="flex w-full flex-col gap-2 sm:flex-row sm:flex-nowrap sm:items-center">
 			<button
 				class="flex min-w-0 flex-1 items-center gap-3 text-left"
 				onclick={() => {
@@ -309,7 +309,7 @@
 			</button>
 
 			<!-- Action buttons -->
-			<div class="flex shrink-0 items-center gap-2 sm:ml-auto">
+			<div class="flex shrink-0 items-center gap-2 mx-auto sm:mx-0 sm:ml-auto">
 				<!-- Season monitor toggle -->
 				<button
 					class="btn btn-ghost btn-sm {season.monitored

--- a/src/lib/components/library/import/GroupEditorPanel.svelte
+++ b/src/lib/components/library/import/GroupEditorPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { untrack } from 'svelte';
 	import {
 		Check,
 		ChevronDown,
@@ -87,7 +88,7 @@
 	} = $props();
 
 	// Expand match list only when there's no match and no locked route context
-	let showMatchList = $state(!selectedMatch && !routeImportContext);
+	let showMatchList = $state(untrack(() => !selectedMatch && !routeImportContext));
 
 	$effect(() => {
 		showMatchList = !selectedMatch && !routeImportContext;

--- a/src/lib/components/library/tv/TVSeriesSidebar.svelte
+++ b/src/lib/components/library/tv/TVSeriesSidebar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { LibrarySeries } from '$lib/types/library';
 	import * as m from '$lib/paraglide/messages.js';
-	import { formatDisplayDateShort } from '$lib/utils/format.js';
 
 	interface Props {
 		series: LibrarySeries;
@@ -96,21 +95,9 @@
 					<dd class="sm:text-right">{series.originalTitle}</dd>
 				</div>
 			{/if}
-			{#if series.genres && series.genres.length > 0}
-				<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
-					<dt class="text-base-content/60">{m.common_genres()}</dt>
-					<dd class="sm:text-right">{series.genres.join(', ')}</dd>
-				</div>
-			{/if}
 			<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
 				<dt class="text-base-content/60">{m.library_seriesHeader_qualityProfileLabel()}</dt>
 				<dd>{qualityProfileName || m.common_default()}</dd>
-			</div>
-			<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
-				<dt class="text-base-content/60">{m.common_added()}</dt>
-				<dd>
-					{formatDisplayDateShort(series.added)}
-				</dd>
 			</div>
 			{#if series.imdbId}
 				<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
@@ -180,14 +167,7 @@
 					</dd>
 				</div>
 			{/each}
-		</dl>
-	</div>
-
-	<!-- Path Info -->
-	<div class="rounded-xl bg-base-200 p-4 md:p-6">
-		<h3 class="mb-3 font-semibold">{m.library_movieDetail_storageHeading()}</h3>
-		<dl class="space-y-2 text-sm">
-			<div>
+			<div class="border-t border-base-content/10 pt-2">
 				<dt class="text-base-content/60">{m.common_path()}</dt>
 				<dd class="mt-1 font-mono text-xs break-all">
 					{seriesStoragePath}

--- a/src/lib/components/tmdb/MediaHero.svelte
+++ b/src/lib/components/tmdb/MediaHero.svelte
@@ -358,7 +358,7 @@
 									? 'text-primary'
 									: 'text-base-content/60'}"
 					>
-						{smartRelease.text}
+						{formatReleaseLine(smartRelease)}
 					</div>
 				{:else if item.status}
 					<div class="mt-1 text-sm text-base-content/60 md:hidden">{item.status}</div>

--- a/src/lib/components/tmdb/MediaHero.svelte
+++ b/src/lib/components/tmdb/MediaHero.svelte
@@ -72,9 +72,7 @@
 
 	const countryCode = $derived(page.data.defaultRegion || TMDB.DEFAULT_REGION);
 
-	function isMovieDetails(
-		item: MediaDetailsWithLibraryStatus
-	): item is MovieDetails & {
+	function isMovieDetails(item: MediaDetailsWithLibraryStatus): item is MovieDetails & {
 		inLibrary?: boolean;
 		hasFile?: boolean;
 		monitored?: boolean;

--- a/src/lib/components/tmdb/MediaHero.svelte
+++ b/src/lib/components/tmdb/MediaHero.svelte
@@ -5,7 +5,22 @@
 	import WatchProviders from './WatchProviders.svelte';
 	import { ConfirmationModal } from '$lib/components/ui/modal';
 	import AddToLibraryModal from '$lib/components/library/AddToLibraryModal.svelte';
-	import { Plus, Check, Clock, Play, Film, ExternalLink, Ban } from 'lucide-svelte';
+	import {
+		Plus,
+		CircleCheckBig,
+		Play,
+		Film,
+		ExternalLink,
+		Ban,
+		X,
+		ChevronLeft,
+		ChevronRight,
+		Maximize2,
+		EyeOff,
+		CircleX
+	} from 'lucide-svelte';
+	import { fade } from 'svelte/transition';
+	import type { Video } from '$lib/types/tmdb';
 	import { formatCurrency, formatLanguage, formatDisplayDateShort } from '$lib/utils/format.js';
 	import { resolvePath } from '$lib/utils/routing';
 	import { SvelteMap } from 'svelte/reactivity';
@@ -24,6 +39,7 @@
 	type MediaDetailsWithLibraryStatus = (MovieDetails | TVShowDetails) & {
 		inLibrary?: boolean;
 		hasFile?: boolean;
+		monitored?: boolean;
 		libraryId?: string;
 	};
 
@@ -32,14 +48,25 @@
 	// Library status state (defaults only, effect syncs from props)
 	let inLibrary = $state(false);
 	let hasFile = $state(false);
+	let monitored = $state(true);
 	let libraryId = $state<string | undefined>(undefined);
 	let showAddModal = $state(false);
 	let showBlockConfirm = $state(false);
+	let activeVideo = $state<Video | null>(null);
+	let activeBackdrop = $state<string | null>(null);
+	let overviewExpanded = $state(false);
+
+	const overviewNeedsExpansion = $derived((item.overview?.length ?? 0) > 250);
+
+	$effect(() => {
+		if (item.id) overviewExpanded = false;
+	});
 
 	// Update state when item changes
 	$effect(() => {
 		inLibrary = item.inLibrary ?? false;
 		hasFile = item.hasFile ?? false;
+		monitored = item.monitored ?? true;
 		libraryId = item.libraryId;
 	});
 
@@ -47,7 +74,12 @@
 
 	function isMovieDetails(
 		item: MediaDetailsWithLibraryStatus
-	): item is MovieDetails & { inLibrary?: boolean; hasFile?: boolean; libraryId?: string } {
+	): item is MovieDetails & {
+		inLibrary?: boolean;
+		hasFile?: boolean;
+		monitored?: boolean;
+		libraryId?: string;
+	} {
 		return 'title' in item;
 	}
 
@@ -173,11 +205,12 @@
 		try {
 			const data = (await getLibraryStatus({ tmdbId: item.id, mediaType })) as {
 				success: boolean;
-				status?: { inLibrary: boolean; hasFile: boolean; libraryId: string };
+				status?: { inLibrary: boolean; hasFile: boolean; monitored?: boolean; libraryId: string };
 			};
 			if (data.success && data.status) {
 				inLibrary = data.status.inLibrary;
 				hasFile = data.status.hasFile;
+				monitored = data.status.monitored ?? true;
 				libraryId = data.status.libraryId;
 			}
 		} catch (e) {
@@ -192,15 +225,68 @@
 		refreshLibraryStatus();
 	}
 
-	function openTrailer() {
-		// Find a YouTube trailer in videos
-		const trailer = item.videos?.results?.find(
-			(v) => v.site === 'YouTube' && (v.type === 'Trailer' || v.type === 'Teaser')
-		);
-		if (trailer) {
-			window.open(`https://www.youtube.com/watch?v=${trailer.key}`, '_blank');
-		}
+	const TYPE_ORDER = ['Trailer', 'Teaser', 'Clip'];
+	const youtubeVideos = $derived(
+		[...(item.videos?.results ?? [])]
+			.filter((v) => v.site === 'YouTube' && TYPE_ORDER.includes(v.type))
+			.sort((a, b) => {
+				const aOrder = TYPE_ORDER.indexOf(a.type);
+				const bOrder = TYPE_ORDER.indexOf(b.type);
+				if (aOrder !== bOrder) return aOrder - bOrder;
+				return Number(b.official) - Number(a.official);
+			})
+			.slice(0, 8)
+	);
+
+	const backdropImages = $derived(
+		[...(item.images?.backdrops ?? [])]
+			.filter((b) => b.iso_639_1 === null)
+			.sort((a, b) => b.vote_average - a.vote_average)
+			.slice(0, 8)
+	);
+
+	const youtubeSearchFallbackUrl = $derived(
+		`https://www.youtube.com/results?search_query=${encodeURIComponent(title + ' trailer')}`
+	);
+
+	const mediaItems = $derived.by(() => {
+		const videos = youtubeVideos.map((v) => ({ type: 'video' as const, data: v }));
+		const supplementCount =
+			videos.length > 0 && videos.length < 3
+				? Math.min(6 - videos.length, backdropImages.length)
+				: 0;
+		const backdrops = backdropImages
+			.slice(0, supplementCount)
+			.map((b) => ({ type: 'backdrop' as const, data: b }));
+		return [...videos, ...backdrops];
+	});
+
+	let carouselContainer = $state<HTMLElement | null>(null);
+	let showLeftArrow = $state(false);
+	let showRightArrow = $state(false);
+
+	function handleCarouselScroll() {
+		if (!carouselContainer) return;
+		showLeftArrow = carouselContainer.scrollLeft > 10;
+		showRightArrow =
+			carouselContainer.scrollLeft <
+			carouselContainer.scrollWidth - carouselContainer.clientWidth - 10;
 	}
+
+	function scrollCarousel(direction: 'left' | 'right') {
+		if (!carouselContainer) return;
+		carouselContainer.scrollBy({
+			left:
+				direction === 'left'
+					? -carouselContainer.clientWidth * 0.75
+					: carouselContainer.clientWidth * 0.75,
+			behavior: 'smooth'
+		});
+	}
+
+	$effect(() => {
+		if (carouselContainer) handleCarouselScroll();
+	});
 </script>
 
 <div class="relative w-full overflow-hidden rounded-xl bg-base-200 shadow-xl">
@@ -211,7 +297,7 @@
 				path={item.backdrop_path}
 				size="original"
 				alt={title}
-				class="h-full w-full object-cover opacity-40 blur-sm"
+				class="h-full w-full object-cover opacity-40"
 			/>
 		{/if}
 		<div class="absolute inset-0 bg-linear-to-t from-base-200 via-base-200/80 to-transparent"></div>
@@ -222,7 +308,7 @@
 	<div class="relative z-10 flex flex-col gap-6 p-6 md:flex-row md:p-8">
 		<!-- Poster -->
 		<div class="hidden shrink-0 sm:block">
-			<div class="w-40 overflow-hidden rounded-lg shadow-lg md:w-48">
+			<div class="w-48 overflow-hidden rounded-lg shadow-lg md:w-56">
 				<TmdbImage
 					path={item.poster_path}
 					size="w342"
@@ -253,8 +339,8 @@
 						<span>{getRuntime(item)}</span>
 					{/if}
 					{#if item.genres && item.genres.length > 0}
-						<span class="hidden sm:inline">•</span>
-						<span class="hidden sm:inline"
+						<span>•</span>
+						<span
 							>{item.genres
 								.slice(0, 3)
 								.map((g) => g.name)
@@ -262,15 +348,51 @@
 						>
 					{/if}
 				</div>
+
+				<!-- Mobile-only release status -->
+				{#if smartRelease}
+					<div
+						class="mt-1 text-sm font-medium md:hidden {smartRelease.variant === 'released'
+							? 'text-success'
+							: smartRelease.variant === 'theaters'
+								? 'text-info'
+								: smartRelease.variant === 'upcoming'
+									? 'text-primary'
+									: 'text-base-content/60'}"
+					>
+						{smartRelease.text}
+					</div>
+				{:else if item.status}
+					<div class="mt-1 text-sm text-base-content/60 md:hidden">{item.status}</div>
+				{/if}
 			</div>
 
 			{#if item.tagline}
-				<p class="text-base text-base-content/50 italic">"{item.tagline}"</p>
+				<p class="border-l-2 border-primary pl-3 text-base text-base-content/50 italic">
+					{item.tagline}
+				</p>
 			{/if}
 
 			<!-- Overview -->
 			{#if item.overview}
-				<p class="text-base leading-relaxed text-base-content/90">{item.overview}</p>
+				<div>
+					<p
+						class="text-base leading-relaxed text-base-content/90 {!overviewExpanded &&
+						overviewNeedsExpansion
+							? 'line-clamp-4 sm:line-clamp-none'
+							: ''}"
+					>
+						{item.overview}
+					</p>
+					{#if overviewNeedsExpansion}
+						<button
+							class="mt-1 text-sm text-primary sm:hidden"
+							onclick={() => (overviewExpanded = !overviewExpanded)}
+						>
+							{overviewExpanded ? 'Read less' : 'Read more'}
+						</button>
+					{/if}
+				</div>
 			{/if}
 
 			<!-- Crew -->
@@ -283,6 +405,144 @@
 				</div>
 			{/if}
 
+			<!-- Video clips row / backdrop gallery -->
+			{#if mediaItems.length > 0}
+				<div class="group/carousel relative">
+					{#if showLeftArrow}
+						<button
+							transition:fade={{ duration: 150 }}
+							onclick={() => scrollCarousel('left')}
+							class="absolute -left-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-base-100/80 p-1 shadow backdrop-blur-sm hover:bg-base-100"
+						>
+							<ChevronLeft size={18} />
+						</button>
+					{/if}
+					{#if showRightArrow}
+						<button
+							transition:fade={{ duration: 150 }}
+							onclick={() => scrollCarousel('right')}
+							class="absolute -right-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-base-100/80 p-1 shadow backdrop-blur-sm hover:bg-base-100"
+						>
+							<ChevronRight size={18} />
+						</button>
+					{/if}
+					<div
+						bind:this={carouselContainer}
+						onscroll={handleCarouselScroll}
+						class="flex gap-3 overflow-x-auto pb-1 scrollbar-none"
+					>
+						{#each mediaItems as item (item.type === 'video' ? item.data.key : item.data.file_path)}
+							{#if item.type === 'video'}
+								<button
+									class="group shrink-0 w-36 text-left"
+									onclick={() => (activeVideo = item.data)}
+								>
+									<div class="relative aspect-video overflow-hidden rounded-lg bg-base-300">
+										<img
+											src="https://img.youtube.com/vi/{item.data.key}/mqdefault.jpg"
+											alt={item.data.name}
+											class="h-full w-full object-cover transition-opacity group-hover:opacity-75"
+										/>
+										<div class="absolute inset-0 flex items-center justify-center">
+											<div
+												class="rounded-full bg-black/50 p-2 transition-transform group-hover:scale-110"
+											>
+												<Play size={14} class="text-white" />
+											</div>
+										</div>
+									</div>
+									<div class="mt-1 truncate text-xs text-base-content/70">{item.data.name}</div>
+									<div class="text-xs text-base-content/40">{item.data.type}</div>
+								</button>
+							{:else}
+								<button
+									class="group shrink-0 w-36 text-left"
+									onclick={() => (activeBackdrop = item.data.file_path)}
+								>
+									<div class="relative aspect-video overflow-hidden rounded-lg bg-base-300">
+										<TmdbImage
+											path={item.data.file_path}
+											size="w300"
+											alt="Backdrop"
+											class="h-full w-full object-cover transition-opacity group-hover:opacity-75"
+										/>
+										<div
+											class="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+										>
+											<div class="rounded-full bg-black/50 p-2">
+												<Maximize2 size={14} class="text-white" />
+											</div>
+										</div>
+									</div>
+								</button>
+							{/if}
+						{/each}
+					</div>
+				</div>
+			{:else if backdropImages.length > 0}
+				<div class="group/carousel relative">
+					<div class="flex gap-3 overflow-x-auto pb-1 scrollbar-none">
+						{#each backdropImages as backdrop (backdrop.file_path)}
+							<button
+								class="group shrink-0 w-36 text-left"
+								onclick={() => (activeBackdrop = backdrop.file_path)}
+							>
+								<div class="relative aspect-video overflow-hidden rounded-lg bg-base-300">
+									<TmdbImage
+										path={backdrop.file_path}
+										size="w300"
+										alt="Backdrop"
+										class="h-full w-full object-cover transition-opacity group-hover:opacity-75"
+									/>
+									<div
+										class="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+									>
+										<div class="rounded-full bg-black/50 p-2">
+											<Maximize2 size={14} class="text-white" />
+										</div>
+									</div>
+								</div>
+							</button>
+						{/each}
+						<!-- YouTube search card -->
+						<!-- eslint-disable svelte/no-navigation-without-resolve -- External YouTube URL -->
+						<a
+							href={youtubeSearchFallbackUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="group shrink-0 w-36"
+						>
+							<div
+								class="flex aspect-video flex-col items-center justify-center gap-1.5 rounded-lg border border-base-content/10 bg-base-300 p-2 transition-colors group-hover:border-base-content/20 group-hover:bg-base-200"
+							>
+								<Play
+									size={18}
+									class="text-base-content/40 transition-colors group-hover:text-base-content/70"
+								/>
+								<span
+									class="text-center text-xs leading-tight text-base-content/40 transition-colors group-hover:text-base-content/70"
+									>{m.hero_trailer()}</span
+								>
+								<ExternalLink size={10} class="text-base-content/30" />
+							</div>
+						</a>
+						<!-- eslint-enable svelte/no-navigation-without-resolve -->
+					</div>
+				</div>
+			{/if}
+
+			{#if mediaItems.length > 0 || backdropImages.length > 0}
+				<hr class="border-base-content/10" />
+			{/if}
+
+			<!-- Mobile-only: Where to Watch -->
+			{#if item['watch/providers']}
+				<div class="border-b border-base-content/10 pb-3 md:hidden">
+					<div class="mb-1.5 text-xs text-base-content/50">{m.hero_metadata_whereToWatch()}</div>
+					<WatchProviders providers={item['watch/providers']} {countryCode} />
+				</div>
+			{/if}
+
 			<!-- Actions row -->
 			<div class="mt-auto flex flex-wrap items-center justify-between gap-4">
 				<div class="flex flex-wrap items-center gap-2">
@@ -291,13 +551,29 @@
 							<div
 								class="flex items-center gap-2 rounded-lg bg-success/20 px-3 py-1.5 text-sm text-success"
 							>
-								<Check class="h-4 w-4" />
+								<CircleCheckBig class="h-4 w-4" />
 								<span>{m.hero_available()}</span>
 							</div>
 							{#if libraryPageLink}
 								<a
 									href={resolvePath(libraryPageLink)}
-									class="btn gap-1 btn-outline btn-sm btn-success"
+									class="btn gap-1 btn-outline btn-sm btn-primary"
+								>
+									<Film class="h-4 w-4" />
+									{m.hero_viewInLibrary()}
+								</a>
+							{/if}
+						{:else if monitored}
+							<div
+								class="flex items-center gap-2 rounded-lg bg-error/20 px-3 py-1.5 text-sm text-error"
+							>
+								<CircleX class="h-4 w-4" />
+								<span>{m.common_missing()}</span>
+							</div>
+							{#if libraryPageLink}
+								<a
+									href={resolvePath(libraryPageLink)}
+									class="btn gap-1 btn-outline btn-sm btn-primary"
 								>
 									<Film class="h-4 w-4" />
 									{m.hero_viewInLibrary()}
@@ -305,15 +581,15 @@
 							{/if}
 						{:else}
 							<div
-								class="flex items-center gap-2 rounded-lg bg-warning/20 px-3 py-1.5 text-sm text-warning"
+								class="flex items-center gap-2 rounded-lg bg-base-content/10 px-3 py-1.5 text-sm text-base-content/50"
 							>
-								<Clock class="h-4 w-4" />
-								<span>{m.hero_monitored()}</span>
+								<EyeOff class="h-4 w-4" />
+								<span>{m.common_unmonitored()}</span>
 							</div>
 							{#if libraryPageLink}
 								<a
 									href={resolvePath(libraryPageLink)}
-									class="btn gap-1 btn-outline btn-sm btn-warning"
+									class="btn gap-1 btn-outline btn-sm btn-primary"
 								>
 									<Film class="h-4 w-4" />
 									{m.hero_viewInLibrary()}
@@ -327,16 +603,26 @@
 						</button>
 					{/if}
 
-					{#if item.videos?.results?.some((v) => v.site === 'YouTube' && (v.type === 'Trailer' || v.type === 'Teaser'))}
-						<button class="btn gap-1 btn-ghost btn-sm" onclick={openTrailer}>
+					{#if youtubeVideos.length === 0 && backdropImages.length === 0}
+						<!-- eslint-disable svelte/no-navigation-without-resolve -- External YouTube URL -->
+						<a
+							href={youtubeSearchFallbackUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn gap-1 btn-ghost btn-sm"
+						>
 							<Play class="h-4 w-4" />
 							{m.hero_trailer()}
-						</button>
+							<ExternalLink size={12} />
+						</a>
+						<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					{/if}
 				</div>
 
 				<!-- External links -->
-				<div class="flex items-center gap-2">
+				<div
+					class="flex w-full items-center gap-2 border-t border-base-content/10 pt-2 sm:w-auto sm:border-0 sm:pt-0"
+				>
 					<button
 						class="btn gap-1 text-error btn-ghost btn-xs"
 						onclick={() => (showBlockConfirm = true)}
@@ -518,6 +804,71 @@
 		</div>
 	</div>
 </div>
+
+<!-- Video player modal -->
+{#if activeVideo}
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label={activeVideo.name}
+		tabindex="-1"
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4"
+		onclick={() => (activeVideo = null)}
+		onkeydown={(e) => e.key === 'Escape' && (activeVideo = null)}
+	>
+		<div role="presentation" class="w-full max-w-4xl" onclick={(e) => e.stopPropagation()}>
+			<div class="mb-3 flex items-center justify-between gap-4">
+				<div>
+					<p class="font-semibold text-white">{activeVideo.name}</p>
+					<p class="text-sm text-white/50">{activeVideo.type}</p>
+				</div>
+				<button
+					class="btn btn-circle btn-ghost btn-sm text-white/70 hover:text-white"
+					onclick={() => (activeVideo = null)}
+				>
+					<X size={18} />
+				</button>
+			</div>
+			<div class="relative w-full overflow-hidden rounded-xl" style="aspect-ratio: 16/9">
+				<iframe
+					src="https://www.youtube-nocookie.com/embed/{activeVideo.key}?autoplay=1"
+					title={activeVideo.name}
+					class="absolute inset-0 h-full w-full"
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					allowfullscreen
+				></iframe>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Backdrop lightbox -->
+{#if activeBackdrop}
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label="Backdrop image"
+		tabindex="-1"
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4"
+		onclick={() => (activeBackdrop = null)}
+		onkeydown={(e) => e.key === 'Escape' && (activeBackdrop = null)}
+	>
+		<button
+			class="absolute right-4 top-4 btn btn-circle btn-ghost btn-sm text-white/70 hover:text-white"
+			onclick={() => (activeBackdrop = null)}
+		>
+			<X size={18} />
+		</button>
+		<div role="presentation" onclick={(e) => e.stopPropagation()}>
+			<TmdbImage
+				path={activeBackdrop}
+				size="original"
+				alt="Backdrop"
+				class="max-h-[90vh] max-w-[90vw] rounded-xl object-contain shadow-2xl"
+			/>
+		</div>
+	</div>
+{/if}
 
 <!-- Add to Library Modal -->
 <AddToLibraryModal

--- a/src/lib/components/tmdb/WatchProviders.svelte
+++ b/src/lib/components/tmdb/WatchProviders.svelte
@@ -8,10 +8,12 @@
 
 	let {
 		providers,
-		countryCode
+		countryCode,
+		limit = 8
 	}: {
 		providers?: WatchProvidersResponse;
 		countryCode?: string;
+		limit?: number;
 	} = $props();
 
 	const effectiveCountryCode = $derived(
@@ -45,7 +47,7 @@
 
 {#if allProviders.length > 0}
 	<div class="flex flex-wrap items-center gap-1.5">
-		{#each allProviders.slice(0, 8) as provider (provider.provider_id)}
+		{#each allProviders.slice(0, limit) as provider (provider.provider_id)}
 			<div
 				class="h-7 w-7 overflow-hidden rounded bg-base-300 transition-transform hover:scale-110"
 				title={provider.provider_name}
@@ -66,8 +68,8 @@
 				{/if}
 			</div>
 		{/each}
-		{#if allProviders.length > 8}
-			<span class="text-xs text-base-content/50">+{allProviders.length - 8}</span>
+		{#if allProviders.length > limit}
+			<span class="text-xs text-base-content/50">+{allProviders.length - limit}</span>
 		{/if}
 	</div>
 {:else}

--- a/src/lib/server/discover.ts
+++ b/src/lib/server/discover.ts
@@ -47,6 +47,7 @@ export interface DiscoverParams {
 	maxDate: string | null;
 	minRating: string | null;
 	certification: string | null;
+	skipKeywordBlocklist?: boolean;
 }
 
 export async function getDiscoverResults(params: DiscoverParams) {
@@ -64,7 +65,8 @@ export async function getDiscoverResults(params: DiscoverParams) {
 		minDate,
 		maxDate,
 		minRating,
-		certification
+		certification,
+		skipKeywordBlocklist = false
 	} = params;
 
 	const fetchOptions = (endpoint: string, p: string = page) => {
@@ -126,8 +128,9 @@ export async function getDiscoverResults(params: DiscoverParams) {
 		return `${endpoint}?${queryParams.toString()}`;
 	};
 
-	const fetchMovies = () => tmdb.fetch(fetchOptions('/discover/movie'));
-	const fetchTV = () => tmdb.fetch(fetchOptions('/discover/tv'));
+	const fetchMovies = () =>
+		tmdb.fetch(fetchOptions('/discover/movie'), {}, false, skipKeywordBlocklist);
+	const fetchTV = () => tmdb.fetch(fetchOptions('/discover/tv'), {}, false, skipKeywordBlocklist);
 
 	let results: (Movie | TVShow)[];
 	let totalPages: number;

--- a/src/lib/server/library/status.ts
+++ b/src/lib/server/library/status.ts
@@ -8,6 +8,7 @@ import { inArray, eq, and } from 'drizzle-orm';
 export interface LibraryStatus {
 	inLibrary: boolean;
 	hasFile: boolean;
+	monitored?: boolean;
 	mediaType: 'movie' | 'tv' | null;
 	libraryId?: string;
 	releaseDate?: string | null;
@@ -56,6 +57,7 @@ export async function getLibraryStatus(
 				id: movies.id,
 				tmdbId: movies.tmdbId,
 				hasFile: movies.hasFile,
+				monitored: movies.monitored,
 				releaseDate: movies.releaseDate,
 				digitalReleaseDate: movies.digitalReleaseDate,
 				physicalReleaseDate: movies.physicalReleaseDate
@@ -67,6 +69,7 @@ export async function getLibraryStatus(
 			statusMap[movie.tmdbId] = {
 				inLibrary: true,
 				hasFile: movie.hasFile ?? false,
+				monitored: movie.monitored ?? true,
 				mediaType: 'movie',
 				libraryId: movie.id,
 				releaseDate: movie.releaseDate,
@@ -82,6 +85,7 @@ export async function getLibraryStatus(
 			.select({
 				id: series.id,
 				tmdbId: series.tmdbId,
+				monitored: series.monitored,
 				episodeFileCount: series.episodeFileCount
 			})
 			.from(series)
@@ -93,6 +97,7 @@ export async function getLibraryStatus(
 			statusMap[show.tmdbId] = {
 				inLibrary: true,
 				hasFile,
+				monitored: show.monitored ?? true,
 				mediaType: 'tv',
 				libraryId: show.id
 			};
@@ -117,6 +122,7 @@ export async function enrichWithLibraryStatus<T extends { id: number }>(
 	(T & {
 		inLibrary: boolean;
 		hasFile: boolean;
+		monitored?: boolean;
 		libraryId?: string;
 		releaseDate?: string | null;
 		digitalReleaseDate?: string | null;
@@ -136,6 +142,7 @@ export async function enrichWithLibraryStatus<T extends { id: number }>(
 			...item,
 			inLibrary: status?.inLibrary ?? false,
 			hasFile: status?.hasFile ?? false,
+			monitored: status?.monitored,
 			libraryId: status?.libraryId,
 			releaseDate: status?.releaseDate ?? null,
 			digitalReleaseDate: status?.digitalReleaseDate ?? null,

--- a/src/lib/server/security/headers.ts
+++ b/src/lib/server/security/headers.ts
@@ -7,7 +7,8 @@ const CSP_HEADER = [
 	"font-src 'self'",
 	"media-src 'self' blob: https: http:",
 	"object-src 'none'",
-	"child-src 'self'",
+	"child-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+	"frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
 	"frame-ancestors 'self'"
 ].join('; ');
 

--- a/src/lib/server/tmdb-cache.ts
+++ b/src/lib/server/tmdb-cache.ts
@@ -180,6 +180,11 @@ export const tmdbCache = new TmdbCache();
 /**
  * Generate a cache key for a TMDB request
  */
-export function getCacheKey(endpoint: string, skipFilters: boolean, language?: string): string {
-	return `tmdb:${endpoint}:${language ?? 'default'}:${skipFilters}`;
+export function getCacheKey(
+	endpoint: string,
+	skipFilters: boolean,
+	language?: string,
+	skipKeywordBlocklist = false
+): string {
+	return `tmdb:${endpoint}:${language ?? 'default'}:${skipFilters}:${skipKeywordBlocklist}`;
 }

--- a/src/lib/server/tmdb.ts
+++ b/src/lib/server/tmdb.ts
@@ -129,12 +129,17 @@ export const tmdb = {
 		}
 	},
 
-	async fetch(endpoint: string, options: RequestInit = {}, skipFilters = false) {
+	async fetch(
+		endpoint: string,
+		options: RequestInit = {},
+		skipFilters = false,
+		skipKeywordBlocklist = false
+	) {
 		const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
 		const isGetRequest = !options.method || options.method === 'GET';
 
 		const { apiKey, filters } = await loadTmdbSettings();
-		const cacheKey = getCacheKey(path, skipFilters, filters?.language);
+		const cacheKey = getCacheKey(path, skipFilters, filters?.language, skipKeywordBlocklist);
 
 		if (isGetRequest) {
 			const cached = tmdbCache.get(cacheKey);
@@ -199,7 +204,7 @@ export const tmdb = {
 					}
 
 					// Apply globally blocked keywords as without_keywords for discover paths
-					if (path.includes('/discover/')) {
+					if (path.includes('/discover/') && !skipKeywordBlocklist) {
 						const { keywordBlocklistService } =
 							await import('$lib/server/settings/KeywordBlocklistService.js');
 						const blockedIds = await keywordBlocklistService.getBlockedKeywordIds();

--- a/src/lib/server/tmdb.ts
+++ b/src/lib/server/tmdb.ts
@@ -303,12 +303,12 @@ export const tmdb = {
 	},
 	async getMovie(id: number): Promise<MovieDetails> {
 		return this.fetch(
-			`/movie/${id}?append_to_response=credits,videos,images,recommendations,similar,watch/providers,release_dates,keywords`
+			`/movie/${id}?append_to_response=credits,videos,images,recommendations,similar,watch/providers,release_dates,keywords&include_image_language=null,en`
 		) as Promise<MovieDetails>;
 	},
 	async getTVShow(id: number): Promise<TVShowDetails> {
 		return this.fetch(
-			`/tv/${id}?append_to_response=credits,videos,images,recommendations,similar,watch/providers,content_ratings,keywords`
+			`/tv/${id}?append_to_response=credits,videos,images,recommendations,similar,watch/providers,content_ratings,keywords&include_image_language=null,en`
 		) as Promise<TVShowDetails>;
 	},
 	async getSeason(tvId: number, seasonNumber: number): Promise<Season> {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -47,6 +47,9 @@
 		Palette
 	} from 'lucide-svelte';
 
+	const GITHUB_URL = 'https://github.com/MoldyTaint/Cinephage';
+	const DISCORD_URL = 'https://discord.gg/scGCBTSWEt';
+
 	type MenuChildItem = {
 		href: string;
 		label: () => string;
@@ -393,7 +396,7 @@
 					</label>
 				</div>
 				<div class="mx-2 flex min-w-0 flex-1 items-center gap-2 px-2">
-					<img src="/logo.png" alt="" class="h-7 w-7" />
+					<img src="/logo.png" alt="" class="h-8 w-8 rounded" />
 					<div class="relative min-w-0">
 						<span class="block truncate pr-10 text-xl leading-tight font-bold"
 							>{m.common_appName()}</span
@@ -449,7 +452,7 @@
 				>
 					{#if layoutState.isSidebarExpanded}
 						<div class="flex min-w-0 items-center gap-2">
-							<img src="/logo.png" alt="" class="h-7 w-7" />
+							<img src="/logo.png" alt="" class="h-7 w-7 rounded" />
 							<div class="relative min-w-0">
 								<span class="block truncate pr-10 text-xl leading-tight font-bold"
 									>{m.common_appName()}</span
@@ -464,7 +467,11 @@
 					{:else}
 						<div class="relative -mr-1 -ml-3">
 							<div class="grid h-11 w-11 place-items-center rounded-lg bg-base-100/70">
-								<img src="/logo.png" alt={m.common_appName()} class="h-9 w-9 object-contain" />
+								<img
+									src="/logo.png"
+									alt={m.common_appName()}
+									class="h-9 w-9 object-contain rounded"
+								/>
 							</div>
 							<span
 								class="absolute bottom-[-0.35rem] left-1/2 badge h-4 min-h-4 -translate-x-1/2 px-1 badge-xs font-semibold badge-warning"
@@ -584,22 +591,78 @@
 						<div class="rounded-xl border border-base-300/70 bg-base-100/70 p-2 shadow-sm">
 							<div class="flex items-center justify-between px-2 pb-2">
 								<span class="text-xs tracking-wide text-base-content/50">{appVersion ?? ''}</span>
-								{#if layoutState.mobileSseStatus === 'connected'}
-									<span class="badge badge-success badge-xs gap-1">
-										<Wifi class="h-3 w-3" />
-										{m.common_live()}
-									</span>
-								{:else if layoutState.mobileSseStatus === 'error'}
-									<span class="badge badge-warning badge-xs gap-1">
-										<Loader2 class="h-3 w-3 animate-spin" />
-										{m.common_reconnecting()}
-									</span>
-								{:else if layoutState.mobileSseStatus === 'connecting'}
-									<span class="badge badge-info badge-xs gap-1">
-										<Loader2 class="h-3 w-3 animate-spin" />
-										{m.common_connecting()}
-									</span>
-								{/if}
+								<div class="flex items-center gap-1.5">
+									<div class="flex items-center gap-0.5 lg:hidden">
+										<a
+											href={DISCORD_URL}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="btn btn-ghost btn-xs px-1 text-base-content/40 hover:text-base-content/70"
+											title="Discord"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-3.5 w-3.5"
+												viewBox="0 0 24 24"
+												fill="currentColor"
+											>
+												<path
+													d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028z"
+												/>
+												<ellipse
+													cx="8.5"
+													cy="12.5"
+													rx="1.5"
+													ry="1.65"
+													fill="var(--discord-eye, white)"
+												/>
+												<ellipse
+													cx="15.5"
+													cy="12.5"
+													rx="1.5"
+													ry="1.65"
+													fill="var(--discord-eye, white)"
+												/>
+											</svg>
+										</a>
+										<a
+											href={GITHUB_URL}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="btn btn-ghost btn-xs px-1 text-base-content/40 hover:text-base-content/70"
+											title="GitHub"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-3.5 w-3.5"
+												viewBox="0 0 24 24"
+												fill="currentColor"
+											>
+												<path
+													d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"
+												/>
+											</svg>
+										</a>
+									</div>
+									<div class="hidden items-center lg:flex">
+										{#if layoutState.mobileSseStatus === 'connected'}
+											<span class="badge badge-success badge-xs gap-1">
+												<Wifi class="h-3 w-3" />
+												{m.common_live()}
+											</span>
+										{:else if layoutState.mobileSseStatus === 'error'}
+											<span class="badge badge-warning badge-xs gap-1">
+												<Loader2 class="h-3 w-3 animate-spin" />
+												{m.common_reconnecting()}
+											</span>
+										{:else if layoutState.mobileSseStatus === 'connecting'}
+											<span class="badge badge-info badge-xs gap-1">
+												<Loader2 class="h-3 w-3 animate-spin" />
+												{m.common_connecting()}
+											</span>
+										{/if}
+									</div>
+								</div>
 							</div>
 							<div class="space-y-1 border-t border-base-300/70 pt-2">
 								<LanguageSelector
@@ -614,19 +677,73 @@
 								/>
 							</div>
 							<div class="mt-2 border-t border-base-300/70 pt-2">
-								<button
-									class="btn w-full justify-start text-error btn-ghost btn-sm hover:bg-error/10"
-									onclick={handleLogout}
-									disabled={isLoggingOut}
-									title={m.action_logout()}
-								>
-									{#if isLoggingOut}
-										<span class="loading loading-xs loading-spinner"></span>
-									{:else}
-										<LogOut class="h-4 w-4" />
-									{/if}
-									<span class="ml-2">{m.action_logout()}</span>
-								</button>
+								<div class="flex items-center gap-1">
+									<button
+										class="btn flex-1 justify-start text-error btn-ghost btn-sm hover:bg-error/10"
+										onclick={handleLogout}
+										disabled={isLoggingOut}
+										title={m.action_logout()}
+									>
+										{#if isLoggingOut}
+											<span class="loading loading-xs loading-spinner"></span>
+										{:else}
+											<LogOut class="h-4 w-4" />
+										{/if}
+										<span class="ml-2">{m.action_logout()}</span>
+									</button>
+									<div class="hidden items-center gap-0.5 lg:flex">
+										<a
+											href={DISCORD_URL}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="btn btn-ghost btn-xs px-2 text-base-content/40 hover:text-base-content/70"
+											title="Discord"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-3.5 w-3.5"
+												viewBox="0 0 24 24"
+												fill="currentColor"
+											>
+												<path
+													d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028z"
+												/>
+												<ellipse
+													cx="8.5"
+													cy="12.5"
+													rx="1.5"
+													ry="1.65"
+													fill="var(--discord-eye, white)"
+												/>
+												<ellipse
+													cx="15.5"
+													cy="12.5"
+													rx="1.5"
+													ry="1.65"
+													fill="var(--discord-eye, white)"
+												/>
+											</svg>
+										</a>
+										<a
+											href={GITHUB_URL}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="btn btn-ghost btn-xs px-2 text-base-content/40 hover:text-base-content/70"
+											title="GitHub"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												class="h-3.5 w-3.5"
+												viewBox="0 0 24 24"
+												fill="currentColor"
+											>
+												<path
+													d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"
+												/>
+											</svg>
+										</a>
+									</div>
+								</div>
 							</div>
 						</div>
 					{:else}

--- a/src/routes/api/discover/+server.ts
+++ b/src/routes/api/discover/+server.ts
@@ -26,7 +26,8 @@ const discoverQuerySchema = z.object({
 	'primary_release_date.lte': z.string().nullable().default(null),
 	'vote_average.gte': z.string().nullable().default(null),
 	certification: z.string().nullable().default(null),
-	exclude_in_library: z.enum(['true', 'false']).optional()
+	exclude_in_library: z.enum(['true', 'false']).optional(),
+	skip_blocked: z.enum(['true', 'false']).optional()
 });
 
 interface TmdbPaginatedResult {
@@ -111,7 +112,8 @@ export const GET: RequestHandler = async ({ url }) => {
 				minDate: params['primary_release_date.gte'],
 				maxDate: params['primary_release_date.lte'],
 				minRating: params['vote_average.gte'],
-				certification: params.certification
+				certification: params.certification,
+				skipKeywordBlocklist: params.skip_blocked === 'true'
 			});
 			results = discoverResult.results;
 			pagination = discoverResult.pagination;

--- a/src/routes/api/settings/blocked-keywords/+server.ts
+++ b/src/routes/api/settings/blocked-keywords/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { keywordBlocklistService } from '$lib/server/settings/KeywordBlocklistService.js';
 import { addBlockedKeywordSchema, removeBlockedKeywordSchema } from '$lib/validation/schemas.js';
+import { tmdbCache } from '$lib/server/tmdb-cache.js';
 
 export const GET: RequestHandler = async (event) => {
 	const authError = requireAdmin(event);
@@ -34,6 +35,7 @@ export const POST: RequestHandler = async (event) => {
 
 	try {
 		const entry = await keywordBlocklistService.addBlockedKeyword(parsed.data.keywordId);
+		tmdbCache.invalidate('/discover/');
 		return json({ success: true, entry });
 	} catch (err) {
 		return json({ error: 'Failed to add keyword', details: String(err) }, { status: 500 });
@@ -55,5 +57,6 @@ export const DELETE: RequestHandler = async (event) => {
 	}
 
 	await keywordBlocklistService.removeBlockedKeyword(parsed.data.id);
+	tmdbCache.invalidate('/discover/');
 	return json({ success: true });
 };

--- a/src/routes/discover/+page.server.ts
+++ b/src/routes/discover/+page.server.ts
@@ -337,16 +337,26 @@ export const load: PageServerLoad = async ({ url }) => {
 		}
 
 		if (isDefaultViewCheck && page === '1') {
-			// Fetch sections for the dashboard-style view
+			// Fetch sections for the dashboard-style view.
+			// Popular/top-rated use /discover/ endpoints so the keyword blocklist
+			// injection in tmdb.fetch() fires. Trending and now-playing don't
+			// support without_keywords so they remain as dedicated endpoints.
 			const [trendingWeek, popularMovies, popularTV, topRatedMovies, topRatedTV, nowPlayingData] =
 				(await Promise.all([
 					tmdb.fetch('/trending/all/week'),
-					tmdb.fetch('/movie/popular'),
-					tmdb.fetch('/tv/popular'),
-					tmdb.fetch('/movie/top_rated'),
-					tmdb.fetch('/tv/top_rated'),
+					tmdb.fetch('/discover/movie?sort_by=popularity.desc'),
+					tmdb.fetch('/discover/tv?sort_by=popularity.desc'),
+					tmdb.fetch('/discover/movie?sort_by=vote_average.desc&vote_count.gte=300'),
+					tmdb.fetch('/discover/tv?sort_by=vote_average.desc&vote_count.gte=300'),
 					tmdb.getNowPlaying()
 				])) as TmdbPaginatedResult[];
+
+			// Discover endpoints don't tag media_type — add it so downstream
+			// code (library status, filters) can identify the media type.
+			popularMovies.results = popularMovies.results.map((r) => ({ ...r, media_type: 'movie' }));
+			popularTV.results = popularTV.results.map((r) => ({ ...r, media_type: 'tv' }));
+			topRatedMovies.results = topRatedMovies.results.map((r) => ({ ...r, media_type: 'movie' }));
+			topRatedTV.results = topRatedTV.results.map((r) => ({ ...r, media_type: 'tv' }));
 
 			// Enrich all sections with library status and filter blocked media
 			const [

--- a/src/routes/discover/+page.svelte
+++ b/src/routes/discover/+page.svelte
@@ -392,6 +392,27 @@
 				allResults = data.results as ResultsType;
 				currentPage = data.pagination?.page ?? 1;
 			}
+		} else if (data.viewType === 'dashboard' && data.sections) {
+			// Collect all unique items across dashboard sections so debug mode
+			// has a populated ID set to diff against.
+			const seen = new SvelteSet<number>();
+			const combined: ResultsType = [];
+			for (const section of [
+				data.sections.trendingWeek,
+				data.sections.popularMovies,
+				data.sections.popularTV,
+				data.sections.topRatedMovies,
+				data.sections.topRatedTV,
+				data.sections.nowPlaying
+			]) {
+				for (const item of section ?? []) {
+					if (!seen.has((item as { id: number }).id)) {
+						seen.add((item as { id: number }).id);
+						combined.push(item as unknown as ResultsType[number]);
+					}
+				}
+			}
+			allResults = combined;
 		}
 	});
 

--- a/src/routes/discover/+page.svelte
+++ b/src/routes/discover/+page.svelte
@@ -348,9 +348,17 @@
 	let isLoadingMore = $state(false);
 	let loadMoreTrigger = $state<HTMLElement>();
 
-	let debugMode = $state(false);
+	let debugMode = $state(
+		typeof localStorage !== 'undefined' && localStorage.getItem('discover_debugMode') === 'true'
+	);
 	let filteredOutResults = $state<ResultsType>([]);
 	let debugLoading = $state(false);
+
+	$effect(() => {
+		if (debugMode && filteredOutResults.length === 0 && !debugLoading) {
+			loadDebugResults();
+		}
+	});
 
 	async function loadDebugResults() {
 		debugLoading = true;
@@ -377,6 +385,7 @@
 
 	function toggleDebug() {
 		debugMode = !debugMode;
+		localStorage.setItem('discover_debugMode', String(debugMode));
 		if (debugMode) {
 			loadDebugResults();
 		} else {

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -5,7 +5,8 @@ import {
 	rootFolders,
 	scoringProfiles,
 	downloadQueue,
-	subtitles
+	subtitles,
+	libraries
 } from '$lib/server/db/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
@@ -28,6 +29,8 @@ export interface QueueItemInfo {
 
 export interface LibraryMoviePageData {
 	movie: LibraryMovie;
+	librarySlug: string | null;
+	libraryName: string | null;
 	tmdbDetails: MovieDetails | null;
 	qualityProfiles: QualityProfileSummary[];
 	rootFolders: Array<{
@@ -99,10 +102,15 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 			physicalReleaseDate: movies.physicalReleaseDate,
 			availabilityDelay: movies.availabilityDelay,
 			downloadReleaseDate: movies.downloadReleaseDate,
-			downloadReleaseType: movies.downloadReleaseType
+			downloadReleaseType: movies.downloadReleaseType,
+			libraryId: movies.libraryId,
+			librarySlug: libraries.slug,
+			libraryName: libraries.name,
+			libraryIsDefault: libraries.isDefault
 		})
 		.from(movies)
 		.leftJoin(rootFolders, eq(movies.rootFolderId, rootFolders.id))
+		.leftJoin(libraries, eq(movies.libraryId, libraries.id))
 		.where(eq(movies.id, id));
 
 	if (movieResult.length === 0) {
@@ -290,8 +298,13 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 	});
 	movieWithFiles.providerRefs = enrichedProviderRefs;
 
+	const librarySlug = movie.libraryIsDefault ? null : (movie.librarySlug ?? null);
+	const libraryName = movie.libraryName ?? null;
+
 	return {
 		movie: movieWithFiles,
+		librarySlug,
+		libraryName,
 		tmdbDetails,
 		qualityProfiles: allQualityProfiles,
 		rootFolders: folders,

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -755,6 +755,8 @@
 	<!-- Header -->
 	<LibraryMovieHeader
 		{movie}
+		librarySlug={data.librarySlug}
+		libraryName={data.libraryName}
 		tmdbMovie={data.tmdbDetails}
 		defaultRegion={page.data.defaultRegion}
 		configuredProviders={data.configuredMetadataProviders}

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -38,7 +38,7 @@
 	import { goto } from '$app/navigation';
 	import { resolvePath } from '$lib/utils/routing';
 	import { createDynamicSSE } from '$lib/sse';
-	import { getFileName, formatDisplayDate } from '$lib/utils/format.js';
+	import { getFileName } from '$lib/utils/format.js';
 	import { layoutState, deriveMobileSseStatus } from '$lib/layout.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
@@ -894,32 +894,9 @@
 							<dd class="sm:text-right">{movie.studios.join(', ')}</dd>
 						</div>
 					{/if}
-					{#if movie.runtime}
-						<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
-							<dt class="text-base-content/60">{m.library_movieDetail_runtime()}</dt>
-							<dd>
-								{m.library_movieDetail_runtimeValue({
-									hours: String(Math.floor(movie.runtime / 60)),
-									minutes: String(movie.runtime % 60)
-								})}
-							</dd>
-						</div>
-					{/if}
-					{#if movie.genres && movie.genres.length > 0}
-						<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
-							<dt class="text-base-content/60">{m.library_movieDetail_genres()}</dt>
-							<dd class="sm:text-right">{movie.genres.join(', ')}</dd>
-						</div>
-					{/if}
 					<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
 						<dt class="text-base-content/60">{m.library_movieHeader_qualityProfileLabel()}</dt>
 						<dd>{qualityProfileName || m.common_default()}</dd>
-					</div>
-					<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
-						<dt class="text-base-content/60">{m.common_added()}</dt>
-						<dd>
-							{formatDisplayDate(movie.added)}
-						</dd>
 					</div>
 					{#if movie.imdbId}
 						<div class="flex flex-col gap-0.5 sm:flex-row sm:justify-between">
@@ -974,14 +951,7 @@
 							</dd>
 						</div>
 					{/each}
-				</dl>
-			</div>
-
-			<!-- Path Info -->
-			<div class="rounded-xl bg-base-200 p-4 md:p-6">
-				<h3 class="mb-3 font-semibold">{m.library_movieDetail_storageHeading()}</h3>
-				<dl class="space-y-2 text-sm">
-					<div>
+					<div class="border-t border-base-content/10 pt-2">
 						<dt class="text-base-content/60">{m.library_movieDetail_path()}</dt>
 						<dd class="mt-1 font-mono text-xs break-all">
 							{movieStoragePath}

--- a/src/routes/library/movies/+page.svelte
+++ b/src/routes/library/movies/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { resolvePath } from '$lib/utils/routing';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -48,6 +48,26 @@
 	import * as m from '$lib/paraglide/messages.js';
 
 	let { data } = $props();
+
+	const SCROLL_KEY = 'cinephage:library:movies:scrollY';
+
+	beforeNavigate(({ to }) => {
+		if (to?.url.pathname.startsWith('/library/movie/')) {
+			localStorage.setItem(SCROLL_KEY, String(window.scrollY));
+		} else {
+			localStorage.removeItem(SCROLL_KEY);
+		}
+	});
+
+	afterNavigate(({ from }) => {
+		if (from?.url.pathname.startsWith('/library/movie/')) {
+			const saved = localStorage.getItem(SCROLL_KEY);
+			if (saved) {
+				requestAnimationFrame(() => window.scrollTo({ top: parseInt(saved), behavior: 'instant' }));
+				localStorage.removeItem(SCROLL_KEY);
+			}
+		}
+	});
 
 	// Selection state
 	let selectedMovies = new SvelteSet<string>();

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { resolvePath } from '$lib/utils/routing';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -43,6 +43,26 @@
 	import * as m from '$lib/paraglide/messages.js';
 
 	let { data } = $props();
+
+	const SCROLL_KEY = 'cinephage:library:tv:scrollY';
+
+	beforeNavigate(({ to }) => {
+		if (to?.url.pathname.startsWith('/library/tv/')) {
+			localStorage.setItem(SCROLL_KEY, String(window.scrollY));
+		} else {
+			localStorage.removeItem(SCROLL_KEY);
+		}
+	});
+
+	afterNavigate(({ from }) => {
+		if (from?.url.pathname.startsWith('/library/tv/')) {
+			const saved = localStorage.getItem(SCROLL_KEY);
+			if (saved) {
+				requestAnimationFrame(() => window.scrollTo({ top: parseInt(saved), behavior: 'instant' }));
+				localStorage.removeItem(SCROLL_KEY);
+			}
+		}
+	});
 
 	// Selection state
 	let selectedSeries = new SvelteSet<string>();

--- a/src/routes/library/tv/[id]/+page.server.ts
+++ b/src/routes/library/tv/[id]/+page.server.ts
@@ -7,7 +7,8 @@ import {
 	rootFolders,
 	scoringProfiles,
 	downloadQueue,
-	subtitles
+	subtitles,
+	libraries
 } from '$lib/server/db/schema.js';
 import { eq, asc, inArray, and } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
@@ -152,6 +153,8 @@ export interface LibrarySeriesPageData {
 		anilist: boolean;
 		mal: boolean;
 	};
+	librarySlug: string | null;
+	libraryName: string | null;
 }
 
 export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPageData> => {
@@ -185,10 +188,15 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 			added: series.added,
 			episodeCount: series.episodeCount,
 			episodeFileCount: series.episodeFileCount,
-			episodeGroupId: series.episodeGroupId
+			episodeGroupId: series.episodeGroupId,
+			libraryId: series.libraryId,
+			librarySlug: libraries.slug,
+			libraryName: libraries.name,
+			libraryIsDefault: libraries.isDefault
 		})
 		.from(series)
 		.leftJoin(rootFolders, eq(series.rootFolderId, rootFolders.id))
+		.leftJoin(libraries, eq(series.libraryId, libraries.id))
 		.where(eq(series.id, id));
 
 	if (seriesResult.length === 0) {
@@ -414,6 +422,9 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 		return null;
 	});
 
+	const librarySlug = seriesData.libraryIsDefault ? null : (seriesData.librarySlug ?? null);
+	const libraryName = seriesData.libraryName ?? null;
+
 	return {
 		series: {
 			...seriesData,
@@ -427,6 +438,8 @@ export const load: PageServerLoad = async ({ params }): Promise<LibrarySeriesPag
 		rootFolders: folders,
 		queueItems,
 		isSearching,
-		configuredMetadataProviders
+		configuredMetadataProviders,
+		librarySlug,
+		libraryName
 	};
 };

--- a/src/routes/library/tv/[id]/+page.svelte
+++ b/src/routes/library/tv/[id]/+page.svelte
@@ -31,8 +31,7 @@
 	import { apiPostStream } from '$lib/api';
 	import type { SeriesEditData } from '$lib/components/library/SeriesEditModal.svelte';
 	import type { SearchMode } from '$lib/components/search/InteractiveSearchModal.svelte';
-	import { CheckSquare, Download, FileEdit, RefreshCw, X } from 'lucide-svelte';
-	import { formatBytes } from '$lib/utils/format.js';
+	import { CheckSquare, FileEdit, RefreshCw, X } from 'lucide-svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -1743,15 +1742,24 @@
 	/>
 </svelte:head>
 
-<div class="flex w-full flex-col gap-4 px-4 pb-20 md:gap-6 md:overflow-x-hidden md:px-6 lg:px-8">
+<div
+	class="flex w-full flex-col gap-4 px-4 pb-20 sm:pb-0 md:gap-6 md:overflow-x-hidden md:px-6 lg:px-8"
+>
 	<!-- Header -->
 	<LibrarySeriesHeader
 		series={seriesForDisplay}
 		tmdbSeries={data.tmdbDetails}
 		defaultRegion={page.data.defaultRegion}
 		configuredProviders={data.configuredMetadataProviders}
+		librarySlug={data.librarySlug}
+		libraryName={data.libraryName}
 		refreshing={isRefreshing}
 		{refreshProgress}
+		episodeCount={seriesForDisplay.episodeCount}
+		episodeFileCount={seriesForDisplay.episodeFileCount}
+		percentComplete={seriesForDisplay.percentComplete}
+		{totalSeriesSize}
+		{downloadingCount}
 		{missingEpisodeCount}
 		{searchingMissing}
 		{missingSearchProgress}
@@ -1771,29 +1779,9 @@
 	<div class="grid gap-4 lg:grid-cols-2 lg:gap-6 xl:grid-cols-3">
 		<!-- Seasons (takes 2 columns) -->
 		<div class="min-w-0 space-y-4 md:col-span-2 lg:col-span-2">
-			<div class="flex items-center justify-between">
+			<div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 				<div class="flex items-center gap-3">
 					<h2 class="text-lg font-semibold">{m.library_tvDetail_seasonsHeading()}</h2>
-					<span class="flex flex-wrap items-center gap-2 text-sm text-base-content/70">
-						<span
-							>{seriesForDisplay.episodeFileCount ?? 0} / {seriesForDisplay.episodeCount ?? 0}
-							{m.common_episodes()}</span
-						>
-						{#if seriesForDisplay.percentComplete === 100}
-							<span class="badge badge-sm badge-success">{m.library_seriesHeader_complete()}</span>
-						{:else if seriesForDisplay.percentComplete > 0}
-							<span class="badge badge-sm badge-primary">{seriesForDisplay.percentComplete}%</span>
-						{/if}
-						{#if totalSeriesSize > 0}
-							<span class="badge badge-sm badge-info">{formatBytes(totalSeriesSize)}</span>
-						{/if}
-						{#if downloadingCount > 0}
-							<span class="badge badge-sm font-semibold badge-success">
-								<Download size={14} class="animate-pulse" />
-								<span>{downloadingCount}</span>
-							</span>
-						{/if}
-					</span>
 				</div>
 				<div class="flex gap-1">
 					{#if !isStreamerProfile && syncableSubtitles.length > 0}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,5 @@
+import { resolveAppVersion } from '$lib/server/version.js';
+
+export function load() {
+	return { version: resolveAppVersion() };
+}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -4,6 +4,11 @@
 	import { authClient } from '$lib/auth/client.js';
 	import * as m from '$lib/paraglide/messages.js';
 
+	const GITHUB_URL = 'https://github.com/MoldyTaint/Cinephage';
+	const DISCORD_URL = 'https://discord.gg/scGCBTSWEt';
+
+	let { data } = $props();
+
 	let username = $state('');
 	let password = $state('');
 	let rememberMe = $state(false);
@@ -136,6 +141,48 @@
 					{/if}
 				</button>
 			</form>
+
+			<div class="mt-6 flex items-center justify-center gap-4 text-xs text-base-content/40">
+				<span>v{data.version}</span>
+				<a
+					href={DISCORD_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-1 hover:text-base-content/70 transition-colors"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path
+							d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028z"
+						/>
+						<ellipse cx="8.5" cy="12.5" rx="1.5" ry="1.65" fill="var(--discord-eye, white)" />
+						<ellipse cx="15.5" cy="12.5" rx="1.5" ry="1.65" fill="var(--discord-eye, white)" />
+					</svg>
+					Discord
+				</a>
+				<a
+					href={GITHUB_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-1 hover:text-base-content/70 transition-colors"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path
+							d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"
+						/>
+					</svg>
+					GitHub
+				</a>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/routes/settings/filters/+page.svelte
+++ b/src/routes/settings/filters/+page.svelte
@@ -19,7 +19,6 @@
 		excluded_genre_ids: []
 	});
 	let saving = $state(false);
-	let saveSuccess = $state(false);
 
 	let languages = $derived(data.languages);
 	let regions = $derived(data.countries);
@@ -34,17 +33,13 @@
 				(currentGenreId) => currentGenreId !== genreId
 			);
 		}
-		saveSuccess = false;
 	}
 
 	async function handleSave() {
 		saving = true;
-		saveSuccess = false;
 
 		try {
 			await updateTmdbFilters(filtersState);
-
-			saveSuccess = true;
 			toasts.success(m.settings_filters_updated());
 		} catch (error) {
 			toasts.error(error instanceof Error ? error.message : m.settings_filters_failedToSave());
@@ -77,7 +72,6 @@
 					type="checkbox"
 					class="checkbox checkbox-primary"
 					bind:checked={filtersState.include_adult}
-					onchange={() => (saveSuccess = false)}
 				/>
 				<span class="label-text">{m.settings_filters_includeAdult()}</span>
 			</label>
@@ -102,7 +96,6 @@
 					step="0.1"
 					bind:value={filtersState.min_vote_average}
 					class="input-bordered input w-full"
-					oninput={() => (saveSuccess = false)}
 				/>
 			</div>
 			<div class="form-control">
@@ -115,7 +108,6 @@
 					min="0"
 					bind:value={filtersState.min_vote_count}
 					class="input-bordered input w-full"
-					oninput={() => (saveSuccess = false)}
 				/>
 			</div>
 		</div>
@@ -132,7 +124,6 @@
 					id="language"
 					class="select-bordered select w-full"
 					bind:value={filtersState.language}
-					onchange={() => (saveSuccess = false)}
 				>
 					{#each languages as lang (lang.code)}
 						<option value={lang.code}>{lang.name}</option>
@@ -143,12 +134,7 @@
 				<label class="label" for="region">
 					<span class="label-text">{m.settings_filters_preferredRegion()}</span>
 				</label>
-				<select
-					id="region"
-					class="select-bordered select w-full"
-					bind:value={filtersState.region}
-					onchange={() => (saveSuccess = false)}
-				>
+				<select id="region" class="select-bordered select w-full" bind:value={filtersState.region}>
 					{#each regions as region (region.code)}
 						<option value={region.code}>{region.name}</option>
 					{/each}
@@ -186,12 +172,6 @@
 			</div>
 		{/if}
 	</SettingsSection>
-
-	{#if saveSuccess}
-		<div class="alert alert-success shadow-lg">
-			<span>{m.settings_filters_updatedSuccess()}</span>
-		</div>
-	{/if}
 
 	<div class="flex justify-end">
 		<button class="btn btn-primary" onclick={handleSave} disabled={saving}>

--- a/src/routes/settings/integrations/+layout.svelte
+++ b/src/routes/settings/integrations/+layout.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-	import { Database, Download, Server, Captions, Languages, Monitor, Archive } from 'lucide-svelte';
+	import {
+		DatabaseSearch,
+		Download,
+		Server,
+		Captions,
+		Languages,
+		Monitor,
+		Archive
+	} from 'lucide-svelte';
 	import { SettingsTabNav } from '$lib/components/settings';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -9,7 +17,7 @@
 		{
 			href: '/settings/integrations/indexers',
 			label: m.nav_indexers(),
-			icon: Database
+			icon: DatabaseSearch
 		},
 		{
 			href: '/settings/integrations/download-clients',

--- a/src/routes/settings/logs/+page.svelte
+++ b/src/routes/settings/logs/+page.svelte
@@ -590,10 +590,6 @@
 {/snippet}
 
 <SettingsPage title={m.settings_logs_heading()} subtitle={m.settings_logs_subtitle()}>
-	{#snippet actions()}
-
-	{/snippet}
-
 	<!-- Log viewer card -->
 	<div class="flex flex-col rounded-xl border border-base-300 bg-base-200">
 		<!-- Toolbar (sticky) -->

--- a/src/routes/setup/+page.server.ts
+++ b/src/routes/setup/+page.server.ts
@@ -1,0 +1,5 @@
+import { resolveAppVersion } from '$lib/server/version.js';
+
+export function load() {
+	return { version: resolveAppVersion() };
+}

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { Shield, User, Lock, CheckCircle, AlertCircle } from 'lucide-svelte';
+	import { User, Lock, CheckCircle, AlertCircle } from 'lucide-svelte';
 	import { authClient } from '$lib/auth/client.js';
 	import { toasts } from '$lib/stores/toast.svelte';
+
+	const GITHUB_URL = 'https://github.com/MoldyTaint/Cinephage';
+	const DISCORD_URL = 'https://discord.gg/scGCBTSWEt';
+
+	let { data } = $props();
 	import { createApiKeys } from '$lib/api';
 	import {
 		isHardReservedUsername,
@@ -152,12 +157,13 @@
 <div class="flex min-h-screen items-center justify-center bg-base-200 p-4">
 	<div class="card w-full max-w-lg bg-base-100 shadow-xl">
 		<div class="card-body">
+			<div class="mb-2 text-center">
+				<img src="/logo.png" alt="Cinephage" class="mx-auto h-20 w-20 rounded-2xl object-contain" />
+			</div>
+
 			{#if currentStep === 1}
 				<!-- Step 1: Welcome -->
 				<div class="space-y-4 text-center">
-					<div class="inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-						<Shield class="h-8 w-8 text-primary" />
-					</div>
 					<h1 class="text-3xl font-bold">{m.setup_welcomeTitle()}</h1>
 					<p class="text-base-content/70">{m.setup_welcomeSubtitle()}</p>
 					<div class="pt-4">
@@ -378,6 +384,48 @@
 					</div>
 				</div>
 			{/if}
+
+			<div class="mt-6 flex items-center justify-center gap-4 text-xs text-base-content/40">
+				<span>v{data.version}</span>
+				<a
+					href={DISCORD_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-1 hover:text-base-content/70 transition-colors"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path
+							d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028z"
+						/>
+						<ellipse cx="8.5" cy="12.5" rx="1.5" ry="1.65" fill="var(--discord-eye, white)" />
+						<ellipse cx="15.5" cy="12.5" rx="1.5" ry="1.65" fill="var(--discord-eye, white)" />
+					</svg>
+					Discord
+				</a>
+				<a
+					href={GITHUB_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-1 hover:text-base-content/70 transition-colors"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path
+							d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"
+						/>
+					</svg>
+					GitHub
+				</a>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Redesigned movie and TV series detail headers with improved layout, metadata, and mobile UX. Enriched the discover media hero with a clips/backdrops carousel, correct library state display, mobile overview expand, release status, and Where to Watch. Added project Discord/Github links to login/setup/footer. Improved dashboard stat cards with inline expand, storage icons, and corrected Quick Actions links. Fixed several type errors and Svelte 5 rune warnings.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Redesigned `LibraryMovieHeader` and `LibraryTVHeader` with improved layout, mobile sticky action bar, and contextual back navigation
- Enriched `MediaHero` with clips/backdrops carousel, library state badges (Downloaded/Missing/Unmonitored), mobile read more/less, release status, and Where to Watch section
- Added logo, version, and Discord/GitHub links to login, setup, and footer menu
- Fixed keyword blocklist to filter dashboard sections and take effect immediately
- Fixed theatrical-only catalog titles resolving as "In Theaters" indefinitely; 3-year fallback now shows "Released"
- Improved `DashboardStatsGrid` with truncation detection, inline expand chevrons, and storage icons replacing text labels
- Fixed `QuickActions` Search Missing link to point to `/settings/tasks`
- Persisted discover debug filter toggle state in localStorage
- Resolved `smartRelease.text` type error in `LibraryMovieHeader` and `MediaHero`
- Fixed Svelte 5 `$state` rune warnings in `GroupEditorPanel` using `untrack()`
- Removed empty `{#snippet actions()}` block in logs settings page

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->

N/A
