### PR TITLE
Fix Knaben indexer HTTP 422 (hide_xxx sent as string, not boolean)

### DIFF
--- a/data/indexers/definitions/knaben.yaml
+++ b/data/indexers/definitions/knaben.yaml
@@ -73,7 +73,7 @@ search:
         order_direction: desc
         size: '150'
         hide_unsafe: 'true'
-        hide_xxx: '{{ .Config.hide_xxx }}'
+        hide_xxx: '{{ if .Config.hide_xxx }}true{{ else }}false{{ end }}'
 
     # TV search
     - path: /v1
@@ -87,7 +87,7 @@ search:
         order_direction: desc
         size: '150'
         hide_unsafe: 'true'
-        hide_xxx: '{{ .Config.hide_xxx }}'
+        hide_xxx: '{{ if .Config.hide_xxx }}true{{ else }}false{{ end }}'
 
     # XXX search — override hide_xxx so adult searches always return adult results
     # regardless of the user's "Hide XXX Content" preference for general browsing
@@ -113,7 +113,7 @@ search:
         order_direction: desc
         size: '150'
         hide_unsafe: 'true'
-        hide_xxx: '{{ .Config.hide_xxx }}'
+        hide_xxx: '{{ if .Config.hide_xxx }}true{{ else }}false{{ end }}'
 
   headers:
     Content-Type: application/json


### PR DESCRIPTION
## Problem
Every Knaben search fails with `HTTP 422: Unprocessable Entity`, surfaced to users
as the misleading "Unable to reach indexer server". It's the only JSON-body POST
indexer, so no other indexer is affected.

## Root cause
`hide_xxx: '{{ .Config.hide_xxx }}'` is a `checkbox` setting. TemplateEngine stores
checkboxes using Prowlarr's `.True`/`null` marker convention, so the template expands
to the literal string `".True"` (or `""`). RequestBuilder's JSON path runs
`JSON.parse(value)`, which throws on `.True` and falls back to the raw string. Knaben's
`/v1` API requires a boolean and rejects it:

`Json deserialize error: invalid type: string ".True", expected a boolean`

## Fix
Emit a real boolean literal via a conditional so `JSON.parse` yields a proper boolean:

```yaml
hide_xxx: '{{ if .Config.hide_xxx }}true{{ else }}false{{ end }}'
```

## Verification
- Ran the real TemplateEngine + RequestBuilder pipeline against `knaben.yaml`:
  before → `"hide_xxx":".True"`, after → `"hide_xxx":true`/`false`.
- Live API: pre-fix body → 422; post-fix body → 200 with results.
- Confirmed against production logs (Knaben 422s while Nyaa/LimeTorrents/EZTV return 200).