### PR TITLE
feat(indexers): migrate Jackett to native JSON search API with IMDB ID fix

### DIFF
--- a/data/indexers/definitions/jackett.yaml
+++ b/data/indexers/definitions/jackett.yaml
@@ -1,0 +1,149 @@
+---
+id: jackett
+name: Jackett
+description: Direct integration with Jackett's native JSON search API
+type: semi-private
+language: en-US
+encoding: UTF-8
+requestdelay: 0
+# Per-indexer request; 15 s is generous enough for a single tracker
+requesttimeout: 15000
+
+links:
+  - http://localhost:9117/
+
+settings:
+  - name: apikey
+    type: password
+    label: API Key
+    required: true
+  - name: trackerId
+    type: text
+    label: Tracker ID
+    required: true
+
+caps:
+  modes:
+    search: [q]
+    movie-search: [q]
+    tv-search: [q]
+  categories:
+    '2000': Movies
+    '2010': Movies/Foreign
+    '2020': Movies/Other
+    '2030': Movies/SD
+    '2040': Movies/HD
+    '2045': Movies/UHD
+    '2050': Movies/BluRay
+    '2060': Movies/3D
+    '2070': Movies/DVD
+    '2080': Movies/WEB-DL
+    '2090': Movies/x265
+    '5000': TV
+    '5010': TV/WEB-DL
+    '5020': TV/Foreign
+    '5030': TV/SD
+    '5040': TV/HD
+    '5045': TV/UHD
+    '5050': TV/Other
+    '5060': TV/Sport
+    '5070': TV/Anime
+    '5080': TV/Documentary
+    '5090': TV/x265
+    '6000': XXX
+    '8000': Other
+    '8010': Other/Misc
+
+search:
+  paths:
+    # Movie search — category-filtered
+    - path: api/v2.0/indexers/all/results
+      method: get
+      categories: [Movies]
+      inputs:
+        Query: '{{ .Keywords }}'
+        apikey: '{{ .Config.apikey }}'
+        $raw: 'Tracker[]={{ .Config.trackerId }}{{ if .Categories }}&Category[]={{ join .Categories "&Category[]=" }}{{ end }}'
+
+    # TV search — category-filtered
+    - path: api/v2.0/indexers/all/results
+      method: get
+      categories: [TV]
+      inputs:
+        Query: '{{ .Keywords }}'
+        apikey: '{{ .Config.apikey }}'
+        $raw: 'Tracker[]={{ .Config.trackerId }}{{ if .Categories }}&Category[]={{ join .Categories "&Category[]=" }}{{ end }}'
+
+    # General keyword search fallback
+    - path: api/v2.0/indexers/all/results
+      method: get
+      inputs:
+        Query: '{{ .Keywords }}'
+        apikey: '{{ .Config.apikey }}'
+        $raw: 'Tracker[]={{ .Config.trackerId }}'
+
+  response:
+    type: json
+
+  rows:
+    selector: Results
+
+  fields:
+    title:
+      selector: Title
+    details:
+      selector: Details
+      optional: true
+    download:
+      selector: Link
+      optional: true
+    magnet:
+      selector: MagnetUri
+      optional: true
+    guid:
+      selector: Guid
+      optional: true
+    infohash:
+      selector: InfoHash
+      optional: true
+    date:
+      selector: PublishDate
+    size:
+      selector: Size
+      optional: true
+    seeders:
+      selector: Seeders
+      optional: true
+    leechers:
+      selector: Peers
+      optional: true
+    category:
+      selector: Category[0]
+      optional: true
+    grabs:
+      selector: Grabs
+      optional: true
+    downloadvolumefactor:
+      selector: DownloadVolumeFactor
+      optional: true
+    uploadvolumefactor:
+      selector: UploadVolumeFactor
+      optional: true
+    imdbid:
+      selector: Imdb
+      optional: true
+      filters:
+        - name: re_replace
+          args: ['^0$', '']
+    tmdbid:
+      selector: Tmdb
+      optional: true
+      filters:
+        - name: re_replace
+          args: ['^0$', '']
+    tvdbid:
+      selector: Tvdb
+      optional: true
+      filters:
+        - name: re_replace
+          args: ['^0$', '']

