### PR TITLE
fix: patch memory leak vectors, stale search cache, and Docker build optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 # ==========================================
-# Build Stage
+# Build-deps base (shared by builder + prod-deps to avoid duplicate apt layers)
 # ==========================================
-FROM node:24-trixie-slim AS builder
+FROM node:24-trixie-slim AS build-deps-base
 WORKDIR /app
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3 \
 	make \
 	g++ \
 	&& rm -rf /var/lib/apt/lists/*
+
+# ==========================================
+# Build Stage
+# ==========================================
+FROM build-deps-base AS builder
 
 COPY package*.json ./
 COPY .npmrc ./
@@ -32,14 +36,7 @@ RUN npm run build
 # ==========================================
 # Production Dependencies Stage
 # ==========================================
-FROM node:24-trixie-slim AS prod-deps
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	python3 \
-	make \
-	g++ \
-	&& rm -rf /var/lib/apt/lists/*
+FROM build-deps-base AS prod-deps
 
 COPY package*.json ./
 COPY .npmrc ./
@@ -50,6 +47,7 @@ COPY .npmrc ./
 RUN npm ci --omit=dev --no-audit --no-fund \
 	&& find node_modules -type f -name '*.map' -delete \
 	&& find node_modules -type d \( -name test -o -name tests -o -name __tests__ -o -name docs -o -name doc -o -name examples -o -name example \) -prune -exec rm -rf '{}' + \
+	&& find node_modules -name 'lightningcss-linux-x64-musl' -prune -exec rm -rf '{}' + \
 	&& find node_modules -type d -empty -delete
 
 # ==========================================

--- a/src/lib/server/indexers/IndexerManager.ts
+++ b/src/lib/server/indexers/IndexerManager.ts
@@ -30,6 +30,7 @@ import type { YamlDefinition } from './schema/yamlDefinition';
 import { buildCapabilitiesFromYaml } from './capabilities';
 import {
 	getSearchOrchestrator,
+	clearSearchCache,
 	type SearchOrchestratorOptions,
 	type EnhancedSearchResult
 } from './search/SearchOrchestrator';
@@ -431,6 +432,9 @@ export class IndexerManager {
 			} else {
 				statusTracker.disable(id);
 			}
+			// Search results are cached without awareness of which indexers are enabled.
+			// Clear so the next search reflects the new indexer set.
+			clearSearchCache();
 		}
 		if (updates.priority !== undefined) {
 			statusTracker.setPriority(id, updates.priority);

--- a/src/lib/server/indexers/ratelimit/HostConcurrencyLimiter.ts
+++ b/src/lib/server/indexers/ratelimit/HostConcurrencyLimiter.ts
@@ -91,12 +91,22 @@ export class HostConcurrencyLimiter {
 	release(url: string): void {
 		const key = concurrencyKey(url);
 		const current = this.inFlight.get(key) ?? 0;
-		this.inFlight.set(key, Math.max(0, current - 1));
+		const updated = Math.max(0, current - 1);
+		if (updated === 0) {
+			this.inFlight.delete(key);
+		} else {
+			this.inFlight.set(key, updated);
+		}
 
 		const queue = this.queues.get(key);
 		if (queue?.length) {
 			const next = queue.shift();
+			if (queue.length === 0) {
+				this.queues.delete(key);
+			}
 			if (next) next(true);
+		} else if (this.queues.has(key)) {
+			this.queues.delete(key);
 		}
 	}
 

--- a/src/lib/server/indexers/ratelimit/HostRateLimiter.ts
+++ b/src/lib/server/indexers/ratelimit/HostRateLimiter.ts
@@ -129,12 +129,21 @@ export class HostRateLimiter {
 
 		let limiter = this.hostLimiters.get(key);
 		if (!limiter) {
+			this.pruneIdleLimiters();
 			const config = this.hostConfigs.get(key) ?? DEFAULT_HOST_RATE_LIMIT;
 			limiter = new RateLimiter(config);
 			this.hostLimiters.set(key, limiter);
 		}
 
 		return limiter;
+	}
+
+	private pruneIdleLimiters(): void {
+		for (const [key, limiter] of this.hostLimiters) {
+			if (limiter.getCurrentCount() === 0) {
+				this.hostLimiters.delete(key);
+			}
+		}
 	}
 
 	/**

--- a/src/lib/server/indexers/search/SearchOrchestrator.ts
+++ b/src/lib/server/indexers/search/SearchOrchestrator.ts
@@ -2941,6 +2941,11 @@ export class SearchOrchestrator {
 
 		return criteria;
 	}
+
+	clearCache(): void {
+		this.cache.clear();
+		this.enhancedCache.clear();
+	}
 }
 
 /** Singleton instance */
