### PR TITLE
feat: add {OriginalTitle} and {OriginalCleanTitle} naming tokens

### DIFF
--- a/src/lib/server/library/naming/NamingService.ts
+++ b/src/lib/server/library/naming/NamingService.ts
@@ -18,6 +18,7 @@ import { TemplateEngine } from './template';
 export interface MediaNamingInfo {
 	// Core info
 	title: string;
+	originalTitle?: string;
 	year?: number;
 	tmdbId?: number;
 	tvdbId?: number;

--- a/src/lib/server/library/naming/RenamePreviewService.test.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.test.ts
@@ -1211,7 +1211,7 @@ describe('RenamePreviewService', () => {
 				};
 
 				const result = service.generateMovieFileName(info);
-				expect(result).toContain('Batman: The Dark Knight');
+				expect(result).toContain('Batman - The Dark Knight');
 				expect(result).toContain('2008');
 				expect(result).toContain('Bluray-1080p');
 				expect(result).toContain('-GROUP');
@@ -1220,8 +1220,7 @@ describe('RenamePreviewService', () => {
 			it('renders {OriginalCleanTitle} in movie file format', () => {
 				const service = new NamingService({
 					...DEFAULT_NAMING_CONFIG,
-					movieFileFormat:
-						'{OriginalCleanTitle} ({Year}) [{QualityFull}]{-{ReleaseGroup}}'
+					movieFileFormat: '{OriginalCleanTitle} ({Year}) [{QualityFull}]{-{ReleaseGroup}}'
 				});
 
 				const info: MediaNamingInfo = {
@@ -1509,5 +1508,4 @@ describe('RenamePreviewService', () => {
 			});
 		});
 	});
-
 });

--- a/src/lib/server/library/naming/RenamePreviewService.test.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.test.ts
@@ -1160,4 +1160,354 @@ describe('RenamePreviewService', () => {
 			expect(folder).toContain('{tmdb-12345}');
 		});
 	});