--- a/src/lib/components/indexers/IndexerDefinitionPicker.svelte
+++ b/src/lib/components/indexers/IndexerDefinitionPicker.svelte
@@ -14,7 +14,7 @@
 	let searchQuery = $state('');
 
 	const filteredDefinitions = $derived(() => {
-		const pickable = definitions.filter((d) => d.id !== 'prowlarr');
+		const pickable = definitions.filter((d) => d.id !== 'prowlarr' && d.id !== 'jackett');
 		if (!searchQuery.trim()) return pickable;
 		const query = searchQuery.toLowerCase();
 		return pickable.filter(
@@ -172,7 +172,7 @@
 
 	<p class="text-center text-sm text-base-content/50">
 		{m.settings_indexers_indexersAvailable({
-			count: definitions.filter((d) => d.id !== 'prowlarr').length
+			count: definitions.filter((d) => d.id !== 'prowlarr' && d.id !== 'jackett').length
 		})}
 	</p>
 </div>

--- a/src/lib/components/indexers/IndexerFormRegular.svelte
+++ b/src/lib/components/indexers/IndexerFormRegular.svelte
@@ -106,9 +106,12 @@
 	let usenetSettingsOpen = $state(false);
 	let categoriesOpen = $state(false);
 
-	// Show the category restriction panel for newznab/torznab/prowlarr definitions
+	// Show the category restriction panel for newznab/torznab/prowlarr/jackett definitions
 	const isNewznabLike = $derived(
-		definition?.id === 'newznab' || definition?.id === 'torznab' || definition?.id === 'prowlarr'
+		definition?.id === 'newznab' ||
+			definition?.id === 'torznab' ||
+			definition?.id === 'prowlarr' ||
+			definition?.id === 'jackett'
 	);
 
 	// Build a parent→children tree from the YAML-defined category map.

--- a/src/lib/components/indexers/IndexerFormRegular.svelte
+++ b/src/lib/components/indexers/IndexerFormRegular.svelte
@@ -33,6 +33,8 @@
 		alternateUrls: string[];
 		prowlarrManaged?: boolean;
 		jackettManaged?: boolean;
+		/** Override URL shown in the read-only managed display (e.g. virtual path for Jackett). */
+		managedDisplayUrl?: string;
 		onNameChange: (value: string) => void;
 		onUrlChange: (value: string) => void;
 		onUrlBlur: () => void;
@@ -78,6 +80,7 @@
 		alternateUrls,
 		prowlarrManaged = false,
 		jackettManaged = false,
+		managedDisplayUrl = undefined,
 		onNameChange,
 		onUrlChange,
 		onUrlBlur,
@@ -313,7 +316,9 @@
 				{/if}
 			</label>
 			{#if prowlarrManaged || jackettManaged}
-				<p class="py-1.5 font-mono text-xs break-all text-base-content/70">{url}</p>
+				<p class="py-1.5 font-mono text-xs break-all text-base-content/70">
+					{managedDisplayUrl ?? url}
+				</p>
 			{:else if definitionUrls.length > 1}
 				<select
 					id="regular-url"

--- a/src/lib/components/indexers/IndexerModal.svelte
+++ b/src/lib/components/indexers/IndexerModal.svelte
@@ -116,6 +116,15 @@
 		);
 	});
 
+	const displayUrl = $derived.by(() => {
+		if (indexer?.definitionId === 'jackett') {
+			const trackerId = (indexer.settings as Record<string, unknown> | null)?.trackerId;
+			if (typeof trackerId === 'string' && trackerId)
+				return `${indexer.baseUrl.replace(/\/+$/, '')}/api/v2.0/indexers/${trackerId}/results`;
+		}
+		return url;
+	});
+
 	const uiHints = $derived(() => {
 		if (selectedDefinition) {
 			return computeUIHints(selectedDefinition);
@@ -472,6 +481,7 @@
 				{alternateUrls}
 				prowlarrManaged={isProwlarrManaged}
 				jackettManaged={isJackettManaged}
+				managedDisplayUrl={isJackettManaged ? displayUrl : undefined}
 				{additionalCategories}
 				onNameChange={(v) => (name = v)}
 				onUrlChange={(v) => (url = v)}

--- a/src/lib/components/indexers/IndexerModal.svelte
+++ b/src/lib/components/indexers/IndexerModal.svelte
@@ -108,6 +108,7 @@
 
 	const isJackettManaged = $derived.by(() => {
 		if (mode !== 'edit' || !indexer || !jackettBaseUrl) return false;
+		if (indexer.definitionId === 'jackett') return true;
 		const base = jackettBaseUrl.replace(/\/+$/, '');
 		return (
 			indexer.baseUrl.startsWith(base + '/api/v2.0/indexers/') &&

--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -83,6 +83,15 @@
 		if (url.length <= maxLength) return url;
 		return url.substring(0, maxLength) + '...';
 	}
+
+	const displayUrl = $derived.by(() => {
+		if (indexer.definitionId === 'jackett') {
+			const trackerId = (indexer.settings as Record<string, unknown> | null)?.trackerId;
+			if (typeof trackerId === 'string' && trackerId)
+				return `${indexer.baseUrl.replace(/\/+$/, '')}/api/v2.0/indexers/${trackerId}/results`;
+		}
+		return indexer.baseUrl;
+	});
 </script>
 
 <tr
@@ -201,9 +210,9 @@
 
 	<!-- URL -->
 	<td class="max-w-50">
-		<div class="tooltip block w-full" data-tip={indexer.baseUrl}>
+		<div class="tooltip block w-full" data-tip={displayUrl}>
 			<span class="block truncate text-sm text-base-content/70">
-				{truncateUrl(indexer.baseUrl)}
+				{truncateUrl(displayUrl)}
 			</span>
 		</div>
 	</td>

--- a/src/lib/components/indexers/IndexerRow.svelte
+++ b/src/lib/components/indexers/IndexerRow.svelte
@@ -71,6 +71,7 @@
 
 	function isJackettIndexer(): boolean {
 		if (!jackettBaseUrl) return false;
+		if (indexer.definitionId === 'jackett') return true;
 		const base = jackettBaseUrl.replace(/\/+$/, '');
 		return (
 			indexer.baseUrl.startsWith(base + '/api/v2.0/indexers/') &&

--- a/src/lib/server/db/migrations/121-migrate-jackett-indexers-to-native.ts
+++ b/src/lib/server/db/migrations/121-migrate-jackett-indexers-to-native.ts
@@ -1,0 +1,80 @@
+import type { MigrationDefinition } from '../migration-helpers.js';
+
+/**
+ * Convert Jackett-imported torznab indexers to the native Jackett JSON definition.
+ *
+ * Legacy format:
+ *   - definition_id = 'torznab'
+ *   - base_url      = jackettBase/api/v2.0/indexers/{trackerId}/results/torznab
+ *   - settings      = { apikey: ... }
+ *
+ * New format:
+ *   - definition_id = 'jackett'
+ *   - base_url      = jackettBase  (root URL)
+ *   - settings      = { apikey: ..., trackerId: '{trackerId}' }
+ *
+ * Idempotent: safe to re-run. Already-converted indexers are skipped.
+ */
+export const migration_v121: MigrationDefinition = {
+	version: 121,
+	name: 'migrate_jackett_indexers_to_native',
+	apply: (sqlite) => {
+		const connRow = sqlite
+			.prepare(`SELECT value FROM settings WHERE key = 'jackett_connection' LIMIT 1`)
+			.get() as { value: string } | undefined;
+
+		if (!connRow) return;
+
+		let jackettBase: string;
+		let apiKey: string;
+		try {
+			const conn = JSON.parse(connRow.value) as { url?: string; apiKey?: string };
+			if (!conn.url || !conn.apiKey) return;
+			jackettBase = conn.url.replace(/\/+$/, '');
+			apiKey = conn.apiKey;
+		} catch {
+			return;
+		}
+
+		// Pattern: jackettBase/api/v2.0/indexers/{trackerId}/results/torznab
+		const prefix = `${jackettBase}/api/v2.0/indexers/`;
+		const suffix = '/results/torznab';
+
+		const legacy = sqlite
+			.prepare(
+				`SELECT id, base_url, settings FROM indexers
+				 WHERE definition_id = 'torznab'
+				   AND base_url LIKE ?`
+			)
+			.all(`${prefix}%`) as { id: string; base_url: string; settings: string | null }[];
+
+		const convertStmt = sqlite.prepare(
+			`UPDATE indexers SET definition_id = 'jackett', base_url = ?, settings = ? WHERE id = ?`
+		);
+
+		for (const row of legacy) {
+			const normalized = row.base_url.replace(/\/+$/, '');
+			if (!normalized.startsWith(prefix)) continue;
+			const rest = normalized.slice(prefix.length);
+			// rest should be: {trackerId}/results/torznab
+			const slashIndex = rest.indexOf('/');
+			const trackerId = slashIndex > -1 ? rest.slice(0, slashIndex) : rest;
+			if (!trackerId) continue;
+			// Verify it actually ends with the torznab suffix
+			if (!normalized.endsWith(suffix)) continue;
+
+			let existing: Record<string, unknown> = {};
+			try {
+				if (row.settings) existing = JSON.parse(row.settings) as Record<string, unknown>;
+			} catch {
+				// keep empty object
+			}
+
+			convertStmt.run(
+				jackettBase,
+				JSON.stringify({ ...existing, apikey: apiKey, trackerId }),
+				row.id
+			);
+		}
+	}
+};

--- a/src/lib/server/db/migrations/index.ts
+++ b/src/lib/server/db/migrations/index.ts
@@ -117,6 +117,7 @@ import { migration_v117 } from './117-add-quality-profile-to-delay-profiles.js';
 import { migration_v118 } from './118-add-scan-mode-to-delay-profiles.js';
 import { migration_v119 } from './119-backfill-release-group-from-title.js';
 import { migration_v120 } from './120-migrate-prowlarr-indexers-to-native.js';
+import { migration_v121 } from './121-migrate-jackett-indexers-to-native.js';
 
 export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v002,
@@ -236,5 +237,6 @@ export const MIGRATIONS: MigrationDefinition[] = [
 	migration_v117,
 	migration_v118,
 	migration_v119,
-	migration_v120
+	migration_v120,
+	migration_v121
 ];

--- a/src/lib/server/indexers/jackett/JackettConnectionService.ts
+++ b/src/lib/server/indexers/jackett/JackettConnectionService.ts
@@ -75,21 +75,36 @@ export function normalizeJackettUrl(url: string): string {
 	return url.replace(/\/+$/, '');
 }
 
-/** Build the Torznab feed URL for a given Jackett indexer ID. */
+/** Build the Torznab feed URL for a given Jackett indexer ID (legacy format). */
 export function jackettIndexerUrl(jackettBase: string, indexerId: string): string {
 	return `${jackettBase}${JACKETT_INDEXERS_PATH}/${indexerId}${TORZNAB_SUFFIX}`;
 }
 
-/** Returns true when baseUrl is a Torznab feed served by this Jackett instance. */
-export function isIndexerFromJackett(baseUrl: string, jackettBase: string): boolean {
+/**
+ * Returns true when the indexer was imported from this Jackett instance.
+ * Checks definitionId first (native format); falls back to URL pattern for
+ * legacy torznab indexers that pre-date migration 121.
+ */
+export function isIndexerFromJackett(
+	indexer: { definitionId?: string; baseUrl: string },
+	jackettBase: string
+): boolean {
+	if (indexer.definitionId === 'jackett') return true;
 	const base = jackettBase.replace(/\/+$/, '');
-	const normalized = baseUrl.replace(/\/+$/, '');
+	const normalized = indexer.baseUrl.replace(/\/+$/, '');
 	const prefix = `${base}${JACKETT_INDEXERS_PATH}/`;
 	return normalized.startsWith(prefix) && normalized.includes(TORZNAB_SUFFIX);
 }
 
-/** Extract the Jackett indexer ID from a stored Cinephage baseUrl. */
-export function extractJackettIndexerId(baseUrl: string, jackettBase: string): string | null {
+/** Extract the Jackett tracker ID from a stored Cinephage indexer (legacy torznab URL or native settings). */
+export function extractJackettIndexerId(
+	baseUrl: string,
+	jackettBase: string,
+	settings?: Record<string, unknown> | null
+): string | null {
+	// New-style: trackerId stored in settings
+	if (settings?.trackerId) return String(settings.trackerId);
+	// Legacy: extract from torznab URL
 	const base = jackettBase.replace(/\/+$/, '');
 	const prefix = `${base}${JACKETT_INDEXERS_PATH}/`;
 	const normalized = baseUrl.replace(/\/+$/, '');
@@ -254,12 +269,11 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 	const manager = await getIndexerManager();
 	const existingIndexers = await manager.getIndexers();
 
-	const managedIndexers = existingIndexers.filter((i) =>
-		isIndexerFromJackett(i.baseUrl, jackettBase)
-	);
+	const managedIndexers = existingIndexers.filter((i) => isIndexerFromJackett(i, jackettBase));
 
 	for (const indexer of managedIndexers) {
-		const indexerId = extractJackettIndexerId(indexer.baseUrl, jackettBase);
+		const existingSettings = indexer.settings as Record<string, unknown> | null;
+		const indexerId = extractJackettIndexerId(indexer.baseUrl, jackettBase, existingSettings);
 		const ji = indexerId ? jackettById.get(indexerId) : undefined;
 
 		if (!ji) {
@@ -288,7 +302,6 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 		// Clear orphaned flag if the indexer has re-appeared in Jackett
 		if (indexer.orphaned) updates.orphaned = false;
 
-		const existingSettings = indexer.settings as Record<string, unknown> | null;
 		const currentKey = existingSettings?.apikey;
 		if (currentKey !== conn.apiKey) {
 			updates.settings = { ...(existingSettings ?? {}), apikey: conn.apiKey };
@@ -312,21 +325,26 @@ export async function syncJackettIndexers(): Promise<SyncResult> {
 	}
 
 	if (conn.syncAddNew) {
-		const managedUrls = new Set(managedIndexers.map((i) => normalizeJackettUrl(i.baseUrl)));
+		// Build a set of already-managed tracker IDs (works for both old torznab URLs and new native)
+		const managedTrackerIds = new Set(
+			managedIndexers.map((i) => {
+				const s = i.settings as Record<string, unknown> | null;
+				return extractJackettIndexerId(i.baseUrl, jackettBase, s);
+			})
+		);
 
 		for (const ji of jackettIndexers) {
-			const baseUrl = jackettIndexerUrl(jackettBase, ji.id);
-			if (managedUrls.has(baseUrl)) continue;
+			if (managedTrackerIds.has(ji.id)) continue;
 
 			try {
 				await manager.createIndexer({
 					name: ji.name,
-					definitionId: 'torznab',
-					baseUrl,
+					definitionId: 'jackett',
+					baseUrl: jackettBase,
 					alternateUrls: [],
 					enabled: true,
 					priority: 25,
-					settings: { apikey: conn.apiKey },
+					settings: { apikey: conn.apiKey, trackerId: ji.id },
 					enableAutomaticSearch: true,
 					enableInteractiveSearch: true,
 					minimumSeeders: 1,
@@ -377,7 +395,7 @@ export async function propagateJackettApiKey(newApiKey: string): Promise<void> {
 	const indexers = await manager.getIndexers();
 
 	for (const indexer of indexers) {
-		if (!isIndexerFromJackett(indexer.baseUrl, jackettBase)) continue;
+		if (!isIndexerFromJackett(indexer, jackettBase)) continue;
 		const existing = indexer.settings as Record<string, unknown> | null;
 		if ((existing?.apikey ?? '') === newApiKey) continue;
 		await manager.updateIndexer(indexer.id, {

--- a/src/lib/server/indexers/runtime/ResponseParser.ts
+++ b/src/lib/server/indexers/runtime/ResponseParser.ts
@@ -684,7 +684,7 @@ export class ResponseParser {
 		// External IDs
 		const imdbId = values['imdb'] || values['imdbid'];
 		if (imdbId) {
-			result.imdbId = imdbId.startsWith('tt') ? imdbId : `tt${imdbId}`;
+			result.imdbId = imdbId.startsWith('tt') ? imdbId : `tt${imdbId.padStart(7, '0')}`;
 		}
 
 		const tmdbIdStr = values['tmdb'] || values['tmdbid'];

--- a/src/routes/api/indexers/jackett/+server.ts
+++ b/src/routes/api/indexers/jackett/+server.ts
@@ -7,7 +7,8 @@ import {
 	normalizeJackettUrl,
 	fetchJackettIndexers,
 	jackettIndexerUrl,
-	isIndexerFromJackett
+	isIndexerFromJackett,
+	extractJackettIndexerId
 } from '$lib/server/indexers/jackett/JackettConnectionService.js';
 
 const requestSchema = z.object({
@@ -67,10 +68,11 @@ export const POST: RequestHandler = async (event) => {
 	const indexers: JackettImportIndexer[] = [];
 	for (const raw of rawIndexers) {
 		const baseUrl = jackettIndexerUrl(jackettBase, raw.id);
-		const existing = existingIndexers.find(
-			(e) =>
-				isIndexerFromJackett(e.baseUrl, jackettBase) && e.baseUrl.replace(/\/+$/, '') === baseUrl
-		);
+		const existing = existingIndexers.find((e) => {
+			if (!isIndexerFromJackett(e, jackettBase)) return false;
+			const s = e.settings as Record<string, unknown> | null;
+			return extractJackettIndexerId(e.baseUrl, jackettBase, s) === raw.id;
+		});
 		if (existing && existing.name !== raw.name) {
 			await manager.updateIndexer(existing.id, { name: raw.name });
 		}

--- a/src/routes/api/indexers/jackett/indexers/+server.ts
+++ b/src/routes/api/indexers/jackett/indexers/+server.ts
@@ -6,7 +6,8 @@ import {
 	fetchJackettIndexers,
 	normalizeJackettUrl,
 	jackettIndexerUrl,
-	isIndexerFromJackett
+	isIndexerFromJackett,
+	extractJackettIndexerId
 } from '$lib/server/indexers/jackett/JackettConnectionService.js';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
 
@@ -50,9 +51,11 @@ export const GET: RequestHandler = async (event) => {
 	const indexers = [];
 	for (const raw of rawIndexers) {
 		const baseUrl = jackettIndexerUrl(base, raw.id);
-		const existing = existingIndexers.find(
-			(e) => isIndexerFromJackett(e.baseUrl, base) && e.baseUrl.replace(/\/+$/, '') === baseUrl
-		);
+		const existing = existingIndexers.find((e) => {
+			if (!isIndexerFromJackett(e, base)) return false;
+			const s = e.settings as Record<string, unknown> | null;
+			return extractJackettIndexerId(e.baseUrl, base, s) === raw.id;
+		});
 		if (existing && existing.name !== raw.name) {
 			await manager.updateIndexer(existing.id, { name: raw.name });
 		}

--- a/src/routes/api/indexers/test/+server.ts
+++ b/src/routes/api/indexers/test/+server.ts
@@ -227,7 +227,8 @@ export const POST: RequestHandler = async (event) => {
 			const jackettConn = await getJackettConnection();
 			if (jackettConn) {
 				const jackettBase = normalizeJackettUrl(jackettConn.url);
-				if (isIndexerFromJackett(existing.baseUrl, jackettBase)) {
+				// Warmup via torznab only applies to legacy format; native indexers use baseUrl = jackettBase
+				if (isIndexerFromJackett(existing, jackettBase) && existing.definitionId !== 'jackett') {
 					const warmupUrl = `${existing.baseUrl}?apikey=${encodeURIComponent(jackettConn.apiKey)}&t=search&q=test`;
 					await fetch(warmupUrl, { signal: AbortSignal.timeout(15000) });
 				}
@@ -250,7 +251,7 @@ export const POST: RequestHandler = async (event) => {
 		}
 		if (freshJackettConn) {
 			const jackettBase = normalizeJackettUrl(freshJackettConn.url);
-			if (isIndexerFromJackett(existing.baseUrl, jackettBase)) {
+			if (isIndexerFromJackett(existing, jackettBase)) {
 				existingSettings = { ...existingSettings, apikey: freshJackettConn.apiKey };
 			}
 		}
@@ -338,7 +339,8 @@ export const POST: RequestHandler = async (event) => {
 			}
 			if (!source && jackettConn2) {
 				const jackettBase = normalizeJackettUrl(jackettConn2.url);
-				if (isIndexerFromJackett(existingBaseUrl, jackettBase)) source = 'Jackett';
+				if (existingIndexer && isIndexerFromJackett(existingIndexer, jackettBase))
+					source = 'Jackett';
 			}
 
 			if (source) {


### PR DESCRIPTION
## Summary

Replaces Jackett's slow Torznab XML endpoint with Jackett's native JSON search API (`/api/v2.0/indexers/all/results?Tracker[]=id`), resolving search timeouts and reducing per-indexer response times. Includes a one-time migration to convert existing Jackett indexers, UI improvements for the native format, and a correctness fix for IMDB ID zero-padding that affected all indexers.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Add `data/indexers/definitions/jackett.yaml`; native JSON definition with `requesttimeout: 15000`, `rows.selector: Results`, per-result freeleech, grabs, and external ID fields
- Add migration 121 to convert existing Jackett torznab indexers to the native definition (extracts `trackerId` from URL, stores in settings, sets `baseUrl` to Jackett root)
- Update `JackettConnectionService`; `isIndexerFromJackett` now accepts the full indexer object and checks `definitionId='jackett'` first, preventing manually-added torznab indexers on the same host being claimed by the sync
- Update sync, `propagateApiKey`, import UI, and test endpoint to track by `trackerId` rather than URL pattern
- Hide `jackett` definition from the Add Indexer picker (import-only, same as Prowlarr)
- Show `…/api/v2.0/indexers/{trackerId}/results` as the display URL in the indexer list and edit modal
- Fix `ResponseParser` to zero-pad numeric IMDB IDs to 7 digits before prepending `tt` (e.g. `460628` → `tt0460628`)

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [ ] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
