### PR TITLE
 fix(import): populate naming tokens, preserve release groups, and resolve absolute episode numbers

### DIFF
--- a/src/lib/library/naming/types.ts
+++ b/src/lib/library/naming/types.ts
@@ -66,6 +66,7 @@ export interface RenameExecuteResult {
 		newPath: string;
 		error?: string;
 	}>;
+	warnings?: string[];
 }
 
 /**

--- a/src/lib/server/downloadClients/import/ImportService.ts
+++ b/src/lib/server/downloadClients/import/ImportService.ts
@@ -2193,13 +2193,20 @@ export class ImportService extends EventEmitter {
 
 		const namingInfo: MediaNamingInfo = {
 			title: movie.title,
+			originalTitle: movie.originalTitle ?? undefined,
 			year: movie.year ?? undefined,
 			tmdbId: movie.tmdbId,
 			imdbId: movie.imdbId ?? undefined,
+			collectionName: movie.collectionName ?? undefined,
 			...fromRelease,
 			bitDepth: mediaInfo?.videoBitDepth?.toString() ?? fromRelease.bitDepth,
 			audioCodec: mediaInfo?.audioCodec ?? fromRelease.audioCodec,
-			audioChannels: this.formatAudioChannels(mediaInfo?.audioChannels) ?? fromRelease.audioChannels
+			audioChannels:
+				this.formatAudioChannels(mediaInfo?.audioChannels) ?? fromRelease.audioChannels,
+			audioLanguages:
+				mediaInfo?.audioLanguages && mediaInfo.audioLanguages.length > 0
+					? mediaInfo.audioLanguages
+					: fromRelease.audioLanguages
 		};
 
 		return this.getNamingService().generateMovieFileName(namingInfo);
@@ -2229,8 +2236,11 @@ export class ImportService extends EventEmitter {
 		const namingInfo: MediaNamingInfo = {
 			...fromRelease,
 			title: seriesData.title,
+			originalTitle: seriesData.originalTitle ?? undefined,
 			year: seriesData.year ?? undefined,
+			tmdbId: seriesData.tmdbId ?? undefined,
 			tvdbId: seriesData.tvdbId ?? undefined,
+			imdbId: seriesData.imdbId ?? undefined,
 			seasonNumber: seasonNum,
 			episodeNumbers: episodeNums,
 			episodeTitle,
@@ -2240,7 +2250,12 @@ export class ImportService extends EventEmitter {
 			isDaily,
 			bitDepth: mediaInfo?.videoBitDepth?.toString() ?? fromRelease.bitDepth,
 			audioCodec: mediaInfo?.audioCodec ?? fromRelease.audioCodec,
-			audioChannels: this.formatAudioChannels(mediaInfo?.audioChannels) ?? fromRelease.audioChannels
+			audioChannels:
+				this.formatAudioChannels(mediaInfo?.audioChannels) ?? fromRelease.audioChannels,
+			audioLanguages:
+				mediaInfo?.audioLanguages && mediaInfo.audioLanguages.length > 0
+					? mediaInfo.audioLanguages
+					: fromRelease.audioLanguages
 		};
 
 		return this.getNamingService().generateEpisodeFileName(namingInfo);

--- a/src/lib/server/indexers/parser/patterns/releaseGroup.ts
+++ b/src/lib/server/indexers/parser/patterns/releaseGroup.ts
@@ -21,8 +21,8 @@ const GROUP_BLACKLIST = [
 	/^(web|webdl|webrip|bluray|brrip|bdrip|remux)-\d{3,4}p$/i,
 	// Codecs
 	/^(x264|x265|h264|h265|hevc|avc|av1|xvid|divx)$/i,
-	// Sources
-	/^(bluray|bdrip|brrip|webrip|webdl|hdtv|dvdrip|remux|web)$/i,
+	// Sources (including partial tokens that appear inside compound source names like WEB-DL)
+	/^(bluray|bdrip|brrip|webrip|webdl|hdtv|dvdrip|remux|web|dl|rip|br|bd)$/i,
 	// Audio
 	/^(aac|ac3|dts|truehd|atmos|flac|mp3|opus|dd|dd\+|ddp|5\.1|7\.1|2\.0)$/i,
 	// Common endings

--- a/src/lib/server/library/manual-import-service.ts
+++ b/src/lib/server/library/manual-import-service.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { basename, dirname, extname, join, relative, resolve } from 'node:path';
 import { readdir, stat, unlink } from 'node:fs/promises';
-import { eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db/index.js';
-import { movies, rootFolders, series, unmatchedFiles } from '$lib/server/db/schema.js';
+import { episodes, movies, rootFolders, series, unmatchedFiles } from '$lib/server/db/schema.js';
 import { tmdb } from '$lib/server/tmdb.js';
 import { createChildLogger } from '$lib/logging';
 
@@ -568,7 +568,10 @@ export class ManualImportService {
 				throw new Error('Cannot import to read-only root folder');
 			}
 
-			const episodeTitleCache = new Map<number, Map<number, string | undefined>>();
+			const episodeMetaCache = new Map<
+				number,
+				Map<number, { title?: string; absoluteNumber?: number; airDate?: string }>
+			>();
 			const tvFiles = this.selectTvSourceFiles(sourceFiles);
 			const destinationSet = new Set<string>();
 
@@ -588,11 +591,13 @@ export class ManualImportService {
 					);
 				}
 
-				const episodeTitle = await this.getEpisodeTitleCached(
+				const episodeMeta = await this.getEpisodeMetaCached(
 					request.tmdbId,
 					fileMapping.seasonNumber,
 					fileMapping.episodeNumber,
-					episodeTitleCache
+					episodeMetaCache,
+					tvContext.existingSeriesDbId,
+					tvContext.tmdbSeriesSeasons
 				);
 				const namingInfo = await this.buildEpisodeNamingInfo(
 					sourceFile.path,
@@ -600,7 +605,9 @@ export class ManualImportService {
 					tvContext.namingInfoBase,
 					fileMapping.seasonNumber,
 					fileMapping.episodeNumber,
-					episodeTitle
+					episodeMeta.title,
+					episodeMeta.absoluteNumber,
+					episodeMeta.airDate
 				);
 				const destinationPath = this.buildEpisodeDestinationPath(
 					rootFolder.path,
@@ -763,9 +770,11 @@ export class ManualImportService {
 				.select({
 					id: movies.id,
 					title: movies.title,
+					originalTitle: movies.originalTitle,
 					year: movies.year,
 					path: movies.path,
 					imdbId: movies.imdbId,
+					collectionName: movies.collectionName,
 					rootFolderId: movies.rootFolderId
 				})
 				.from(movies)
@@ -795,9 +804,11 @@ export class ManualImportService {
 				folderName: movie.path,
 				namingInfoBase: {
 					title: movie.title,
+					originalTitle: movie.originalTitle ?? undefined,
 					year: movie.year ?? undefined,
 					tmdbId: request.tmdbId,
-					imdbId: movie.imdbId ?? undefined
+					imdbId: movie.imdbId ?? undefined,
+					collectionName: movie.collectionName ?? undefined
 				}
 			};
 		}
@@ -847,9 +858,11 @@ export class ManualImportService {
 			folderName,
 			namingInfoBase: {
 				title: tmdbMovie.title,
+				originalTitle: tmdbMovie.original_title || undefined,
 				year,
 				tmdbId: request.tmdbId,
-				imdbId: externalIds.imdb_id ?? undefined
+				imdbId: externalIds.imdb_id ?? undefined,
+				collectionName: tmdbMovie.belongs_to_collection?.name ?? undefined
 			}
 		};
 	}
@@ -859,12 +872,15 @@ export class ManualImportService {
 		seriesFolderName: string;
 		useSeasonFolders: boolean;
 		namingInfoBase: MediaNamingInfo;
+		existingSeriesDbId?: string;
+		tmdbSeriesSeasons?: Array<{ season_number: number; episode_count: number }>;
 	}> {
 		if (request.importTarget === 'existing') {
 			const [show] = await db
 				.select({
 					id: series.id,
 					title: series.title,
+					originalTitle: series.originalTitle,
 					year: series.year,
 					path: series.path,
 					imdbId: series.imdbId,
@@ -899,8 +915,10 @@ export class ManualImportService {
 				rootFolder,
 				seriesFolderName: show.path,
 				useSeasonFolders: show.seasonFolder ?? true,
+				existingSeriesDbId: show.id,
 				namingInfoBase: {
 					title: show.title,
+					originalTitle: show.originalTitle ?? undefined,
 					year: show.year ?? undefined,
 					tmdbId: request.tmdbId,
 					tvdbId: show.tvdbId ?? undefined,
@@ -957,13 +975,15 @@ export class ManualImportService {
 			rootFolder,
 			seriesFolderName,
 			useSeasonFolders: true,
+			tmdbSeriesSeasons: tvShow.seasons,
 			namingInfoBase: {
 				title: tvShow.name,
+				originalTitle: tvShow.original_name || undefined,
 				year,
 				tmdbId: request.tmdbId,
 				tvdbId: externalIds.tvdb_id ?? undefined,
 				imdbId: externalIds.imdb_id ?? undefined,
-				isAnime: isAnimeMedia
+				isAnime: rootFolder.mediaSubType === 'anime' || isAnimeMedia
 			}
 		};
 	}
@@ -987,35 +1007,95 @@ export class ManualImportService {
 		throw new Error('Destination library is required for new imports');
 	}
 
-	private async getEpisodeTitle(
-		tmdbId: number,
-		seasonNumber: number,
-		episodeNumber: number
-	): Promise<string | undefined> {
-		try {
-			const tmdbSeason = await tmdb.getSeason(tmdbId, seasonNumber);
-			return tmdbSeason.episodes?.find((ep) => ep.episode_number === episodeNumber)?.name;
-		} catch {
-			return undefined;
-		}
-	}
-
-	private async getEpisodeTitleCached(
+	private async getEpisodeMeta(
 		tmdbId: number,
 		seasonNumber: number,
 		episodeNumber: number,
-		cache: Map<number, Map<number, string | undefined>>
-	): Promise<string | undefined> {
-		const cachedSeason = cache.get(seasonNumber);
-		if (cachedSeason && cachedSeason.has(episodeNumber)) {
-			return cachedSeason.get(episodeNumber);
+		existingSeriesDbId?: string,
+		tmdbSeriesSeasons?: Array<{ season_number: number; episode_count: number }>
+	): Promise<{ title?: string; absoluteNumber?: number; airDate?: string }> {
+		let absoluteNumber: number | undefined;
+
+		if (existingSeriesDbId) {
+			// Walk all episodes in order (same algorithm as RenamePreviewService.buildAbsoluteEpisodeFallbackMap)
+			// so null absolute numbers are filled in sequentially rather than dropped.
+			const allEps = await db
+				.select({
+					seasonNumber: episodes.seasonNumber,
+					episodeNumber: episodes.episodeNumber,
+					absoluteEpisodeNumber: episodes.absoluteEpisodeNumber
+				})
+				.from(episodes)
+				.where(and(eq(episodes.seriesId, existingSeriesDbId), gt(episodes.seasonNumber, 0)))
+				.orderBy(asc(episodes.seasonNumber), asc(episodes.episodeNumber));
+
+			let lastAbsolute = 0;
+			for (const ep of allEps) {
+				if (ep.absoluteEpisodeNumber != null && ep.absoluteEpisodeNumber > 0) {
+					lastAbsolute = ep.absoluteEpisodeNumber;
+				} else {
+					lastAbsolute++;
+				}
+				if (ep.seasonNumber === seasonNumber && ep.episodeNumber === episodeNumber) {
+					absoluteNumber = lastAbsolute;
+					break;
+				}
+			}
 		}
 
-		const episodeTitle = await this.getEpisodeTitle(tmdbId, seasonNumber, episodeNumber);
-		const seasonCache = cache.get(seasonNumber) ?? new Map<number, string | undefined>();
-		seasonCache.set(episodeNumber, episodeTitle);
+		try {
+			const tmdbSeason = await tmdb.getSeason(tmdbId, seasonNumber);
+			const ep = tmdbSeason.episodes?.find((e) => e.episode_number === episodeNumber);
+
+			// For new series: TMDB absolute_episode_number is the primary source.
+			// If absent, compute from the series season list (already fetched with the show).
+			if (absoluteNumber === undefined) {
+				absoluteNumber = ep?.absolute_episode_number ?? undefined;
+
+				if (absoluteNumber === undefined && tmdbSeriesSeasons) {
+					const priorEpisodeCount = tmdbSeriesSeasons
+						.filter((s) => s.season_number > 0 && s.season_number < seasonNumber)
+						.reduce((sum, s) => sum + s.episode_count, 0);
+					absoluteNumber = priorEpisodeCount + episodeNumber;
+				}
+			}
+
+			return {
+				title: ep?.name,
+				absoluteNumber,
+				airDate: ep?.air_date || undefined
+			};
+		} catch {
+			return { absoluteNumber };
+		}
+	}
+
+	private async getEpisodeMetaCached(
+		tmdbId: number,
+		seasonNumber: number,
+		episodeNumber: number,
+		cache: Map<number, Map<number, { title?: string; absoluteNumber?: number; airDate?: string }>>,
+		existingSeriesDbId?: string,
+		tmdbSeriesSeasons?: Array<{ season_number: number; episode_count: number }>
+	): Promise<{ title?: string; absoluteNumber?: number; airDate?: string }> {
+		const cachedSeason = cache.get(seasonNumber);
+		if (cachedSeason?.has(episodeNumber)) {
+			return cachedSeason.get(episodeNumber)!;
+		}
+
+		const meta = await this.getEpisodeMeta(
+			tmdbId,
+			seasonNumber,
+			episodeNumber,
+			existingSeriesDbId,
+			tmdbSeriesSeasons
+		);
+		const seasonCache =
+			cache.get(seasonNumber) ??
+			new Map<number, { title?: string; absoluteNumber?: number; airDate?: string }>();
+		seasonCache.set(episodeNumber, meta);
 		cache.set(seasonNumber, seasonCache);
-		return episodeTitle;
+		return meta;
 	}
 
 	private async resolveDetectionGroupPaths(pathValue: string): Promise<string[]> {
@@ -1466,7 +1546,9 @@ export class ManualImportService {
 		namingInfoBase: MediaNamingInfo,
 		seasonNumber: number,
 		episodeNumber: number,
-		episodeTitle?: string
+		episodeTitle?: string,
+		absoluteNumber?: number,
+		airDate?: string
 	): Promise<MediaNamingInfo> {
 		const probedInfo = await this.probeMediaInfoForNaming(sourceFilePath);
 		return this.enrichNamingInfo(
@@ -1474,7 +1556,9 @@ export class ManualImportService {
 				...namingInfoBase,
 				seasonNumber,
 				episodeNumbers: [episodeNumber],
-				episodeTitle
+				episodeTitle,
+				absoluteNumber,
+				airDate
 			},
 			parsed,
 			sourceFilePath,
@@ -1487,8 +1571,10 @@ export class ManualImportService {
 		height?: number;
 		videoCodec?: string;
 		videoHdrFormat?: string;
+		videoBitDepth?: number;
 		audioCodec?: string;
 		audioChannels?: number;
+		audioLanguages?: string[];
 	} | null> {
 		try {
 			return await mediaInfoService.extractMediaInfo(sourceFilePath, { allowStrmProbe: true });
@@ -1513,8 +1599,10 @@ export class ManualImportService {
 			height?: number;
 			videoCodec?: string;
 			videoHdrFormat?: string;
+			videoBitDepth?: number;
 			audioCodec?: string;
 			audioChannels?: number;
+			audioLanguages?: string[];
 		} | null
 	): MediaNamingInfo {
 		const parsedNamingInfo = releaseToNamingInfo(parsed, sourceFilePath);
@@ -1522,8 +1610,10 @@ export class ManualImportService {
 		const parsedResolution = this.normalizeMetadataToken(parsedNamingInfo.resolution);
 		const parsedCodec = this.normalizeMetadataToken(parsedNamingInfo.codec);
 		const parsedHdr = this.normalizeMetadataToken(parsedNamingInfo.hdr);
+		const parsedBitDepth = this.normalizeMetadataToken(parsedNamingInfo.bitDepth);
 		const parsedAudioCodec = this.normalizeMetadataToken(parsedNamingInfo.audioCodec);
 		const parsedAudioChannels = this.normalizeMetadataToken(parsedNamingInfo.audioChannels);
+		const parsedReleaseGroup = this.normalizeMetadataToken(parsedNamingInfo.releaseGroup);
 
 		return {
 			...parsedNamingInfo,
@@ -1531,11 +1621,22 @@ export class ManualImportService {
 			resolution: parsedResolution ?? this.mapMediaInfoResolution(probedInfo),
 			codec: parsedCodec ?? this.mapMediaInfoCodec(probedInfo?.videoCodec),
 			hdr: parsedHdr ?? this.mapMediaInfoHdr(probedInfo?.videoHdrFormat),
+			bitDepth: parsedBitDepth ?? this.mapMediaInfoBitDepth(probedInfo?.videoBitDepth),
 			audioCodec: parsedAudioCodec ?? this.normalizeMetadataToken(probedInfo?.audioCodec),
 			audioChannels:
 				parsedAudioChannels ?? this.mapMediaInfoAudioChannels(probedInfo?.audioChannels),
+			audioLanguages:
+				probedInfo?.audioLanguages && probedInfo.audioLanguages.length > 0
+					? probedInfo.audioLanguages
+					: parsedNamingInfo.audioLanguages,
+			releaseGroup: parsedReleaseGroup,
 			originalExtension: extname(sourceFilePath)
 		};
+	}
+
+	private mapMediaInfoBitDepth(bitDepth?: number): string | undefined {
+		if (!bitDepth || bitDepth <= 0) return undefined;
+		return `${bitDepth}`;
 	}
 
 	private normalizeMetadataToken(value?: string | null): string | undefined {

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -834,7 +834,12 @@ export class MediaMatcherService {
 
 		// Parse quality from the original filename (preserves quality markers)
 		const originalFilename = basename(file.path, extname(file.path));
-		const parsedQuality = parseRelease(originalFilename);
+		// Strip trailing brackets containing non-ASCII chars (e.g. OriginalTitle suffix) before
+		// parsing so the release group immediately preceding them is detected correctly
+		const parseableFilename = originalFilename
+			.replace(/(\s*\[[^\]]*\P{ASCII}[^\]]*\])+$/u, '')
+			.trim();
+		const parsedQuality = parseRelease(parseableFilename || originalFilename);
 
 		// Create movie file entry with proper sceneName, releaseGroup, and quality data
 		await db.insert(movieFiles).values({
@@ -1174,7 +1179,12 @@ export class MediaMatcherService {
 
 		// Parse quality from the original filename (preserves quality markers)
 		const originalFilename = basename(file.path, extname(file.path));
-		const parsedQuality = parseRelease(originalFilename);
+		// Strip trailing brackets containing non-ASCII chars (e.g. OriginalTitle suffix) before
+		// parsing so the release group immediately preceding them is detected correctly
+		const parseableFilename = originalFilename
+			.replace(/(\s*\[[^\]]*\P{ASCII}[^\]]*\])+$/u, '')
+			.trim();
+		const parsedQuality = parseRelease(parseableFilename || originalFilename);
 
 		// Create/update episode file entry with proper sceneName, releaseGroup, and quality data
 		await this.upsertEpisodeFileByPath({

--- a/src/lib/server/library/naming/NamingService.ts
+++ b/src/lib/server/library/naming/NamingService.ts
@@ -337,7 +337,9 @@ export function releaseToNamingInfo(
 		releaseGroup?: string;
 		isProper?: boolean;
 		isRepack?: boolean;
+		is3d?: boolean;
 		edition?: string;
+		languages?: string[];
 		episode?: { season?: number; episodes?: number[]; absoluteEpisode?: number };
 	},
 	originalPath?: string
@@ -350,9 +352,11 @@ export function releaseToNamingInfo(
 		bitDepth: parsed.bitDepth !== 'unknown' ? (parsed.bitDepth ?? undefined) : undefined,
 		audioCodec: parsed.audioCodec ?? undefined,
 		audioChannels: parsed.audioChannels !== 'unknown' ? parsed.audioChannels : undefined,
+		audioLanguages: parsed.languages && parsed.languages.length > 0 ? parsed.languages : undefined,
 		releaseGroup: parsed.releaseGroup,
 		proper: parsed.isProper,
 		repack: parsed.isRepack,
+		is3D: parsed.is3d,
 		edition: parsed.edition,
 		seasonNumber: parsed.episode?.season,
 		episodeNumbers: parsed.episode?.episodes,

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -390,7 +390,8 @@ export class RenamePreviewService {
 			processed: 0,
 			succeeded: 0,
 			failed: 0,
-			results: []
+			results: [],
+			warnings: []
 		};
 
 		if (fileIds.length === 0) {
@@ -487,12 +488,21 @@ export class RenamePreviewService {
 					return matched?.success && item.currentParentPath !== item.newParentPath;
 				});
 				if (successfulFolderChange && firstItem) {
-					await this.applyFolderRename(
+					const originalStem = basename(
+						successfulFolderChange.currentFullPath,
+						extname(successfulFolderChange.currentFullPath)
+					);
+					const folderWarnings = await this.applyFolderRename(
 						mediaId,
 						firstItem.mediaType as 'movie' | 'episode',
 						successfulFolderChange.currentParentPath,
-						successfulFolderChange.newParentPath
+						successfulFolderChange.newParentPath,
+						originalStem
 					);
+					if (folderWarnings.length > 0) {
+						result.warnings ??= [];
+						result.warnings.push(...folderWarnings);
+					}
 				}
 
 				return groupResult;
@@ -1057,12 +1067,32 @@ export class RenamePreviewService {
 	 * 2. Move any remaining files (artwork, nfo, subtitles, etc.) from the old folder to the new one.
 	 * 3. Remove the old folder tree if it is now empty.
 	 */