@@ -2957,4 +2962,9 @@ export function getSearchOrchestrator(): SearchOrchestrator {
 /** Reset the singleton (for testing) */
 export function resetSearchOrchestrator(): void {
 	orchestratorInstance = null;
+}
+
+/** Clear all cached search results (call when indexer config changes). */
+export function clearSearchCache(): void {
+	orchestratorInstance?.clearCache();
 }

--- a/src/lib/server/library/ffprobe.ts
+++ b/src/lib/server/library/ffprobe.ts
@@ -203,15 +203,15 @@ export async function isFFprobeAvailable(ffprobePath?: string): Promise<boolean>
 			resolve(false);
 		});
 
-		proc.on('close', (code) => {
-			resolve(code === 0 && output.includes('ffprobe'));
-		});
-
-		// Timeout after 5 seconds
-		setTimeout(() => {
+		const timeoutId = setTimeout(() => {
 			proc.kill();
 			resolve(false);
 		}, 5000);
+
+		proc.on('close', (code) => {
+			clearTimeout(timeoutId);
+			resolve(code === 0 && output.includes('ffprobe'));
+		});
 	});
 }
 
@@ -235,7 +235,13 @@ export async function getFFprobeVersion(ffprobePath?: string): Promise<string | 
 			resolve(null);
 		});
 
+		const timeoutId = setTimeout(() => {
+			proc.kill();
+			resolve(null);
+		}, 5000);
+
 		proc.on('close', (code) => {
+			clearTimeout(timeoutId);
 			if (code === 0) {
 				// Extract version from first line: "ffprobe version X.X.X ..."
 				const match = output.match(/ffprobe version (\S+)/);
@@ -244,11 +250,6 @@ export async function getFFprobeVersion(ffprobePath?: string): Promise<string | 
 				resolve(null);
 			}
 		});
-
-		setTimeout(() => {
-			proc.kill();
-			resolve(null);
-		}, 5000);
 	});
 }
 

--- a/src/lib/server/sse.ts
+++ b/src/lib/server/sse.ts
@@ -185,6 +185,7 @@ export function createSSEOperationStream(
 	} = {}
 ): Response {
 	const heartbeatIntervalMs = options.heartbeatInterval ?? 30000;
+	let cleanupRef: (() => void) | null = null;
 
 	const stream = new ReadableStream({
 		async start(controller) {
@@ -215,6 +216,7 @@ export function createSSEOperationStream(
 				}
 			};
 
+			cleanupRef = cleanup;
 			request.signal.addEventListener('abort', cleanup, { once: true });
 
 			send('connected', { timestamp: new Date().toISOString() });
@@ -237,7 +239,7 @@ export function createSSEOperationStream(
 			}
 		},
 		cancel() {
-			// Abort handling closes the stream.
+			cleanupRef?.();
 		}
 	});
 

