### PR TITLE
fix(captcha,import,indexers): improve CF bypass reliability, wire preferHardlink in manual importer, update BitSearch domain

### DIFF
--- a/data/indexers/definitions/bitsearch.yaml
+++ b/data/indexers/definitions/bitsearch.yaml
@@ -9,9 +9,10 @@ type: public
 encoding: UTF-8
 requestdelay: 2
 links:
-  - https://bitsearch.to/
+  - https://bitsearch.eu/
   - https://solidtorrents.eu/
 legacylinks:
+  - https://bitsearch.to/
   - https://bitsearch.nocensor.cloud/
   - https://bitsearch.mrunblock.bond/
   - https://solidtorrents.net/

--- a/src/lib/server/captcha/browser/CamoufoxSolver.ts
+++ b/src/lib/server/captcha/browser/CamoufoxSolver.ts
@@ -23,7 +23,20 @@ import { detectChallengeFromPage } from '../detection/ChallengeDetector';
  * Challenge title patterns that indicate an ongoing challenge.
  * Used to detect when challenge is still active vs completed.
  */
-const CHALLENGE_TITLE_PATTERNS = ['Just a moment', 'Checking', 'Please wait', 'DDoS-Guard'];
+const CHALLENGE_TITLE_PATTERNS = [
+	'Just a moment',
+	'Checking',
+	'Please wait',
+	'DDoS-Guard',
+	// Cloudflare challenge titles in other languages
+	'Un instant', // French
+	'Einen Moment', // German
+	'Un momento', // Spanish/Italian
+	'Aguarde', // Portuguese
+	'しばらくお待ち', // Japanese
+	'잠시만', // Korean
+	'请稍候' // Chinese
+];
 
 /**
  * Wait for Cloudflare challenge to complete.
@@ -49,6 +62,27 @@ async function waitForChallengeComplete(page: Page, timeout = 30000): Promise<bo
 				// Wait a bit for page to load after cookie is set
 				await new Promise((r) => setTimeout(r, 1000));
 				return true;
+			}
+
+			// Turnstile: try clicking the checkbox inside the CF challenge iframe.
+			// Camoufox's humanize handles mouse movements but doesn't target Turnstile
+			// specifically — clicking the checkbox widget is needed for managed challenges.
+			try {
+				const frame = page
+					.frames()
+					.find(
+						(f) => f.url().includes('challenges.cloudflare.com') || f.url().includes('turnstile')
+					);
+				if (frame) {
+					const checkbox = frame.locator('input[type="checkbox"]');
+					const isVisible = await checkbox.isVisible({ timeout: 200 }).catch(() => false);
+					if (isVisible) {
+						logger.debug('[CamoufoxSolver] Clicking Turnstile checkbox');
+						await checkbox.click({ timeout: 2000 }).catch(() => null);
+					}
+				}
+			} catch {
+				// Turnstile not present or not interactable — continue waiting
 			}
 		} catch {
 			// Navigation can destroy execution context - this is expected during challenge completion
@@ -338,7 +372,21 @@ export async function browserFetch(
 		// Always wait for challenge completion - Cloudflare challenges may auto-solve
 		// via Camoufox's humanize feature without explicit detection
 		logger.debug('[CamoufoxSolver] Waiting for any challenge to complete');
-		await waitForChallengeComplete(page, timeout - (Date.now() - startTime));
+		const solved = await waitForChallengeComplete(page, timeout - (Date.now() - startTime));
+
+		if (!solved) {
+			return {
+				success: false,
+				body: '',
+				url: request.url,
+				status: 0,
+				headers: {},
+				cookies: [],
+				userAgent: '',
+				error: `Cloudflare bypass failed for ${new URL(request.url).hostname}: challenge not solved within timeout`,
+				timeMs: Date.now() - startTime
+			};
+		}
 
 		// Get the page content
 		const body = await page.content();

--- a/src/lib/server/downloadClients/import/FileTransfer.ts
+++ b/src/lib/server/downloadClients/import/FileTransfer.ts
@@ -248,12 +248,12 @@ export async function transferFile(
 					);
 				}
 			} else {
-				logger.debug(
+				logger.info(
 					{
-						source,
-						dest
+						source: basename(source),
+						dest: basename(dest)
 					},
-					'Source and dest on different filesystems, using copy'
+					'Hardlink not possible (source and destination on different filesystems), falling back to copy'
 				);
 			}
 		}

--- a/src/lib/server/library/manual-import-service.ts
+++ b/src/lib/server/library/manual-import-service.ts
@@ -1323,7 +1323,8 @@ export class ManualImportService {
 		const transferResult = await transferFileWithMode(sourcePath, destinationPath, {
 			importMode,
 			canMoveFiles,
-			preserveSymlinks
+			preserveSymlinks,
+			preferHardlink: settings.preferHardlink
 		});
 
 		if (!transferResult.success) {


### PR DESCRIPTION
## Summary
Fixes three unrelated issues: Cloudflare challenges were exiting early on non-English pages and silently returning broken results, manual imports were ignoring the preferHardlink setting and always hardlinking regardless of what you had configured, and BitSearch had a stale domain that needed updating.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made
- Add localized CF challenge page titles (French, German, Spanish, Portuguese, Japanese, Korean, Chinese) to `CHALLENGE_TITLE_PATTERNS` so the solver waits the full timeout instead of returning immediately on non-English pages
- Return an error from `browserFetch()` when `waitForChallengeComplete()` times out instead of silently returning the challenge HTML as a success response
- Attempt explicit Turnstile checkbox click on each poll iteration to directly interact with Managed Challenge / Turnstile widgets
- Pass `settings.preferHardlink` to `transferFileWithMode()` in `manual-import-service.ts` so the file management preference is respected (was always defaulting to `true`)
- Raise "different filesystems" log from debug to info so users can see why hardlinks are silently falling back to copy
- Update BitSearch indexer links to correct domain

## Areas Affected
<!-- Check all that apply -->
- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (npm run test)
- [x] Type checking passes (npm run check)

## Checklist
- [x] Code follows project conventions
- [x] Ran npm run format
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (feat:, fix:, etc.)
- [x] Svelte 5 runes used correctly ($state, $derived, $effect, $props)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots
<!-- For UI changes, include before/after screenshots -->