+	// Extensions that identify companion files (artwork, metadata, subtitles).
+	// Used for stem-matched carry when the media file lives in the root folder.
+	private static readonly COMPANION_EXTENSIONS = new Set([
+		'.nfo',
+		'.jpg',
+		'.jpeg',
+		'.png',
+		'.webp',
+		'.tbn',
+		'.srt',
+		'.sub',
+		'.ass',
+		'.ssa',
+		'.vtt',
+		'.sup',
+		'.idx'
+	]);
+
 	private async applyFolderRename(
 		mediaId: string,
 		mediaType: 'movie' | 'episode',
 		oldParentPath: string,
-		newParentPath: string
-	): Promise<void> {
+		newParentPath: string,
+		originalFileStem: string
+	): Promise<string[]> {
+		const warnings: string[] = [];
 		try {
 			let rootFolderId: string | undefined;
 			if (mediaType === 'movie') {
@@ -1072,18 +1102,19 @@ export class RenamePreviewService {
 				const show = db.select().from(series).where(eq(series.id, mediaId)).get();
 				rootFolderId = show?.rootFolderId ?? undefined;
 			}
-			if (!rootFolderId) return;
+			if (!rootFolderId) return warnings;
 
 			const rootFolder = db
 				.select()
 				.from(rootFolders)
 				.where(eq(rootFolders.id, rootFolderId))
 				.get();
-			if (!rootFolder) return;
+			if (!rootFolder) return warnings;
 
 			const rootFolderPath = rootFolder.path;
 			const oldFolder = join(rootFolderPath, oldParentPath);
 			const newFolder = join(rootFolderPath, newParentPath);
+			const isRootFolder = resolve(oldFolder) === resolve(rootFolderPath);
 
 			// 1. Update DB path record so the library entry shows the correct folder.
 			if (mediaType === 'movie') {
@@ -1093,32 +1124,66 @@ export class RenamePreviewService {
 			}
 
 			logger.info(
-				{ mediaId, mediaType, from: oldFolder, to: newFolder },
+				{ mediaId, mediaType, from: oldFolder, to: newFolder, isRootFolder },
 				'[RenamePreviewService] Folder path updated in DB after file renames'
 			);
 
-			// 2. Move any remaining files from the old folder root to the new folder root.
-			// These are extra files (artwork, nfo, subs) not covered by the file renames.
+			// 2. Move companion files from the old folder to the new folder.
+			// When the media file is in a dedicated subfolder, carry everything (the
+			// whole folder belongs to this title). When it is in the root folder,
+			// only carry files whose names start with the original media file's stem
+			// to avoid carrying unrelated files into this title's new subfolder.
 			try {
 				const entries = await readdir(oldFolder, { withFileTypes: true });
+				const unmatchedCompanions: string[] = [];
+
 				for (const entry of entries) {
 					if (!entry.isFile()) continue;
+
+					if (isRootFolder) {
+						const entryStem = basename(entry.name, extname(entry.name));
+						const entryExt = extname(entry.name).toLowerCase();
+						const stemMatches = entryStem.startsWith(originalFileStem);
+
+						if (!stemMatches) {
+							// Track companion-extension files we couldn't safely match.
+							if (RenamePreviewService.COMPANION_EXTENSIONS.has(entryExt)) {
+								unmatchedCompanions.push(entry.name);
+							}
+							continue;
+						}
+					}
+
 					const src = join(oldFolder, entry.name);
 					const dest = join(newFolder, entry.name);
-					if (await fileExists(dest)) continue; // don't overwrite
+					if (await fileExists(dest)) continue;
 					try {
 						await rename(src, dest);
 					} catch {
-						// Cross-device: fall back to copy+delete via moveFile
 						await moveFile(src, dest);
 					}
+				}
+
+				if (unmatchedCompanions.length > 0) {
+					warnings.push(
+						`Some companion files could not be automatically matched to "${originalFileStem}" ` +
+							`and were left in the root folder: ${unmatchedCompanions.join(', ')}. ` +
+							`Move them manually if needed.`
+					);
+					logger.info(
+						{ mediaId, unmatchedCompanions },
+						'[RenamePreviewService] Unmatched companion files left in root folder'
+					);
 				}
 			} catch {
 				// Old folder may not exist or be unreadable — not fatal.
 			}
 
 			// 3. Remove the old folder tree if empty (handles empty season subfolders for series).
-			await this.tryRemoveEmptyDir(oldFolder);
+			// Skip when the old folder is the root — never remove the root folder.
+			if (!isRootFolder) {
+				await this.tryRemoveEmptyDir(oldFolder);
+			}
 		} catch (error) {
 			logger.warn(
 				{
@@ -1129,6 +1194,7 @@ export class RenamePreviewService {
 				'[RenamePreviewService] applyFolderRename cleanup failed (non-fatal)'
 			);
 		}
+		return warnings;
 	}
 
 	/**

--- a/src/lib/types/tmdb.d.ts
+++ b/src/lib/types/tmdb.d.ts
@@ -154,6 +154,7 @@ export interface MovieDetails extends Omit<Movie, 'genre_ids'> {
 export interface Episode {
 	air_date: string;
 	episode_number: number;
+	absolute_episode_number?: number;
 	id: number;
 	name: string;
 	overview: string;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,8 +39,10 @@
 		FolderCog,
 		Ban,
 		Globe,
-		Palette
+		Palette,
+		Pin
 	} from 'lucide-svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	const GITHUB_URL = 'https://github.com/MoldyTaint/Cinephage';
 	const DISCORD_URL = 'https://discord.gg/scGCBTSWEt';
@@ -80,7 +82,9 @@
 	let isMobileDrawerOpen = $state(false);
 	let isLoggingOut = $state(false);
 	let expandedMenuSection = $state<string | null>(null);
+	let pinnedMenuSections = $state<Set<string>>(new Set());
 	const SIDEBAR_EXPANDED_STORAGE_KEY = 'cinephage.sidebar.expanded';
+	const PINNED_SECTIONS_STORAGE_KEY = 'cinephage.sidebar.pinned';
 
 	function usesFocusedLayout(pathname: string): boolean {
 		return (
@@ -142,7 +146,28 @@
 
 	function handleSubmenuToggle(item: MenuItem): void {
 		const key = getMenuSectionKey(item);
+		if (pinnedMenuSections.has(key)) {
+			// Clicking a pinned section un-pins and collapses it
+			togglePinnedSection(key);
+			expandedMenuSection = null;
+			return;
+		}
 		expandedMenuSection = expandedMenuSection === key ? null : key;
+	}
+
+	function togglePinnedSection(key: string): void {
+		const next = new SvelteSet(pinnedMenuSections);
+		if (next.has(key)) {
+			next.delete(key);
+		} else {
+			next.add(key);
+			// Ensure the section is visually open immediately
+			expandedMenuSection = key;
+		}
+		pinnedMenuSections = next;
+		if (browser) {
+			localStorage.setItem(PINNED_SECTIONS_STORAGE_KEY, JSON.stringify([...next]));
+		}
 	}
 
 	function openFooterDropdownOnExpand(type: 'language' | 'theme'): void {
@@ -356,6 +381,17 @@
 		if (stored === 'true' || stored === 'false') {
 			layoutState.isSidebarExpanded = stored === 'true';
 		}
+		const storedPinned = localStorage.getItem(PINNED_SECTIONS_STORAGE_KEY);
+		if (storedPinned) {
+			try {
+				const keys = JSON.parse(storedPinned);
+				if (Array.isArray(keys)) {
+					pinnedMenuSections = new Set(keys as string[]);
+				}
+			} catch {
+				// ignore malformed data
+			}
+		}
 	});
 
 	$effect(() => {
@@ -507,8 +543,10 @@
 							<li class={layoutState.isSidebarExpanded ? 'w-full' : 'mx-auto w-11'}>
 								{#if item.children}
 									{#if layoutState.isSidebarExpanded}
+										{@const sectionKey = getMenuSectionKey(item)}
+										{@const isPinned = pinnedMenuSections.has(sectionKey)}
 										<details
-											open={isItemActive(item) || expandedMenuSection === getMenuSectionKey(item)}
+											open={isItemActive(item) || expandedMenuSection === sectionKey || isPinned}
 											class="group/nav-section"
 										>
 											<summary
@@ -521,8 +559,23 @@
 											>
 												<item.icon class="h-4.5 w-4.5 shrink-0" />
 												<span class="truncate">{item.label()}</span>
+												<button
+													type="button"
+													class="ml-auto rounded p-0.5 transition-all {isPinned
+														? 'text-primary opacity-90'
+														: 'opacity-0 group-hover/nav-section:opacity-40 hover:opacity-70!'}"
+													title={isPinned ? 'Unpin menu' : 'Pin menu open'}
+													onclick={(event) => {
+														event.stopPropagation();
+														togglePinnedSection(sectionKey);
+													}}
+												>
+													<Pin class="h-3 w-3 {isPinned ? 'fill-primary' : ''}" />
+												</button>
 												<ChevronDown
-													class="nav-chevron h-4 w-4 shrink-0 text-base-content/60 transition-transform duration-200 group-open/nav-section:rotate-180"
+													class="nav-chevron h-4 w-4 shrink-0 text-base-content/60 transition-transform duration-200 group-open/nav-section:rotate-180 {isPinned
+														? 'opacity-30'
+														: ''}"
 												/>
 											</summary>
 											<ul>

--- a/src/routes/settings/library/naming/rename/+page.svelte
+++ b/src/routes/settings/library/naming/rename/+page.svelte
@@ -28,6 +28,7 @@
 	let reorganizing = $state(false);
 	let error = $state<string | null>(null);
 	let success = $state<string | null>(null);
+	let renameWarnings = $state<string[]>([]);
 	let preview = $state<RenamePreviewResult | null>(null);
 	let executeResult = $state<RenameExecuteResult | null>(null);
 
@@ -80,6 +81,7 @@
 		executing = true;
 		error = null;
 		success = null;
+		renameWarnings = [];
 
 		try {
 			const response = await executeRename(
@@ -92,6 +94,10 @@
 			}
 
 			executeResult = response as unknown as RenameExecuteResult;
+
+			if (executeResult?.warnings?.length) {
+				renameWarnings = executeResult.warnings;
+			}
 
 			if (executeResult && executeResult.succeeded > 0) {
 				success = m.settings_naming_rename_successCount({ count: executeResult.succeeded });
@@ -281,6 +287,17 @@
 		<div class="mb-4 alert alert-success">
 			<CheckCircle class="h-5 w-5" />
 			<span>{success}</span>
+		</div>
+	{/if}
+
+	{#if renameWarnings.length > 0}
+		<div class="mb-4 space-y-2">
+			{#each renameWarnings as warning (warning)}
+				<div class="alert alert-warning">
+					<AlertTriangle class="h-5 w-5 shrink-0" />
+					<span class="text-sm">{warning}</span>
+				</div>
+			{/each}
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

Fixes several gaps in the manual import and triggered-download import flows where naming tokens were not being populated, causing incorrect file names and inconsistent rename previews.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
Discord:
[File renaming issues with existing Library items](https://discord.com/channels/1449917989561303165/1526506609205968916)
[QOL Improvements - Pin Menus](https://discord.com/channels/1449917989561303165/1527001791470768148)
[Naming settings from Library & Storage > Naming is not applied to Anime. > The standard episode setting is used.](https://discord.com/channels/1449917989561303165/1522594343079248003/1526526317510529045)


## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Populate all missing naming tokens during manual import: `{OriginalTitle}`, `{CollectionName}`, `{AirDate}`, `{AudioLanguages}`, and `{3D}` now sourced from DB, TMDB, FFprobe, and the release title parser
- Resolve absolute episode number reliably: existing series walk the DB in order (replicating the rename service fallback algorithm); new series fall back to summing prior season episode counts from TMDB (no extra API calls)
- Fix anime template not applying during manual import: destination root folder `mediaSubType === 'anime'` now takes priority over TMDB detection for the `isAnime` flag
- Preserve release group when the filename ends with a non-ASCII `{OriginalTitle}` bracket: strip trailing non-ASCII brackets before passing to `parseRelease` in `media-matcher.ts` (episode and movie paths); `sceneName` in DB still stores the full filename
- Map `parsed.languages` in `releaseToNamingInfo` as `audioLanguages` fallback for `.strm` files and other cases where the media probe cannot determine audio languages
- Add pin button to sidebar submenus to keep sections open across navigation (persisted to `localStorage`)
- Fix rename sweep incorrectly moving all files when media lives directly in the root folder; carry only stem-matched companions and surface unattributable files as warnings

## Areas Affected

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
N/A