--- a/src/lib/server/storage/insights/InsightsService.ts
+++ b/src/lib/server/storage/insights/InsightsService.ts
@@ -13,6 +13,7 @@ class InsightsService implements BackgroundService {
 	private _error?: Error;
 	private insightsLock = false;
 	private listenersAttached = false;
+	private attachPromise: Promise<void> | null = null;
 	private readonly rules: StorageInsightRule[];
 
 	constructor() {
@@ -45,6 +46,10 @@ class InsightsService implements BackgroundService {
 	}
 
 	async stop(): Promise<void> {
+		if (this.attachPromise) {
+			await this.attachPromise;
+			this.attachPromise = null;
+		}
 		this.detachListeners();
 		this._status = 'pending';
 	}
@@ -52,7 +57,7 @@ class InsightsService implements BackgroundService {
 	private attachListeners(): void {
 		if (this.listenersAttached) return;
 		this.listenersAttached = true;
-		void import('$lib/server/storage/reconciliation/ReconciliationService.js')
+		this.attachPromise = import('$lib/server/storage/reconciliation/ReconciliationService.js')
 			.then(({ getReconciliationService }) => {
 				getReconciliationService().on('reconcileComplete', this.handleTrigger);
 			})

--- a/src/lib/server/storage/reconciliation/ReconciliationService.ts
+++ b/src/lib/server/storage/reconciliation/ReconciliationService.ts
@@ -40,6 +40,7 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 	private _error?: Error;
 	private reconcileLock = false;
 	private listenersAttached = false;
+	private attachPromise: Promise<void> | null = null;
 
 	get status(): ServiceStatus {
 		return this._status;
@@ -73,6 +74,10 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 	}
 
 	async stop(): Promise<void> {
+		if (this.attachPromise) {
+			await this.attachPromise;
+			this.attachPromise = null;
+		}
 		this.detachListeners();
 		this._status = 'pending';
 	}
@@ -80,31 +85,35 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 	private attachListeners(): void {
 		if (this.listenersAttached) return;
 		this.listenersAttached = true;
-		// Lazy-import to avoid circular deps at module load time
-		void import('$lib/server/library/library-scheduler.js')
-			.then(({ getLibraryScheduler }) => {
-				getLibraryScheduler().on('scanComplete', this.handleTrigger);
-			})
-			.catch((e) => {
-				logger.error('[ReconciliationService] failed to subscribe to scanComplete', e);
-			});
-		void import('$lib/server/mediaServerStats/MediaServerStatsSyncService.js')
-			.then(({ getMediaServerStatsSyncService }) => {
-				getMediaServerStatsSyncService().on('syncComplete', this.handleTrigger);
-			})
-			.catch((e) => {
-				logger.error('[ReconciliationService] failed to subscribe to syncComplete', e);
-			});
-		// Subscribe to library data mutations (movie/series/episode/season CRUD,
-		// root-folder and library changes). The reconcileLock coalesces concurrent
-		// triggers, so a 50-item batch delete produces one reconcile run, not 50.
-		void import('$lib/server/library/LibraryMediaEvents.js')
-			.then(({ libraryMediaEvents }) => {
-				libraryMediaEvents.onLibraryDataChanged(this.handleTrigger);
-			})
-			.catch((e) => {
-				logger.error('[ReconciliationService] failed to subscribe to library:data-changed', e);
-			});
+		// Lazy-import to avoid circular deps at module load time.
+		// Track the combined Promise so stop() can await completion before detaching,
+		// preventing orphaned listeners if stop() is called while imports are in-flight.
+		this.attachPromise = Promise.all([
+			import('$lib/server/library/library-scheduler.js')
+				.then(({ getLibraryScheduler }) => {
+					getLibraryScheduler().on('scanComplete', this.handleTrigger);
+				})
+				.catch((e) => {
+					logger.error('[ReconciliationService] failed to subscribe to scanComplete', e);
+				}),
+			import('$lib/server/mediaServerStats/MediaServerStatsSyncService.js')
+				.then(({ getMediaServerStatsSyncService }) => {
+					getMediaServerStatsSyncService().on('syncComplete', this.handleTrigger);
+				})
+				.catch((e) => {
+					logger.error('[ReconciliationService] failed to subscribe to syncComplete', e);
+				}),
+			// Subscribe to library data mutations (movie/series/episode/season CRUD,
+			// root-folder and library changes). The reconcileLock coalesces concurrent
+			// triggers, so a 50-item batch delete produces one reconcile run, not 50.
+			import('$lib/server/library/LibraryMediaEvents.js')
+				.then(({ libraryMediaEvents }) => {
+					libraryMediaEvents.onLibraryDataChanged(this.handleTrigger);
+				})
+				.catch((e) => {
+					logger.error('[ReconciliationService] failed to subscribe to library:data-changed', e);
+				}),
+		]).then(() => undefined);
 	}
 
 	private detachListeners(): void {

--- a/src/lib/server/storage/reconciliation/ReconciliationService.ts
+++ b/src/lib/server/storage/reconciliation/ReconciliationService.ts
@@ -112,7 +112,7 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 				})
 				.catch((e) => {
 					logger.error('[ReconciliationService] failed to subscribe to library:data-changed', e);
-				}),
+				})
 		]).then(() => undefined);
 	}
 


### PR DESCRIPTION
## Summary

Patch memory leak vectors across several services, fix stale search results after toggling indexers, and remove redundant layers in the Docker build.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- **Search cache invalidation** - `SearchOrchestrator` now exposes `clearCache()` (clears both `ReleaseCache` and `enhancedCache`); `IndexerManager` calls it whenever `enabled`, `upstreamEnabled`, or `orphaned` changes so toggling an indexer immediately invalidates stale results
- **Listener lifecycle race** - `ReconciliationService` and `InsightsService` now store their attach `Promise` and `await` it in `stop()`, preventing orphaned duplicate event listeners when `stop()` is called while lazy imports are still in-flight
- **SSE heartbeat leak** - `createSSEOperationStream` wires its `cleanup` ref to `cancel()` so the 30-second heartbeat interval is cleared even when the `ReadableStream` consumer cancels before `request.signal` fires abort
- **ffprobe timeout handles** - `isFFprobeAvailable` and `getFFprobeVersion` now store and clear their 5-second guard timeouts in the `close` handler, matching the pattern already used by `runFFprobe`
- **Rate limiter map growth** - `HostConcurrencyLimiter.release()` deletes `inFlight`/`queues` map entries when they reach zero; `HostRateLimiter.getLimiterForHost()` prunes idle limiters on first miss so both maps stay bounded to active hosts
- **Dockerfile** - extract shared `build-deps-base` stage (eliminates one duplicate `apt-get install python3 make g++`); prune `lightningcss-linux-x64-musl` (~10 MB) from prod `node_modules` since the musl variant is unused on Debian/glibc

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