+
+	describe('OriginalTitle Token — NamingService integration (WP-2)', () => {
+		/**
+		 * These tests verify that when originalTitle is present in MediaNamingInfo,
+		 * the {OriginalTitle} and {OriginalCleanTitle} tokens render correctly
+		 * in movie and series naming formats.
+		 *
+		 * This is the code path exercised by buildMoviePreviewItem()
+		 * and buildEpisodePreviewItem() in RenamePreviewService.
+		 * These tests will FAIL until the originalTitle wiring is added.
+		 */
+
+		describe('Movie naming with originalTitle', () => {
+			it('renders {OriginalTitle} in movie folder format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFolderFormat: '{OriginalTitle} ({Year}) {MediaId}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'English Title',
+					originalTitle: 'Crouching Tiger, Hidden Dragon',
+					year: 2000,
+					tmdbId: 146
+				};
+
+				const result = service.generateMovieFolderName(info);
+				expect(result).toContain('Crouching Tiger, Hidden Dragon');
+				expect(result).toContain('2000');
+				expect(result).not.toContain('English Title');
+			});
+
+			it('renders {OriginalTitle} in movie file format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFileFormat: '{OriginalTitle} ({Year}) [{QualityFull}]{-{ReleaseGroup}}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'The Dark Knight',
+					originalTitle: 'Batman: The Dark Knight',
+					year: 2008,
+					tmdbId: 155,
+					resolution: '1080p',
+					source: 'Bluray',
+					codec: 'x264',
+					releaseGroup: 'GROUP',
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateMovieFileName(info);
+				expect(result).toContain('Batman: The Dark Knight');
+				expect(result).toContain('2008');
+				expect(result).toContain('Bluray-1080p');
+				expect(result).toContain('-GROUP');
+			});
+
+			it('renders {OriginalCleanTitle} in movie file format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFileFormat:
+						'{OriginalCleanTitle} ({Year}) [{QualityFull}]{-{ReleaseGroup}}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Star Wars: A New Hope (Fallback)',
+					originalTitle: 'Star Wars',
+					year: 1977,
+					tmdbId: 11,
+					resolution: '2160p',
+					source: 'Remux',
+					codec: 'x265',
+					hdr: 'DV',
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateMovieFileName(info);
+				expect(result).toContain('Star Wars');
+				expect(result).toContain('1977');
+				expect(result).toContain('Remux-2160p');
+				expect(result).not.toContain('Fallback');
+			});
+
+			it('renders {OriginalCleanTitle} with special chars stripped but colons preserved', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFileFormat: '{OriginalCleanTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Fallback Title!',
+					originalTitle: 'Film "Name" <Test> |Bad?',
+					year: 2020,
+					tmdbId: 99999,
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateMovieFileName(info);
+				// Special chars like " < > | ? are removed by clean title
+				expect(result).toContain('Film Name Test Bad');
+				expect(result).not.toContain('"');
+				expect(result).not.toContain('<');
+				expect(result).not.toContain('>');
+				expect(result).not.toContain('|');
+				expect(result).not.toContain('?');
+			});
+
+			it('falls back to title when originalTitle is undefined', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFolderFormat: '{OriginalTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Only Title Available',
+					year: 2023,
+					tmdbId: 12345
+					// originalTitle intentionally omitted
+				};
+
+				const result = service.generateMovieFolderName(info);
+				expect(result).toContain('Only Title Available');
+				expect(result).toContain('2023');
+			});
+
+			it('falls back to title when originalTitle is explicitly undefined', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFolderFormat: '{OriginalCleanTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Normal Title',
+					originalTitle: undefined,
+					year: 2023,
+					tmdbId: 12345
+				};
+
+				const result = service.generateMovieFolderName(info);
+				expect(result).toContain('Normal Title');
+			});
+		});
+
+		describe('Series naming with originalTitle', () => {
+			it('renders {OriginalTitle} in series folder format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					seriesFolderFormat: '{OriginalTitle} ({Year}) {SeriesId}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Attack on Titan',
+					originalTitle: 'Shingeki no Kyojin',
+					year: 2013,
+					tvdbId: 267440,
+					tmdbId: 1429
+				};
+
+				const result = service.generateSeriesFolderName(info);
+				expect(result).toContain('Shingeki no Kyojin');
+				expect(result).toContain('2013');
+				expect(result).not.toContain('Attack on Titan');
+			});
+
+			it('renders {OriginalTitle} in episode file format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					episodeFileFormat:
+						'{OriginalTitle} ({Year}) - S{Season:00}E{Episode:00} - {EpisodeCleanTitle} [{QualityFull}]'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Demon Slayer',
+					originalTitle: 'Kimetsu no Yaiba',
+					year: 2019,
+					tvdbId: 348225,
+					seasonNumber: 1,
+					episodeNumbers: [1],
+					episodeTitle: 'Cruelty',
+					resolution: '1080p',
+					source: 'Bluray',
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateEpisodeFileName(info);
+				expect(result).toContain('Kimetsu no Yaiba');
+				expect(result).toContain('S01E01');
+				expect(result).toContain('Cruelty');
+				expect(result).toContain('Bluray-1080p');
+				expect(result).not.toContain('Demon Slayer');
+			});
+
+			it('renders {OriginalCleanTitle} in episode file format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					episodeFileFormat:
+						'{OriginalCleanTitle} ({Year}) - S{Season:00}E{Episode:00} - {EpisodeCleanTitle}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Fullmetal Alchemist: Brotherhood',
+					originalTitle: 'Hagane no Renkinjutsushi: Fullmetal Alchemist',
+					year: 2009,
+					tvdbId: 102261,
+					seasonNumber: 1,
+					episodeNumbers: [1],
+					episodeTitle: 'Fullmetal Alchemist',
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateEpisodeFileName(info);
+				expect(result).toContain('Hagane no Renkinjutsushi');
+				expect(result).toContain('Fullmetal Alchemist');
+				expect(result).toContain('S01E01');
+			});
+
+			it('renders {OriginalCleanTitle} in series folder format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					seriesFolderFormat: '{OriginalCleanTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Cowboy Bebop!',
+					originalTitle: 'Cowboy Bebop (Kauboi Bibappu)',
+					year: 1998,
+					tvdbId: 76885,
+					tmdbId: 1
+				};
+
+				const result = service.generateSeriesFolderName(info);
+				// CleanTitle preserves parens content, strips trailing '!'
+				expect(result).toContain('Cowboy Bebop');
+				expect(result).toContain('Kauboi Bibappu');
+				expect(result).not.toContain('!');
+			});
+
+			it('falls back to title in series when originalTitle is undefined', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					seriesFolderFormat: '{OriginalTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Breaking Bad',
+					year: 2008,
+					tvdbId: 81189,
+					tmdbId: 1396
+					// originalTitle intentionally omitted
+				};
+
+				const result = service.generateSeriesFolderName(info);
+				expect(result).toContain('Breaking Bad');
+				expect(result).toContain('2008');
+			});
+
+			it('falls back to title in episode when originalTitle is undefined', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					episodeFileFormat:
+						'{OriginalTitle} ({Year}) - S{Season:00}E{Episode:00} - {EpisodeCleanTitle}'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Game of Thrones',
+					year: 2011,
+					tvdbId: 121361,
+					seasonNumber: 1,
+					episodeNumbers: [1],
+					episodeTitle: 'Winter Is Coming',
+					originalExtension: '.mkv'
+					// originalTitle intentionally omitted
+				};
+
+				const result = service.generateEpisodeFileName(info);
+				expect(result).toContain('Game of Thrones');
+				expect(result).toContain('S01E01');
+				expect(result).toContain('Winter Is Coming');
+			});
+
+			it('renders {OriginalTitle} in anime episode format', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					animeEpisodeFormat:
+						'{OriginalTitle} ({Year}) - S{Season:00}E{Episode:00} - {Absolute:000} - {EpisodeCleanTitle} [{QualityFull}]'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'One Punch Man',
+					originalTitle: 'One Punch Man',
+					year: 2015,
+					tvdbId: 289906,
+					seasonNumber: 1,
+					episodeNumbers: [1],
+					absoluteNumber: 1,
+					episodeTitle: 'The Strongest Man',
+					isAnime: true,
+					resolution: '1080p',
+					source: 'Bluray',
+					bitDepth: '10',
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateEpisodeFileName(info);
+				expect(result).toContain('One Punch Man');
+				expect(result).toContain('S01E01');
+				expect(result).toContain('001');
+			});
+		});
+
+		describe('Alias tokens render correctly', () => {
+			it('MovieOriginalTitle alias works in movie formats', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					movieFileFormat: '{MovieOriginalTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'Parasite',
+					originalTitle: 'Gisaengchung',
+					year: 2019,
+					tmdbId: 496243,
+					originalExtension: '.mkv'
+				};
+
+				const result = service.generateMovieFileName(info);
+				expect(result).toContain('Gisaengchung');
+				expect(result).not.toContain('Parasite');
+			});
+
+			it('SeriesOriginalTitle alias works in series formats', () => {
+				const service = new NamingService({
+					...DEFAULT_NAMING_CONFIG,
+					seriesFolderFormat: '{SeriesOriginalTitle} ({Year})'
+				});
+
+				const info: MediaNamingInfo = {
+					title: 'My Hero Academia',
+					originalTitle: 'Boku no Hero Academia',
+					year: 2016,
+					tvdbId: 305074,
+					tmdbId: 65930
+				};
+
+				const result = service.generateSeriesFolderName(info);
+				expect(result).toContain('Boku no Hero Academia');
+			});
+		});
+	});
+
 });

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -964,6 +964,7 @@ export class RenamePreviewService {
 			// really there, so renamed files will reflect the true audio format.
 			const namingInfo: MediaNamingInfo = {
 				title: movie.title,
+				originalTitle: movie.originalTitle ?? undefined,
 				year: movie.year ?? undefined,
 				tmdbId: movie.tmdbId,
 				imdbId: movie.imdbId ?? undefined,
@@ -1093,6 +1094,7 @@ export class RenamePreviewService {
 			// really there, so renamed files will reflect the true audio format.
 			const namingInfo: MediaNamingInfo = {
 				title: show.title,
+				originalTitle: show.originalTitle ?? undefined,
 				year: show.year ?? undefined,
 				tvdbId: show.tvdbId ?? undefined,
 				tmdbId: show.tmdbId,

--- a/src/lib/server/library/naming/naming-helpers.test.ts
+++ b/src/lib/server/library/naming/naming-helpers.test.ts
@@ -1,0 +1,154 @@
+/**
+ * naming-helpers Tests
+ *
+ * Tests for buildMovieFolderName helper, including originalTitle support (WP-2).
+ * These tests will FAIL until the originalTitle wiring change is made.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { createTestDb, destroyTestDb } from '../../../../test/db-helper';
+import { namingSettingsService } from './NamingSettingsService';
+import { namingSettings } from '$lib/server/db/schema';
+
+const testDb = createTestDb();
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb.db;
+	},
+	get sqlite() {
+		return testDb.sqlite;
+	},
+	initializeDatabase: vi.fn().mockResolvedValue(undefined)
+}));
+
+// Dynamic import after mock so the DB resolves to the test DB
+const { buildMovieFolderName } = await import('./naming-helpers');
+
+describe('buildMovieFolderName', () => {
+	beforeEach(() => {
+		// Clear naming settings between tests (not in core table list)
+		testDb.db.delete(namingSettings).run();
+		namingSettingsService.invalidateCache();
+	});
+
+	afterAll(() => {
+		destroyTestDb(testDb);
+	});
+
+	describe('originalTitle parameter (WP-2)', () => {
+		it('passes originalTitle through to the naming engine when format uses {OriginalTitle}', async () => {
+			await namingSettingsService.updateConfig({
+				movieFolderFormat: '{OriginalTitle} ({Year})'
+			});
+			namingSettingsService.invalidateCache();
+
+			const result = buildMovieFolderName(
+				'English Title',
+				2024,
+				12345,
+				undefined,
+				undefined,
+				'Crouching Tiger, Hidden Dragon'
+			);
+
+			// Should contain the original title, not the English title
+			expect(result).toContain('Crouching Tiger, Hidden Dragon');
+			expect(result).toContain('2024');
+			expect(result).not.toContain('English Title');
+		});
+
+		it('passes originalTitle through when format uses {OriginalCleanTitle}', async () => {
+			await namingSettingsService.updateConfig({
+				movieFolderFormat: '{OriginalCleanTitle} ({Year})'
+			});
+			namingSettingsService.invalidateCache();
+
+			const result = buildMovieFolderName(
+				'English Title',
+				2024,
+				12345,
+				undefined,
+				undefined,
+				'Spirited Away (Sen to Chihiro no Kamikakushi)'
+			);
+
+			// {OriginalCleanTitle} strips filesystem-unsafe chars but preserves most content
+			expect(result).toContain('Spirited Away');
+			expect(result).toContain('Sen to Chihiro no Kamikakushi');
+			expect(result).toContain('2024');
+		});
+
+		it('falls back to title when originalTitle is null', async () => {
+			await namingSettingsService.updateConfig({
+				movieFolderFormat: '{OriginalTitle} ({Year})'
+			});
+			namingSettingsService.invalidateCache();
+
+			const result = buildMovieFolderName(
+				'English Title',
+				2024,
+				12345,
+				undefined,
+				undefined,
+				null
+			);
+
+			// Should fall back to the English title
+			expect(result).toContain('English Title');
+			expect(result).toContain('2024');
+		});
+
+		it('falls back to title when originalTitle is undefined (not passed)', async () => {
+			await namingSettingsService.updateConfig({
+				movieFolderFormat: '{OriginalTitle} ({Year})'
+			});
+			namingSettingsService.invalidateCache();
+
+			// Call WITHOUT the originalTitle parameter at all
+			const result = buildMovieFolderName('English Title', 2024, 12345);
+
+			// Should fall back to the English title
+			expect(result).toContain('English Title');
+			expect(result).toContain('2024');
+		});
+
+		it('default format uses English title even when originalTitle differs', async () => {
+			// Default format uses {CleanTitle}, not {OriginalTitle}
+			// Even if originalTitle is passed, the default format renders the English title
+			namingSettingsService.invalidateCache();
+
+			const result = buildMovieFolderName(
+				'Star Wars',
+				1977,
+				11,
+				undefined,
+				undefined,
+				'Star Wars: Episode IV - A New Hope'
+			);
+
+			// Default format uses {CleanTitle} — should render the first param (English title)
+			expect(result).toContain('Star Wars');
+			expect(result).toContain('1977');
+		});
+
+		it('handles Japanese originalTitle with {OriginalCleanTitle}', async () => {
+			await namingSettingsService.updateConfig({
+				movieFolderFormat: '{OriginalCleanTitle} ({Year})'
+			});
+			namingSettingsService.invalidateCache();
+
+			const result = buildMovieFolderName(
+				'Spirited Away',
+				2001,
+				129,
+				undefined,
+				undefined,
+				'Sen to Chihiro no Kamikakushi'
+			);
+
+			expect(result).toContain('Sen to Chihiro no Kamikakushi');
+			expect(result).toContain('2001');
+		});
+	});
+});

--- a/src/lib/server/library/naming/naming-helpers.test.ts
+++ b/src/lib/server/library/naming/naming-helpers.test.ts
@@ -85,14 +85,7 @@ describe('buildMovieFolderName', () => {
 			});
 			namingSettingsService.invalidateCache();
 
-			const result = buildMovieFolderName(
-				'English Title',
-				2024,
-				12345,
-				undefined,
-				undefined,
-				null
-			);
+			const result = buildMovieFolderName('English Title', 2024, 12345, undefined, undefined, null);
 
 			// Should fall back to the English title
 			expect(result).toContain('English Title');

--- a/src/lib/server/library/naming/naming-helpers.ts
+++ b/src/lib/server/library/naming/naming-helpers.ts
@@ -6,7 +6,8 @@ export function buildMovieFolderName(
 	year?: number,
 	tmdbId?: number,
 	collectionName?: string,
-	localizedTitles?: Record<string, string>
+	localizedTitles?: Record<string, string>,
+	originalTitle?: string | null
 ): string {
 	const config = namingSettingsService.getConfigSync();
 	const service = new NamingService(config);
@@ -15,6 +16,7 @@ export function buildMovieFolderName(
 		year,
 		tmdbId,
 		collectionName,
-		localizedTitles
+		localizedTitles,
+		originalTitle: originalTitle ?? undefined
 	});
 }

--- a/src/lib/server/library/naming/token-reference.ts
+++ b/src/lib/server/library/naming/token-reference.ts
@@ -34,6 +34,8 @@ export function buildTokensResponse() {
 			{ token: '{SeriesTitle}', description: 'Series title as-is' },
 			{ token: '{SeriesCleanTitle}', description: 'Series title with special chars removed' },
 			{ token: '{Year}', description: 'First air year' },
+			{ token: '{SeriesOriginalTitle}', description: 'Original series title as-is' },
+			{ token: '{SeriesOriginalCleanTitle}', description: 'Original series title with special chars removed' },
 			...metadata.mediaId
 				.filter((t) => t.name === 'TvdbId' || t.name === 'TmdbId' || t.name === 'SeriesId')
 				.map(formatTokenForApi)

--- a/src/lib/server/library/naming/token-reference.ts
+++ b/src/lib/server/library/naming/token-reference.ts
@@ -35,7 +35,10 @@ export function buildTokensResponse() {
 			{ token: '{SeriesCleanTitle}', description: 'Series title with special chars removed' },
 			{ token: '{Year}', description: 'First air year' },
 			{ token: '{SeriesOriginalTitle}', description: 'Original series title as-is' },
-			{ token: '{SeriesOriginalCleanTitle}', description: 'Original series title with special chars removed' },
+			{
+				token: '{SeriesOriginalCleanTitle}',
+				description: 'Original series title with special chars removed'
+			},
 			...metadata.mediaId
 				.filter((t) => t.name === 'TvdbId' || t.name === 'TmdbId' || t.name === 'SeriesId')
 				.map(formatTokenForApi)

--- a/src/lib/server/library/naming/tokens/definitions/core.test.ts
+++ b/src/lib/server/library/naming/tokens/definitions/core.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { coreTokens } from './core';
+
+describe('OriginalTitle token', () => {
+	const originalTitleToken = coreTokens.find((t) => t.name === 'OriginalTitle')!;
+	const originalCleanTitleToken = coreTokens.find((t) => t.name === 'OriginalCleanTitle')!;
+
+	describe('{OriginalTitle}', () => {
+		it('renders info.originalTitle when present', () => {
+			expect(
+				originalTitleToken.render(
+					{ title: 'English Title', originalTitle: 'Original Name' },
+					{} as any
+				)
+			).toBe('Original Name');
+		});
+
+		it('falls back to info.title when originalTitle is undefined', () => {
+			expect(
+				originalTitleToken.render(
+					{ title: 'English Title' },
+					{} as any
+				)
+			).toBe('English Title');
+		});
+
+		it('returns empty string when both title and originalTitle are empty/undefined', () => {
+			expect(
+				originalTitleToken.render({ title: '' }, {} as any)
+			).toBe('');
+
+			// When title is explicitly undefined (unlikely but handled)
+			expect(
+				originalTitleToken.render({ title: undefined as any }, {} as any)
+			).toBe('');
+		});
+
+		it('does NOT support locale format spec', () => {
+			expect(originalTitleToken.supportsFormatSpec).toBeFalsy();
+		});
+
+		it('ignores format spec argument even if passed', () => {
+			expect(
+				originalTitleToken.render(
+					{ title: 'Title', originalTitle: 'Original' },
+					{} as any,
+					'ES'
+				)
+			).toBe('Original');
+		});
+
+		it('has correct metadata', () => {
+			expect(originalTitleToken.name).toBe('OriginalTitle');
+			expect(originalTitleToken.aliases).toEqual([
+				'SeriesOriginalTitle',
+				'MovieOriginalTitle'
+			]);
+			expect(originalTitleToken.category).toBe('core');
+			expect(originalTitleToken.applicability).toEqual(['movie', 'series']);
+		});
+
+		it('is NOT applicable to episodes (TMDB has no original_name for episodes)', () => {
+			expect(originalTitleToken.applicability).not.toContain('episode');
+		});
+	});
+
+	describe('{OriginalCleanTitle}', () => {
+		it('renders cleaned info.originalTitle when present — removes special chars but preserves colons', () => {
+			expect(
+				originalCleanTitleToken.render(
+					{ title: 'Fallback', originalTitle: 'The Movie!' },
+					{} as any
+				)
+			).toBe('The Movie');
+
+			// Colons are preserved (handled downstream by colonReplacement)
+			expect(
+				originalCleanTitleToken.render(
+					{ title: 'Fallback', originalTitle: 'Star Wars: A New Hope' },
+					{} as any
+				)
+			).toBe('Star Wars: A New Hope');
+
+			// Multiple special characters removed
+			expect(
+				originalCleanTitleToken.render(
+					{ title: 'Fallback', originalTitle: 'Film "Name" <Test> |Bad?' },
+					{} as any
+				)
+			).toBe('Film Name Test Bad');
+		});
+
+		it('falls back to cleaned info.title when originalTitle is undefined', () => {
+			expect(
+				originalCleanTitleToken.render(
+					{ title: 'The Movie!' },
+					{} as any
+				)
+			).toBe('The Movie');
+		});
+
+		it('returns empty string when both title and originalTitle are empty/undefined', () => {
+			expect(
+				originalCleanTitleToken.render({ title: '' }, {} as any)
+			).toBe('');
+
+			expect(
+				originalCleanTitleToken.render({ title: undefined as any }, {} as any)
+			).toBe('');
+		});
+
+		it('handles title with only special characters correctly', () => {
+			expect(
+				originalCleanTitleToken.render(
+					{ title: 'Fallback', originalTitle: '!@#$%' },
+					{} as any
+				)
+			).toBe('@#$%');
+		});
+
+		it('does NOT support locale format spec', () => {
+			expect(originalCleanTitleToken.supportsFormatSpec).toBeFalsy();
+		});
+
+		it('has correct metadata', () => {
+			expect(originalCleanTitleToken.name).toBe('OriginalCleanTitle');
+			expect(originalCleanTitleToken.aliases).toEqual([
+				'SeriesOriginalCleanTitle',
+				'MovieOriginalCleanTitle'
+			]);
+			expect(originalCleanTitleToken.category).toBe('core');
+			expect(originalCleanTitleToken.applicability).toEqual(['movie', 'series']);
+		});
+
+		it('is NOT applicable to episodes', () => {
+			expect(originalCleanTitleToken.applicability).not.toContain('episode');
+		});
+	});
+
+	describe('Existing core tokens remain intact', () => {
+		it('Title token still exists', () => {
+			const titleToken = coreTokens.find((t) => t.name === 'Title');
+			expect(titleToken).toBeDefined();
+		});
+
+		it('CleanTitle token still exists', () => {
+			const cleanToken = coreTokens.find((t) => t.name === 'CleanTitle');
+			expect(cleanToken).toBeDefined();
+		});
+
+		it('Year token still exists', () => {
+			const yearToken = coreTokens.find((t) => t.name === 'Year');
+			expect(yearToken).toBeDefined();
+		});
+	});
+});

--- a/src/lib/server/library/naming/tokens/definitions/core.test.ts
+++ b/src/lib/server/library/naming/tokens/definitions/core.test.ts
@@ -16,23 +16,16 @@ describe('OriginalTitle token', () => {
 		});
 
 		it('falls back to info.title when originalTitle is undefined', () => {
-			expect(
-				originalTitleToken.render(
-					{ title: 'English Title' },
-					{} as any
-				)
-			).toBe('English Title');
+			expect(originalTitleToken.render({ title: 'English Title' }, {} as any)).toBe(
+				'English Title'
+			);
 		});
 
 		it('returns empty string when both title and originalTitle are empty/undefined', () => {
-			expect(
-				originalTitleToken.render({ title: '' }, {} as any)
-			).toBe('');
+			expect(originalTitleToken.render({ title: '' }, {} as any)).toBe('');
 
 			// When title is explicitly undefined (unlikely but handled)
-			expect(
-				originalTitleToken.render({ title: undefined as any }, {} as any)
-			).toBe('');
+			expect(originalTitleToken.render({ title: undefined as any }, {} as any)).toBe('');
 		});
 
 		it('does NOT support locale format spec', () => {
@@ -41,20 +34,13 @@ describe('OriginalTitle token', () => {
 
 		it('ignores format spec argument even if passed', () => {
 			expect(
-				originalTitleToken.render(
-					{ title: 'Title', originalTitle: 'Original' },
-					{} as any,
-					'ES'
-				)
+				originalTitleToken.render({ title: 'Title', originalTitle: 'Original' }, {} as any, 'ES')
 			).toBe('Original');
 		});
 
 		it('has correct metadata', () => {
 			expect(originalTitleToken.name).toBe('OriginalTitle');
-			expect(originalTitleToken.aliases).toEqual([
-				'SeriesOriginalTitle',
-				'MovieOriginalTitle'
-			]);
+			expect(originalTitleToken.aliases).toEqual(['SeriesOriginalTitle', 'MovieOriginalTitle']);
 			expect(originalTitleToken.category).toBe('core');
 			expect(originalTitleToken.applicability).toEqual(['movie', 'series']);
 		});
@@ -68,7 +54,7 @@ describe('OriginalTitle token', () => {
 		it('renders cleaned info.originalTitle when present — removes special chars but preserves colons', () => {
 			expect(
 				originalCleanTitleToken.render(
-					{ title: 'Fallback', originalTitle: 'The Movie!' },
+					{ title: 'Fallback', originalTitle: 'The Movie?' },
 					{} as any
 				)
 			).toBe('The Movie');
@@ -91,30 +77,18 @@ describe('OriginalTitle token', () => {
 		});
 
 		it('falls back to cleaned info.title when originalTitle is undefined', () => {
-			expect(
-				originalCleanTitleToken.render(
-					{ title: 'The Movie!' },
-					{} as any
-				)
-			).toBe('The Movie');
+			expect(originalCleanTitleToken.render({ title: 'The Movie?' }, {} as any)).toBe('The Movie');
 		});
 
 		it('returns empty string when both title and originalTitle are empty/undefined', () => {
-			expect(
-				originalCleanTitleToken.render({ title: '' }, {} as any)
-			).toBe('');
+			expect(originalCleanTitleToken.render({ title: '' }, {} as any)).toBe('');
 
-			expect(
-				originalCleanTitleToken.render({ title: undefined as any }, {} as any)
-			).toBe('');
+			expect(originalCleanTitleToken.render({ title: undefined as any }, {} as any)).toBe('');
 		});
 
 		it('handles title with only special characters correctly', () => {
 			expect(
-				originalCleanTitleToken.render(
-					{ title: 'Fallback', originalTitle: '!@#$%' },
-					{} as any
-				)
+				originalCleanTitleToken.render({ title: 'Fallback', originalTitle: '?@#$%' }, {} as any)
 			).toBe('@#$%');
 		});
 

--- a/src/lib/server/library/naming/tokens/definitions/core.ts
+++ b/src/lib/server/library/naming/tokens/definitions/core.ts
@@ -13,7 +13,7 @@ import type { TokenDefinition } from '../types';
  */
 function generateCleanTitle(title: string): string {
 	return title
-		.replace(/[/\\?*"<>|]/g, '')
+		.replace(/[/\\?*"<>|!]/g, '')
 		.replace(/\s+/g, ' ')
 		.trim();
 }
@@ -51,6 +51,29 @@ export const coreTokens: TokenDefinition[] = [
 				formatSpec && isLanguageCode(formatSpec)
 					? info.localizedTitles?.[formatSpec.toLowerCase()] || info.title
 					: info.title;
+			return title ? generateCleanTitle(title) : '';
+		}
+	},
+	{
+		name: 'OriginalTitle',
+		aliases: ['SeriesOriginalTitle', 'MovieOriginalTitle'],
+		category: 'core',
+		description: 'Original title as-is',
+		applicability: ['movie', 'series'],
+		supportsFormatSpec: false,
+		render: (info) => {
+			return info.originalTitle || info.title || '';
+		}
+	},
+	{
+		name: 'OriginalCleanTitle',
+		aliases: ['SeriesOriginalCleanTitle', 'MovieOriginalCleanTitle'],
+		category: 'core',
+		description: 'Original title with special characters removed',
+		applicability: ['movie', 'series'],
+		supportsFormatSpec: false,
+		render: (info) => {
+			const title = info.originalTitle || info.title || '';
 			return title ? generateCleanTitle(title) : '';
 		}
 	},

--- a/src/lib/server/library/naming/tokens/definitions/core.ts
+++ b/src/lib/server/library/naming/tokens/definitions/core.ts
@@ -13,7 +13,7 @@ import type { TokenDefinition } from '../types';
  */
 function generateCleanTitle(title: string): string {
 	return title
-		.replace(/[/\\?*"<>|!]/g, '')
+		.replace(/[/\\?*"<>|]/g, '')
 		.replace(/\s+/g, ' ')
 		.trim();
 }


### PR DESCRIPTION
## Summary
Add two new naming tokens for movies and series that use TMDB's original-language title instead of the localized English title.

### New tokens
- **`{OriginalTitle}`** — original title as-is (fallback: `title` → `''`)
- **`{OriginalCleanTitle}`** — original title with filesystem-unsafe characters removed

### Changes (8 files, +693/-3)
| File | Change |
|---|---|
| `NamingService.ts` | Added `originalTitle?: string` to `MediaNamingInfo` interface |
| `core.ts` | Added `OriginalTitle` + `OriginalCleanTitle` token definitions |
| `RenamePreviewService.ts` | Wired `originalTitle` from movie/show DB records |
| `naming-helpers.ts` | Added `originalTitle` parameter to `buildMovieFolderName()` |
| `token-reference.ts` | Added tokens to series tab in token picker UI |
| `core.test.ts` ✨ | 17 unit tests |
| `naming-helpers.test.ts` ✨ | 6 integration tests |
| `RenamePreviewService.test.ts` | +15 naming integration tests |

### Design decisions
- Applicability: `['movie', 'series']` — **not** episode (TMDB doesn't expose `original_name` for episodes)
- Fallback chain: `originalTitle → title → ''`
- No locale format spec support (`supportsFormatSpec: false`)

### Test results
```
3 test files | 90 tests passed | 0 failures
```