### PR TITLE
fix: stop retrying TMDB external ID lookup for deleted entries and hide headless mode toggle

### DIFF
--- a/src/lib/server/services/ExternalIdService.ts
+++ b/src/lib/server/services/ExternalIdService.ts
@@ -335,14 +335,22 @@ export class ExternalIdService implements BackgroundService {
 				success: true
 			};
 		} catch (error) {
-			logger.warn(
-				{
-					id: movie.id,
-					title: movie.title,
-					err: error
-				},
-				`[${this.name}] Failed to fetch external IDs for movie`
-			);
+			const message = error instanceof Error ? error.message : String(error);
+			const isNotFound = /resource you requested could not be found/i.test(message);
+
+			if (isNotFound) {
+				const { eq } = await import('drizzle-orm');
+				await db.update(movies).set({ imdbId: '' }).where(eq(movies.id, movie.id));
+				logger.info(
+					{ id: movie.id, title: movie.title, tmdbId: movie.tmdbId },
+					`[${this.name}] TMDB entry not found for movie — marked as no IMDB ID`
+				);
+			} else {
+				logger.warn(
+					{ id: movie.id, title: movie.title, err: error },
+					`[${this.name}] Failed to fetch external IDs for movie`
+				);
+			}
 
 			return {
 				id: movie.id,
@@ -352,7 +360,7 @@ export class ExternalIdService implements BackgroundService {
 				imdbId: null,
 				tvdbId: null,
 				success: false,
-				error: error instanceof Error ? error.message : String(error)
+				error: message
 			};
 		}
 	}
@@ -443,14 +451,25 @@ export class ExternalIdService implements BackgroundService {
 				success: true
 			};
 		} catch (error) {
-			logger.warn(
-				{
-					id: show.id,
-					title: show.title,
-					err: error
-				},
-				`[${this.name}] Failed to fetch external IDs for series`
-			);
+			const message = error instanceof Error ? error.message : String(error);
+			const isNotFound = /resource you requested could not be found/i.test(message);
+
+			if (isNotFound) {
+				const { eq } = await import('drizzle-orm');
+				await db
+					.update(series)
+					.set({ imdbId: show.imdbId ?? '', tvdbId: show.tvdbId ?? 0 })
+					.where(eq(series.id, show.id));
+				logger.info(
+					{ id: show.id, title: show.title, tmdbId: show.tmdbId },
+					`[${this.name}] TMDB entry not found for series — marked as no external IDs`
+				);
+			} else {
+				logger.warn(
+					{ id: show.id, title: show.title, err: error },
+					`[${this.name}] Failed to fetch external IDs for series`
+				);
+			}
 
 			return {
 				id: show.id,
@@ -460,7 +479,7 @@ export class ExternalIdService implements BackgroundService {
 				imdbId: null,
 				tvdbId: null,
 				success: false,
-				error: error instanceof Error ? error.message : String(error)
+				error: message
 			};
 		}
 	}

--- a/src/routes/settings/system/captcha/+page.svelte
+++ b/src/routes/settings/system/captcha/+page.svelte
@@ -312,30 +312,6 @@
 					</label>
 				</div>
 
-				<!-- Headless Mode -->
-				<div class="form-control">
-					<label
-						class="label w-full cursor-pointer items-start justify-start gap-3 py-0 whitespace-normal"
-					>
-						<input
-							type="checkbox"
-							bind:checked={captchaSettings.headless}
-							class="toggle mt-0.5 shrink-0 toggle-secondary"
-							disabled={!captchaSettings.enabled}
-						/>
-						<div class="min-w-0">
-							<span class="label-text block font-medium whitespace-normal">
-								{m.settings_integrations_captcha_headlessLabel()}
-							</span>
-							<p
-								class="text-sm leading-relaxed wrap-break-word whitespace-normal text-base-content/60"
-							>
-								{m.settings_integrations_captcha_headlessDesc()}
-							</p>
-						</div>
-					</label>
-				</div>
-
 				<div class="divider text-sm">{m.settings_integrations_captcha_timing()}</div>
 
 				<div class="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

Stops ExternalIdService from endlessly retrying TMDB lookups for movies/shows that no longer exist in TMDB, and removes the Headless Mode toggle from captcha settings since the app always runs headless in production.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- `ExternalIdService`: on TMDB 404 "resource not found", write `imdb_id = ''` (movies) or preserve existing `imdb_id`/`tvdb_id` (series) so the record is skipped on subsequent startups instead of retried indefinitely
- `captcha/+page.svelte`: remove Headless Mode toggle — the field remains in the data model defaulting to `true`, but exposing the toggle in the UI is misleading when the app is always deployed headless

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
N/A