### PR TITLE
fix: library scan stability, smart list pagination, collection management, and monitoring UX

### DIFF
--- a/src/lib/components/library/CollectionPickerModal.svelte
+++ b/src/lib/components/library/CollectionPickerModal.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+	import { X, Search, Layers, RefreshCw, Trash2 } from 'lucide-svelte';
+	import { createFocusTrap, lockBodyScroll } from '$lib/utils/focus';
+
+	interface CollectionResult {
+		id: number;
+		name: string;
+		poster_path: string | null;
+		backdrop_path: string | null;
+		overview: string;
+	}
+
+	interface Props {
+		open: boolean;
+		/** Required when onPicked is not provided (standalone save mode). */
+		movieId?: string;
+		currentCollectionId: number | null;
+		currentCollectionName: string | null;
+		onClose: () => void;
+		/** Standalone mode: saves to API and calls onUpdated. */
+		onUpdated?: (collectionId: number | null, collectionName: string | null) => void;
+		/** Picker mode: skips API call, passes selection back to parent. */
+		onPicked?: (collectionId: number | null, collectionName: string | null) => void;
+	}
+
+	let {
+		open,
+		movieId,
+		currentCollectionId,
+		currentCollectionName,
+		onClose,
+		onUpdated,
+		onPicked
+	}: Props = $props();
+
+	let query = $state('');
+	let results = $state<CollectionResult[]>([]);
+	let searching = $state(false);
+	let saving = $state(false);
+	let error = $state<string | null>(null);
+	let modalRef = $state<HTMLElement | null>(null);
+	let searchInputRef = $state<HTMLInputElement | null>(null);
+	let cleanupFocusTrap: (() => void) | null = null;
+	let cleanupScrollLock: (() => void) | null = null;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	$effect(() => {
+		if (!open) {
+			query = '';
+			results = [];
+			error = null;
+		}
+	});
+
+	$effect(() => {
+		if (open && modalRef) {
+			cleanupScrollLock = lockBodyScroll();
+			cleanupFocusTrap = createFocusTrap(modalRef);
+			searchInputRef?.focus();
+		}
+		return () => {
+			if (cleanupFocusTrap) {
+				cleanupFocusTrap();
+				cleanupFocusTrap = null;
+			}
+			if (cleanupScrollLock) {
+				cleanupScrollLock();
+				cleanupScrollLock = null;
+			}
+		};
+	});
+
+	function handleQueryInput() {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		const q = query.trim();
+		if (!q) {
+			results = [];
+			return;
+		}
+		debounceTimer = setTimeout(() => doSearch(q), 350);
+	}
+
+	async function doSearch(q: string) {
+		searching = true;
+		error = null;
+		try {
+			const res = await fetch(`/api/tmdb/collection/search?q=${encodeURIComponent(q)}`);
+			if (!res.ok) throw new Error(await res.text());
+			results = await res.json();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Search failed';
+		} finally {
+			searching = false;
+		}
+	}
+
+	async function selectCollection(col: CollectionResult) {
+		await applyCollection(col.id, col.name);
+	}
+
+	async function clearCollection() {
+		await applyCollection(null, null);
+	}
+
+	async function applyCollection(collectionId: number | null, collectionName: string | null) {
+		if (onPicked) {
+			onPicked(collectionId, collectionName);
+			onClose();
+			return;
+		}
+
+		saving = true;
+		error = null;
+		try {
+			const res = await fetch(`/api/library/movies/${movieId}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ tmdbCollectionId: collectionId, collectionName })
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				throw new Error(body.error ?? 'Failed to update collection');
+			}
+			onUpdated?.(collectionId, collectionName);
+			onClose();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to save';
+		} finally {
+			saving = false;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			onClose();
+		}
+	}
+</script>
+
+{#if open}
+	<div class="fixed inset-0 z-50 bg-black/50" onclick={onClose} role="presentation"></div>
+
+	<div class="pointer-events-none fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div
+			bind:this={modalRef}
+			class="pointer-events-auto flex max-h-[80vh] w-full max-w-lg flex-col rounded-xl bg-base-100 shadow-2xl"
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={handleKeydown}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="collection-picker-title"
+			tabindex="0"
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between border-b border-base-300 p-4">
+				<div class="flex items-center gap-3">
+					<Layers class="h-5 w-5 text-primary" />
+					<h2 id="collection-picker-title" class="text-lg font-semibold">Set Collection</h2>
+				</div>
+				<button class="btn btn-square btn-ghost btn-sm" onclick={onClose} aria-label="Close">
+					<X class="h-5 w-5" />
+				</button>
+			</div>
+
+			<!-- Content -->
+			<div class="flex flex-1 flex-col gap-3 overflow-hidden p-4">
+				<!-- Current collection -->
+				{#if currentCollectionName}
+					<div
+						class="flex items-center justify-between rounded-lg border border-base-300 bg-base-200 px-3 py-2 text-sm"
+					>
+						<div class="flex items-center gap-2 min-w-0">
+							<Layers class="h-4 w-4 shrink-0 text-primary" />
+							<span class="truncate font-medium">{currentCollectionName}</span>
+							<span class="badge badge-xs badge-ghost shrink-0">current</span>
+						</div>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs ml-2 shrink-0 text-error"
+							disabled={saving}
+							onclick={clearCollection}
+							title="Remove collection assignment"
+						>
+							<Trash2 class="h-3.5 w-3.5" />
+							Clear
+						</button>
+					</div>
+				{/if}
+
+				<!-- Search input -->
+				<div class="form-control relative">
+					<Search
+						class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40"
+					/>
+					{#if searching}
+						<RefreshCw
+							class="pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin text-base-content/40"
+						/>
+					{/if}
+					<input
+						type="text"
+						placeholder="Search TMDB collections..."
+						class="input input-bordered w-full pl-9 pr-9"
+						bind:this={searchInputRef}
+						bind:value={query}
+						oninput={handleQueryInput}
+					/>
+				</div>
+
+				{#if error}
+					<div class="alert alert-error py-2 text-sm">{error}</div>
+				{/if}
+
+				<!-- Results -->
+				<div class="min-h-0 flex-1 overflow-y-auto">
+					{#if results.length === 0 && query.trim() && !searching}
+						<p class="py-8 text-center text-sm text-base-content/50">No collections found</p>
+					{:else if results.length === 0 && !query.trim()}
+						<p class="py-8 text-center text-sm text-base-content/50">
+							Type to search for a collection
+						</p>
+					{:else}
+						<ul class="space-y-2">
+							{#each results as col (col.id)}
+								{@const isCurrent = col.id === currentCollectionId}
+								<li>
+									<button
+										type="button"
+										class="flex w-full items-center gap-3 rounded-lg border border-base-300 bg-base-100 p-2 text-left transition-colors hover:border-primary hover:bg-base-200 disabled:opacity-50"
+										class:border-primary={isCurrent}
+										class:bg-base-200={isCurrent}
+										disabled={saving}
+										onclick={() => selectCollection(col)}
+									>
+										<div class="h-16 w-11 shrink-0 overflow-hidden rounded bg-base-300">
+											{#if col.poster_path}
+												<img
+													src="https://image.tmdb.org/t/p/w92{col.poster_path}"
+													alt={col.name}
+													class="h-full w-full object-cover"
+													loading="lazy"
+												/>
+											{:else}
+												<div class="flex h-full w-full items-center justify-center">
+													<Layers class="h-5 w-5 text-base-content/20" />
+												</div>
+											{/if}
+										</div>
+										<div class="min-w-0 flex-1">
+											<p class="truncate font-medium text-sm">{col.name}</p>
+											{#if col.overview}
+												<p class="mt-0.5 line-clamp-2 text-xs text-base-content/60">
+													{col.overview}
+												</p>
+											{/if}
+										</div>
+										{#if isCurrent}
+											<span class="badge badge-primary badge-sm shrink-0">current</span>
+										{/if}
+									</button>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Footer -->
+			<div class="border-t border-base-300 p-4">
+				<button class="btn btn-ghost w-full" onclick={onClose}>Cancel</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { X, FolderOpen } from 'lucide-svelte';
+	import { X, FolderOpen, Layers, Pencil, Trash2, Search, RefreshCw } from 'lucide-svelte';
 	import { FolderBrowser, DesiredQualitiesPicker } from '$lib/components/library';
 	import type { LibraryMovie, DesiredQuality } from '$lib/types/library';
 	import { ModalWrapper, ModalFooter } from '$lib/components/ui/modal';
@@ -60,6 +60,8 @@
 		wantsSubtitles: boolean;
 		folderPath?: string;
 		removeUnwantedFiles?: boolean;
+		tmdbCollectionId?: number | null;
+		collectionName?: string | null;
 	}
 
 	let { open, movie, qualityProfiles, delayProfiles, rootFolders, saving, onClose, onSave }: Props =
@@ -79,6 +81,15 @@
 	let removeUnwantedFiles = $state(false);
 	let folderPath = $state('');
 	let showFolderPicker = $state(false);
+	let collectionId = $state<number | null>(null);
+	let collectionName = $state<string | null>(null);
+	let collectionSearchOpen = $state(false);
+	let collectionQuery = $state('');
+	let collectionResults = $state<
+		{ id: number; name: string; poster_path: string | null; overview: string }[]
+	>([]);
+	let collectionSearching = $state(false);
+	let collectionSearchTimer: ReturnType<typeof setTimeout> | null = null;
 	let animeRootWarningShown = $state(false);
 	let enforceAnimeSubtype = $state(false);
 	let detectedAnime = $state(false);
@@ -153,6 +164,8 @@
 			enforceAnimeSubtype = false;
 			detectedAnime = false;
 			folderPath = movie.path ?? '';
+			collectionId = movie.tmdbCollectionId ?? null;
+			collectionName = movie.collectionName ?? null;
 			void loadAnimeRoutingContext(movie.tmdbId);
 		}
 	});
@@ -258,6 +271,38 @@
 			: null
 	);
 
+	function handleCollectionQueryInput() {
+		if (collectionSearchTimer) clearTimeout(collectionSearchTimer);
+		const q = collectionQuery.trim();
+		if (!q) {
+			collectionResults = [];
+			return;
+		}
+		collectionSearchTimer = setTimeout(async () => {
+			collectionSearching = true;
+			try {
+				const res = await fetch(`/api/tmdb/collection/search?q=${encodeURIComponent(q)}`);
+				if (res.ok) collectionResults = await res.json();
+			} finally {
+				collectionSearching = false;
+			}
+		}, 350);
+	}
+
+	function pickCollection(id: number, name: string) {
+		collectionId = id;
+		collectionName = name;
+		collectionSearchOpen = false;
+		collectionQuery = '';
+		collectionResults = [];
+	}
+
+	function openCollectionSearch() {
+		collectionSearchOpen = true;
+		collectionQuery = '';
+		collectionResults = [];
+	}
+
 	function handleSave() {
 		onSave({
 			monitored,
@@ -270,7 +315,9 @@
 			availabilityDelay,
 			wantsSubtitles,
 			...(folderPathChanged && folderPath.trim() ? { folderPath: folderPath.trim() } : {}),
-			...(showRemoveUnwantedFiles && removeUnwantedFiles ? { removeUnwantedFiles: true } : {})
+			...(showRemoveUnwantedFiles && removeUnwantedFiles ? { removeUnwantedFiles: true } : {}),
+			tmdbCollectionId: collectionId,
+			collectionName
 		});
 	}
 </script>
@@ -485,6 +532,128 @@
 				{/if}
 			</div>
 		{/if}
+
+		<!-- Collection -->
+		<div class="form-control">
+			<div class="label">
+				<span class="label-text font-medium">Collection</span>
+			</div>
+
+			{#if collectionSearchOpen}
+				<!-- Inline search -->
+				<div class="rounded-lg border border-base-300 bg-base-200 p-3 space-y-2">
+					<div class="relative">
+						<Search
+							class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40"
+						/>
+						<input
+							type="text"
+							placeholder="Search TMDB collections..."
+							class="input input-sm w-full rounded-full border-base-content/20 bg-base-100 pl-9 pr-8 transition-all duration-200 placeholder:text-base-content/40 hover:bg-base-200/60 focus:border-primary/50 focus:bg-base-200/60 focus:ring-1 focus:ring-primary/20 focus:outline-none"
+							bind:value={collectionQuery}
+							oninput={handleCollectionQueryInput}
+						/>
+						{#if collectionSearching}
+							<RefreshCw
+								class="pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin text-base-content/40"
+							/>
+						{:else if collectionQuery}
+							<button
+								type="button"
+								class="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-0.5 text-base-content/40 hover:text-base-content"
+								onclick={() => {
+									collectionQuery = '';
+									collectionResults = [];
+								}}
+								aria-label="Clear search">×</button
+							>
+						{/if}
+					</div>
+					{#if collectionResults.length > 0}
+						<ul class="max-h-48 overflow-y-auto space-y-1">
+							{#each collectionResults as col (col.id)}
+								<li>
+									<button
+										type="button"
+										class="flex w-full items-center gap-2 rounded-lg p-2 text-left text-sm hover:bg-base-300 transition-colors"
+										onclick={() => pickCollection(col.id, col.name)}
+									>
+										<div class="h-10 w-7 shrink-0 overflow-hidden rounded bg-base-300">
+											{#if col.poster_path}
+												<img
+													src="https://image.tmdb.org/t/p/w92{col.poster_path}"
+													alt={col.name}
+													class="h-full w-full object-cover"
+													loading="lazy"
+												/>
+											{:else}
+												<div class="flex h-full w-full items-center justify-center">
+													<Layers class="h-3 w-3 text-base-content/20" />
+												</div>
+											{/if}
+										</div>
+										<span class="truncate font-medium">{col.name}</span>
+									</button>
+								</li>
+							{/each}
+						</ul>
+					{:else if collectionQuery.trim() && !collectionSearching}
+						<p class="text-center text-xs text-base-content/50 py-2">No collections found</p>
+					{/if}
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs w-full"
+						onclick={() => {
+							collectionSearchOpen = false;
+							collectionQuery = '';
+							collectionResults = [];
+						}}
+					>
+						Cancel
+					</button>
+				</div>
+			{:else}
+				<!-- Current value display -->
+				<div
+					class="flex items-center gap-2 rounded-lg border border-base-300 bg-base-200 px-3 py-2 text-sm"
+				>
+					<Layers class="h-4 w-4 shrink-0 text-primary" />
+					<span
+						class="min-w-0 flex-1 truncate {collectionName ? '' : 'italic text-base-content/40'}"
+					>
+						{collectionName ?? 'No collection assigned'}
+					</span>
+					{#if collectionName}
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs text-error"
+							onclick={() => {
+								collectionId = null;
+								collectionName = null;
+							}}
+							title="Remove collection"
+						>
+							<Trash2 class="h-3.5 w-3.5" />
+						</button>
+					{/if}
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs"
+						onclick={openCollectionSearch}
+						title="Change collection"
+					>
+						<Pencil class="h-3.5 w-3.5" />
+					</button>
+				</div>
+			{/if}
+
+			<div class="label">
+				<span class="label-text-alt wrap-break-word whitespace-normal text-base-content/60">
+					Used by the <code class="font-mono">{'{Collection}'}</code> naming token to organize movies
+					into collection folders.
+				</span>
+			</div>
+		</div>
 
 		<!-- Minimum Availability -->
 		<div class="form-control">

--- a/src/lib/components/library/RenamePreviewModal.svelte
+++ b/src/lib/components/library/RenamePreviewModal.svelte
@@ -25,6 +25,7 @@
 	// State
 	let loading = $state(false);
 	let executing = $state(false);
+	let refreshing = $state(false);
 	let error = $state<string | null>(null);
 	let success = $state<string | null>(null);
 	let preview = $state<RenamePreviewResult | null>(null);
@@ -67,6 +68,20 @@
 			error = e instanceof Error ? e.message : m.library_renamePreview_failedToLoad();
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function refreshMetadata() {
+		refreshing = true;
+		error = null;
+		try {
+			const res = await fetch(`/api/library/movies/${mediaId}/refresh`, { method: 'POST' });
+			if (!res.ok) throw new Error(await res.text());
+			await loadPreview();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to refresh metadata';
+		} finally {
+			refreshing = false;
 		}
 	}
 
@@ -284,6 +299,33 @@
 							>
 						{/if}
 					</div>
+
+					{#if preview.missingCollectionData}
+						<div class="alert alert-warning mb-4">
+							<AlertTriangle class="h-4 w-4 shrink-0" />
+							<div class="min-w-0 flex-1 text-sm">
+								<p class="font-medium">No collection data</p>
+								<p class="text-warning-content/80">
+									Your folder template uses <code class="font-mono">{'{Collection}'}</code> but this movie
+									has no collection data - paths may be incorrect. Refresh metadata to fetch it from TMDB.
+								</p>
+							</div>
+							<button
+								type="button"
+								class="btn btn-sm btn-warning"
+								disabled={refreshing}
+								onclick={refreshMetadata}
+							>
+								{#if refreshing}
+									<RefreshCw class="h-3 w-3 animate-spin" />
+									Refreshing...
+								{:else}
+									<RefreshCw class="h-3 w-3" />
+									Refresh Metadata
+								{/if}
+							</button>
+						</div>
+					{/if}
 
 					{#if preview.totalFiles === 0}
 						<div class="py-10 text-center text-base-content/60">

--- a/src/lib/components/library/index.ts
+++ b/src/lib/components/library/index.ts
@@ -13,6 +13,7 @@ export { default as MovieFilesTab } from './MovieFilesTab.svelte';
 export { default as LibraryMovieHeader } from './LibraryMovieHeader.svelte';
 export { default as MovieEditModal } from './MovieEditModal.svelte';
 export { default as RenamePreviewModal } from './RenamePreviewModal.svelte';
+export { default as CollectionPickerModal } from './CollectionPickerModal.svelte';
 export { default as AddToLibraryModal } from './AddToLibraryModal.svelte';
 export { default as AddMovieForm } from './AddMovieForm.svelte';
 export { default as AddSeriesForm } from './AddSeriesForm.svelte';

--- a/src/lib/components/naming/TokenPicker.svelte
+++ b/src/lib/components/naming/TokenPicker.svelte
@@ -54,6 +54,7 @@
 
 	const categoryOrder = [
 		'movie',
+		'collection',
 		'series',
 		'episode',
 		'quality',
@@ -167,24 +168,26 @@
 
 <div class="space-y-4">
 	<!-- Search -->
-	<div class="form-control">
-		<div class="relative">
-			<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/50" />
-			<input
-				type="text"
-				placeholder={m.naming_tokenSearchPlaceholder()}
-				class="input-bordered input input-sm w-full pl-9"
-				bind:value={searchQuery}
-			/>
-			{#if searchQuery}
-				<button
-					class="btn absolute top-1/2 right-2 btn-circle -translate-y-1/2 btn-ghost btn-xs"
-					onclick={() => (searchQuery = '')}
-				>
-					×
-				</button>
-			{/if}
-		</div>
+	<div class="form-control relative">
+		<Search
+			class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40"
+		/>
+		<input
+			type="text"
+			placeholder={m.naming_tokenSearchPlaceholder()}
+			class="input input-sm w-full rounded-full border-base-content/20 bg-base-200/60 pr-8 pl-10 transition-all duration-200 placeholder:text-base-content/40 hover:bg-base-200 focus:border-primary/50 focus:bg-base-200 focus:ring-1 focus:ring-primary/20 focus:outline-none"
+			bind:value={searchQuery}
+		/>
+		{#if searchQuery}
+			<button
+				type="button"
+				class="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-0.5 text-base-content/40 hover:text-base-content"
+				onclick={() => (searchQuery = '')}
+				aria-label="Clear search"
+			>
+				×
+			</button>
+		{/if}
 	</div>
 
 	<!-- Category Tabs -->
@@ -228,7 +231,7 @@
 	{/if}
 
 	<!-- Token Grid -->
-	<div class="max-h-[400px] space-y-3 overflow-y-auto pr-1">
+	<div class="max-h-100 space-y-3 overflow-y-auto pr-1">
 		{#if searchQuery}
 			<!-- Search Results -->
 			{#each getFilteredCategories() as category (category.name)}

--- a/src/lib/components/tasks/TaskTableRow.svelte
+++ b/src/lib/components/tasks/TaskTableRow.svelte
@@ -97,14 +97,14 @@
 
 <tr class="group hover:bg-base-200/50 {task.isRunning ? 'bg-primary/5' : ''}">
 	<!-- Task Name -->
-	<td>
+	<td class="max-w-0">
 		<div class="flex items-center gap-3">
 			<div class="min-w-0 flex-1">
 				<div class="truncate font-medium">
 					{(m as unknown as Record<string, () => string>)[`task_name_${camelCaseId}`]?.() ??
 						task.name}
 				</div>
-				<div class="truncate text-sm text-base-content/60">
+				<div class="text-sm text-base-content/60">
 					{(m as unknown as Record<string, () => string>)[`task_desc_${camelCaseId}`]?.() ??
 						task.description}
 				</div>

--- a/src/lib/components/tasks/TasksTable.svelte
+++ b/src/lib/components/tasks/TasksTable.svelte
@@ -105,15 +105,15 @@
 					{/each}
 				</div>
 				<div class="hidden overflow-x-auto md:block">
-					<table class="table w-full table-zebra">
+					<table class="table w-full table-fixed table-zebra">
 						<thead>
 							<tr>
-								<th class="w-1/3">{m.task_table_colTask()}</th>
-								<th>{m.task_table_colInterval()}</th>
-								<th>{m.task_table_colLastRun()}</th>
-								<th>{m.task_table_colNextRun()}</th>
-								<th>{m.task_table_colStatus()}</th>
-								<th class="w-px"></th>
+								<th>{m.task_table_colTask()}</th>
+								<th class="w-20">{m.task_table_colInterval()}</th>
+								<th class="w-28">{m.task_table_colLastRun()}</th>
+								<th class="w-28">{m.task_table_colNextRun()}</th>
+								<th class="w-16">{m.task_table_colStatus()}</th>
+								<th class="w-20"></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -193,14 +193,14 @@
 					{/each}
 				</div>
 				<div class="hidden overflow-x-auto md:block">
-					<table class="table w-full table-zebra">
+					<table class="table w-full table-fixed table-zebra">
 						<thead>
 							<tr>
-								<th class="w-1/3">{m.task_table_colTask()}</th>
-								<th>{m.task_table_colType()}</th>
-								<th>{m.task_table_colLastRun()}</th>
-								<th>{m.task_table_colStatus()}</th>
-								<th class="w-px"></th>
+								<th>{m.task_table_colTask()}</th>
+								<th class="w-20">{m.task_table_colType()}</th>
+								<th class="w-28">{m.task_table_colLastRun()}</th>
+								<th class="w-16">{m.task_table_colStatus()}</th>
+								<th class="w-20"></th>
 							</tr>
 						</thead>
 						<tbody>

--- a/src/lib/library/naming/types.ts
+++ b/src/lib/library/naming/types.ts
@@ -48,6 +48,10 @@ export interface RenamePreviewResult {
 	totalAlreadyCorrect: number;
 	totalCollisions: number;
 	totalErrors: number;
+
+	// Set when the movie folder template uses {Collection} but this movie
+	// has no collection data — paths will be wrong until metadata is refreshed.
+	missingCollectionData?: boolean;
 }
 
 /**

--- a/src/lib/server/library/disk-scan.ts
+++ b/src/lib/server/library/disk-scan.ts
@@ -415,6 +415,10 @@ export class DiskScanService extends EventEmitter {
 				if (this.scanAborted) {
 					throw new Error('Scan was cancelled');
 				}
+
+				// Yield to the event loop between batches so HTTP requests and
+				// logging can be served even when scanning a large library.
+				await new Promise<void>((resolve) => setImmediate(resolve));
 			}
 
 			progress.filesFound = filesFound;

--- a/src/lib/server/library/jobs/LibraryJobWorker.ts
+++ b/src/lib/server/library/jobs/LibraryJobWorker.ts
@@ -136,6 +136,9 @@ export class LibraryJobWorker extends EventEmitter implements BackgroundService 
 
 					const reloaded = await this.jobService.getJob(queuedJob.id);
 					if (reloaded?.cancelRequested) break;
+
+					// Yield between pages so the event loop stays responsive.
+					await new Promise<void>((resolve) => setImmediate(resolve));
 				}
 				await this.jobService.markCompleted(queuedJob.id, {
 					phase: 'done',
@@ -186,6 +189,10 @@ export class LibraryJobWorker extends EventEmitter implements BackgroundService 
 				await new Promise<void>((resolve) => {
 					this.loopTimer = setTimeout(resolve, 1000);
 				});
+			} else {
+				// Yield before picking up the next job so the event loop can
+				// serve HTTP requests and flush logs between jobs.
+				await new Promise<void>((resolve) => setImmediate(resolve));
 			}
 		}
 	}

--- a/src/lib/server/library/library-scheduler.ts
+++ b/src/lib/server/library/library-scheduler.ts
@@ -403,6 +403,8 @@ export class LibrarySchedulerService extends EventEmitter implements BackgroundS
 		const importService = getImportService();
 		for (const s of allSeries) {
 			await importService.updateSeriesStats(s.id);
+			// Yield between series to keep the event loop responsive.
+			await new Promise<void>((resolve) => setImmediate(resolve));
 		}
 
 		logger.info('[LibraryScheduler] Series stats updated');

--- a/src/lib/server/library/library-watcher.ts
+++ b/src/lib/server/library/library-watcher.ts
@@ -104,7 +104,7 @@ export class LibraryWatcherService extends EventEmitter {
 		const watcher = chokidar.watch(folderPath, {
 			persistent: true,
 			ignoreInitial: true,
-			followSymlinks: true,
+			followSymlinks: false,
 			depth: 10,
 			awaitWriteFinish: {
 				stabilityThreshold: 2000,

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -641,6 +641,8 @@ export class MediaMatcherService {
 					reason
 				});
 			}
+			// Yield between files so the event loop stays responsive under heavy matching load.
+			await new Promise<void>((resolve) => setImmediate(resolve));
 		}
 
 		return { results, hasMore };

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -275,6 +275,14 @@ export class RenamePreviewService {
 			}
 		}
 
+		// Warn when the folder template uses {Collection} but this movie has no
+		// collection data — the token resolves to empty string, so the preview
+		// will show the movie moving OUT of its collection folder.
+		const namingConfig = namingSettingsService.getConfigSync();
+		if (namingConfig.movieFolderFormat?.includes('{Collection}') && !movie.collectionName) {
+			result.missingCollectionData = true;
+		}
+
 		const files = db.select().from(movieFiles).where(eq(movieFiles.movieId, movieId)).all();
 
 		for (const file of files) {

--- a/src/lib/server/smartlists/providers/TmdbListProvider.ts
+++ b/src/lib/server/smartlists/providers/TmdbListProvider.ts
@@ -13,8 +13,6 @@ import type { ExternalListProvider, ExternalListItem, ExternalListResult } from 
 export interface TmdbListConfig {
 	/** TMDb list ID */
 	listId: string;
-	/** Maximum pages to fetch (default: 5) */
-	maxPages?: number;
 }
 
 interface TmdbListItem {
@@ -43,6 +41,9 @@ interface TmdbListResponse {
 	description: string;
 	poster_path: string | null;
 	item_count: number;
+	page: number;
+	total_pages: number;
+	total_results: number;
 	items: TmdbListItem[];
 }
 
@@ -104,50 +105,52 @@ export class TmdbListProvider implements ExternalListProvider {
 		);
 
 		try {
-			// TMDb list API doesn't have pagination in the same way as discover
-			// It returns all items in one request (up to a limit)
-			// We'll fetch the list and filter by media type if specified (empty string = show all)
-			const response = (await tmdb.fetch(
-				`/list/${normalizedListId}`,
-				{},
-				true
-			)) as TmdbListResponse;
+			let currentPage = 1;
+			let totalPages = 1;
 
-			if (!response.items || response.items.length === 0) {
-				logger.info({ listId: normalizedListId }, '[TmdbListProvider] List is empty');
-				return {
-					items: [],
-					totalCount: 0,
-					failedCount: 0
-				};
-			}
+			while (currentPage <= totalPages) {
+				const response = (await tmdb.fetch(
+					`/list/${normalizedListId}?page=${currentPage}`,
+					{},
+					true
+				)) as TmdbListResponse;
 
-			logger.info(
-				{
-					listId: normalizedListId,
-					listName: response.name,
-					itemCount: response.items.length
-				},
-				'[TmdbListProvider] Fetched list'
-			);
-
-			for (const item of response.items) {
-				// Filter by media type if specified (skip filter if mediaType is empty string)
-				if (mediaType && item.media_type && item.media_type !== mediaType) {
-					continue;
+				if (currentPage === 1) {
+					if (!response.items || response.items.length === 0) {
+						logger.info({ listId: normalizedListId }, '[TmdbListProvider] List is empty');
+						return { items: [], totalCount: 0, failedCount: 0 };
+					}
+					totalPages = response.total_pages ?? 1;
+					logger.info(
+						{
+							listId: normalizedListId,
+							listName: response.name,
+							totalResults: response.total_results,
+							totalPages
+						},
+						'[TmdbListProvider] Fetched list metadata'
+					);
 				}
 
-				const parsedItem = this.parseItem(item);
-				if (parsedItem) {
-					items.push(parsedItem);
+				for (const item of response.items ?? []) {
+					if (mediaType && item.media_type && item.media_type !== mediaType) {
+						continue;
+					}
+					const parsedItem = this.parseItem(item);
+					if (parsedItem) {
+						items.push(parsedItem);
+					}
 				}
+
+				currentPage++;
 			}
 
 			logger.info(
 				{
 					listId: normalizedListId,
 					totalItems: items.length,
-					filteredFrom: response.items.length
+					pagesFetched: currentPage - 1,
+					totalPages
 				},
 				'[TmdbListProvider] Completed TMDb list fetch'
 			);

--- a/src/lib/server/smartlists/providers/types.ts
+++ b/src/lib/server/smartlists/providers/types.ts
@@ -107,8 +107,6 @@ export interface TmdbPopularConfig {
 export interface TmdbListConfig {
 	/** TMDb list ID */
 	listId: string;
-	/** Maximum pages to fetch */
-	maxPages?: number;
 }
 
 /**

--- a/src/lib/server/storage/insights/items/health-issues.ts
+++ b/src/lib/server/storage/insights/items/health-issues.ts
@@ -1,14 +1,42 @@
-import { rootFolders } from '$lib/server/db/schema';
+import { libraries, rootFolders } from '$lib/server/db/schema';
 import { inArray } from 'drizzle-orm';
 import type { InsightItemResolver } from './types.js';
 
 export const healthIssuesResolver: InsightItemResolver = async ({ db, insight, page, limit }) => {
 	const rawDetails = insight.detailsJson ? JSON.parse(insight.detailsJson) : null;
-	if (
-		!rawDetails?.folderIds ||
-		!Array.isArray(rawDetails.folderIds) ||
-		rawDetails.folderIds.length === 0
-	) {
+	const tone = (insight.severity === 'critical' ? 'critical' : 'warn') as 'critical' | 'warn';
+
+	// Libraries without a root folder
+	if (Array.isArray(rawDetails?.libraryIds) && rawDetails.libraryIds.length > 0) {
+		const allIds: string[] = rawDetails.libraryIds;
+		const total = allIds.length;
+		const slicedIds = allIds.slice((page - 1) * limit, (page - 1) * limit + limit);
+
+		const rows = db
+			.select({ id: libraries.id, name: libraries.name, mediaType: libraries.mediaType })
+			.from(libraries)
+			.where(inArray(libraries.id, slicedIds))
+			.all();
+		const rowsById = new Map(rows.map((r) => [r.id, r]));
+
+		return {
+			items: slicedIds.map((id) => {
+				const row = rowsById.get(id);
+				return {
+					id: `hi-lib-${id}`,
+					kind: 'folder' as const,
+					title: row?.name ?? `Library ${id}`,
+					subtitle: row?.mediaType === 'tv' ? 'TV library' : 'Movie library',
+					badges: [{ label: 'No root folder', tone }],
+					href: '/settings/library/libraries'
+				};
+			}),
+			total
+		};
+	}
+
+	// Root folder health issues (inaccessible, read-only, needs scan)
+	if (!Array.isArray(rawDetails?.folderIds) || rawDetails.folderIds.length === 0) {
 		return { items: [], total: 0 };
 	}
 
@@ -37,12 +65,7 @@ export const healthIssuesResolver: InsightItemResolver = async ({ db, insight, p
 				kind: 'folder' as const,
 				title: row?.name ?? `Folder ${id}`,
 				subtitle: pathsById.get(id) ?? row?.path,
-				badges: [
-					{
-						label: 'Action needed',
-						tone: (insight.severity === 'critical' ? 'critical' : 'warn') as 'critical' | 'warn'
-					}
-				],
+				badges: [{ label: 'Action needed', tone }],
 				href: '/settings/monitoring/status/folders'
 			};
 		}),

--- a/src/lib/server/storage/insights/items/redundant-quality-tiers.ts
+++ b/src/lib/server/storage/insights/items/redundant-quality-tiers.ts
@@ -1,0 +1,46 @@
+import { movies } from '$lib/server/db/schema';
+import { inArray } from 'drizzle-orm';
+import type { InsightItemResolver } from './types.js';
+
+export const redundantQualityTiersResolver: InsightItemResolver = async ({
+	db,
+	insight,
+	page,
+	limit
+}) => {
+	const rawDetails = insight.detailsJson ? JSON.parse(insight.detailsJson) : null;
+	if (!Array.isArray(rawDetails?.items) || rawDetails.items.length === 0) {
+		return { items: [], total: 0 };
+	}
+
+	type DetailItem = { tmdbId: number | null; title: string | null; redundantCount: number };
+	const allItems: DetailItem[] = rawDetails.items;
+	const total = allItems.length;
+	const sliced = allItems.slice((page - 1) * limit, (page - 1) * limit + limit);
+
+	const tmdbIds = sliced.filter((i) => i.tmdbId != null).map((i) => i.tmdbId!);
+	const movieMap = new Map<number, string>();
+	if (tmdbIds.length > 0) {
+		const rows = db
+			.select({ id: movies.id, tmdbId: movies.tmdbId })
+			.from(movies)
+			.where(inArray(movies.tmdbId, tmdbIds))
+			.all();
+		for (const r of rows) if (r.tmdbId != null) movieMap.set(r.tmdbId, r.id);
+	}
+
+	return {
+		items: sliced.map((item, idx) => ({
+			id: `rqt-${page}-${idx}`,
+			kind: 'movie' as const,
+			title: item.title ?? 'Unknown',
+			subtitle: `${item.redundantCount} redundant file${item.redundantCount === 1 ? '' : 's'}`,
+			badges: [{ label: 'Redundant', tone: 'info' as const }],
+			href:
+				item.tmdbId != null && movieMap.has(item.tmdbId)
+					? `/library/movie/${movieMap.get(item.tmdbId)}`
+					: undefined
+		})),
+		total
+	};
+};

--- a/src/lib/server/storage/insights/items/registry.ts
+++ b/src/lib/server/storage/insights/items/registry.ts
@@ -9,6 +9,7 @@ import { orphanedFilesResolver } from './orphaned-files.js';
 import { untrackedByCinephageResolver } from './untracked-by-cinephage.js';
 import { missingFromMediaServerResolver } from './missing-from-media-server.js';
 import { filenameDuplicatesResolver } from './filename-duplicates.js';
+import { redundantQualityTiersResolver } from './redundant-quality-tiers.js';
 
 /**
  * Registry of per-type item resolvers.
@@ -40,3 +41,4 @@ registerInsightItemResolver('orphaned-files', orphanedFilesResolver);
 registerInsightItemResolver('untracked-by-cinephage', untrackedByCinephageResolver);
 registerInsightItemResolver('missing-from-media-server', missingFromMediaServerResolver);
 registerInsightItemResolver('filename-duplicates', filenameDuplicatesResolver);
+registerInsightItemResolver('redundant-quality-tiers', redundantQualityTiersResolver);

--- a/src/lib/server/storage/insights/items/untracked-by-cinephage.ts
+++ b/src/lib/server/storage/insights/items/untracked-by-cinephage.ts
@@ -21,7 +21,10 @@ export const untrackedByCinephageResolver: InsightItemResolver = async ({ db, pa
 			id: storageItems.id,
 			title: storageItems.title,
 			tmdbId: storageItems.tmdbId,
-			itemType: storageItems.itemType
+			itemType: storageItems.itemType,
+			seriesName: storageItems.seriesName,
+			seasonNumber: storageItems.seasonNumber,
+			episodeNumber: storageItems.episodeNumber
 		})
 		.from(storageItems)
 		.where(
@@ -58,19 +61,28 @@ export const untrackedByCinephageResolver: InsightItemResolver = async ({ db, pa
 	}
 
 	return {
-		items: rows.map((row) => ({
-			id: `ut-${row.id}`,
-			kind: row.itemType === 'movie' ? ('movie' as const) : ('episode' as const),
-			title: row.title,
-			badges: [{ label: 'Not tracked', tone: 'info' as const }],
-			href: row.tmdbId
-				? movieMap.has(row.tmdbId)
-					? `/library/movie/${movieMap.get(row.tmdbId)}`
-					: seriesMap.has(row.tmdbId)
-						? `/library/tv/${seriesMap.get(row.tmdbId)}`
-						: undefined
-				: undefined
-		})),
+		items: rows.map((row) => {
+			const isEpisode = row.itemType !== 'movie';
+			const seasonLabel = `S${String(row.seasonNumber ?? 0).padStart(2, '0')}`;
+			const episodeLabel = `E${String(row.episodeNumber ?? 0).padStart(2, '0')}`;
+			const episodeTitle = isEpisode
+				? `${seasonLabel}${episodeLabel} · ${row.title}`
+				: row.title;
+			return {
+				id: `ut-${row.id}`,
+				kind: isEpisode ? ('episode' as const) : ('movie' as const),
+				title: isEpisode ? episodeTitle : row.title,
+				subtitle: isEpisode ? (row.seriesName ?? row.title) : undefined,
+				badges: [{ label: 'Not tracked', tone: 'info' as const }],
+				href: row.tmdbId
+					? movieMap.has(row.tmdbId)
+						? `/library/movie/${movieMap.get(row.tmdbId)}`
+						: seriesMap.has(row.tmdbId)
+							? `/library/tv/${seriesMap.get(row.tmdbId)}`
+							: undefined
+					: undefined
+			};
+		}),
 		total
 	};
 };

--- a/src/lib/server/storage/insights/items/untracked-by-cinephage.ts
+++ b/src/lib/server/storage/insights/items/untracked-by-cinephage.ts
@@ -65,9 +65,7 @@ export const untrackedByCinephageResolver: InsightItemResolver = async ({ db, pa
 			const isEpisode = row.itemType !== 'movie';
 			const seasonLabel = `S${String(row.seasonNumber ?? 0).padStart(2, '0')}`;
 			const episodeLabel = `E${String(row.episodeNumber ?? 0).padStart(2, '0')}`;
-			const episodeTitle = isEpisode
-				? `${seasonLabel}${episodeLabel} · ${row.title}`
-				: row.title;
+			const episodeTitle = isEpisode ? `${seasonLabel}${episodeLabel} · ${row.title}` : row.title;
 			return {
 				id: `ut-${row.id}`,
 				kind: isEpisode ? ('episode' as const) : ('movie' as const),

--- a/src/lib/server/storage/insights/rules/HealthIssuesRule.ts
+++ b/src/lib/server/storage/insights/rules/HealthIssuesRule.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { count, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { libraries, libraryScanHistory, rootFolders } from '$lib/server/db/schema';
 import type { StorageInsightRule, RuleContext, InsightFinding } from '../types.js';
 
@@ -81,20 +81,21 @@ export class HealthIssuesRule implements StorageInsightRule {
 		}
 
 		// 4. Libraries without root folder (warning)
-		const libCount =
-			ctx.db
-				.select({ count: count() })
-				.from(libraries)
-				.where(sql`${libraries.defaultRootFolderId} IS NULL AND ${libraries.isSystem} = 0`)
-				.get()?.count ?? 0;
+		const libsWithoutFolder = ctx.db
+			.select({ id: libraries.id })
+			.from(libraries)
+			.where(sql`${libraries.defaultRootFolderId} IS NULL AND ${libraries.isSystem} = 0`)
+			.all();
 
-		if (libCount > 0) {
+		if (libsWithoutFolder.length > 0) {
+			const libCount = libsWithoutFolder.length;
 			findings.push({
 				type: this.type,
 				severity: 'warning',
 				scope: 'global',
 				title: `Libraries without a root folder`,
 				summary: `${libCount} librar${libCount === 1 ? 'y' : 'ies'} ${libCount === 1 ? 'has' : 'have'} no default root folder configured. New additions won't know where to go.`,
+				details: { libraryIds: libsWithoutFolder.map((l) => l.id) },
 				itemCount: libCount
 			});
 		}

--- a/src/lib/server/tmdb.ts
+++ b/src/lib/server/tmdb.ts
@@ -324,6 +324,27 @@ export const tmdb = {
 		return this.fetch(`/collection/${id}`) as Promise<Collection>;
 	},
 
+	async searchCollections(query: string): Promise<
+		{
+			id: number;
+			name: string;
+			poster_path: string | null;
+			backdrop_path: string | null;
+			overview: string;
+		}[]
+	> {
+		const result = (await this.fetch(`/search/collection?query=${encodeURIComponent(query)}`)) as {
+			results: {
+				id: number;
+				name: string;
+				poster_path: string | null;
+				backdrop_path: string | null;
+				overview: string;
+			}[];
+		};
+		return result.results ?? [];
+	},
+
 	async getPerson(id: number): Promise<PersonDetails> {
 		return this.fetch(
 			`/person/${id}?append_to_response=combined_credits,external_ids`

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1555,7 +1555,10 @@ export const movieUpdateSchema = z.object({
 		.refine((v) => !v.includes('..') && !v.startsWith('/'), {
 			message: 'Folder path must be a relative name with no path traversal'
 		})
-		.optional()
+		.optional(),
+	/** Override the TMDB collection assignment for this movie. */
+	tmdbCollectionId: z.number().int().positive().nullable().optional(),
+	collectionName: z.string().min(1).nullable().optional()
 });
 
 /**

--- a/src/routes/api/library/movies/[id]/+server.ts
+++ b/src/routes/api/library/movies/[id]/+server.ts
@@ -201,7 +201,9 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		wantsSubtitles,
 		languageProfileId,
 		delayProfileId,
-		folderPath
+		folderPath,
+		tmdbCollectionId,
+		collectionName
 	} = body;
 
 	// Capture current state before update (for subtitle trigger detection)
@@ -358,6 +360,13 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 			}
 		}
 		updateData.path = trimmed;
+	}
+
+	if (tmdbCollectionId !== undefined) {
+		updateData.tmdbCollectionId = tmdbCollectionId;
+	}
+	if (collectionName !== undefined) {
+		updateData.collectionName = collectionName;
 	}
 
 	if (Object.keys(updateData).length === 0 && !moveRequest) {

--- a/src/routes/api/tmdb/collection/search/+server.ts
+++ b/src/routes/api/tmdb/collection/search/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { tmdb } from '$lib/server/tmdb.js';
+
+/**
+ * GET /api/tmdb/collection/search?q=query
+ * Search TMDB collections by name.
+ */
+export const GET: RequestHandler = async ({ url }) => {
+	const q = url.searchParams.get('q')?.trim() ?? '';
+	if (!q) {
+		return json([]);
+	}
+
+	const results = await tmdb.searchCollections(q);
+	return json(results);
+};

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -109,6 +109,7 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 			added: movies.added,
 			hasFile: movies.hasFile,
 			tmdbCollectionId: movies.tmdbCollectionId,
+			collectionName: movies.collectionName,
 			releaseDate: movies.releaseDate,
 			digitalReleaseDate: movies.digitalReleaseDate,
 			physicalReleaseDate: movies.physicalReleaseDate,

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -444,6 +444,9 @@
 
 	async function handleEditSave(editData: MovieEditData) {
 		isSaving = true;
+		const collectionChanged =
+			editData.tmdbCollectionId !== movie.tmdbCollectionId ||
+			editData.collectionName !== movie.collectionName;
 		try {
 			const result = await updateMovie(movie.id, editData as unknown as Record<string, unknown>);
 
@@ -454,6 +457,8 @@
 			movie.minimumAvailability = editData.minimumAvailability;
 			movie.availabilityDelay = editData.availabilityDelay;
 			movie.wantsSubtitles = editData.wantsSubtitles;
+			movie.tmdbCollectionId = editData.tmdbCollectionId ?? null;
+			movie.collectionName = editData.collectionName ?? null;
 
 			if (result?.moveQueued) {
 				toasts.success(m.library_movieDetail_moveQueued());
@@ -464,6 +469,10 @@
 			}
 
 			isEditModalOpen = false;
+
+			if (collectionChanged) {
+				isRenameModalOpen = true;
+			}
 		} catch (error) {
 			showActionError(m.toast_library_movieDetail_failedToUpdate(), error);
 		} finally {

--- a/src/routes/settings/monitoring/status/+page.svelte
+++ b/src/routes/settings/monitoring/status/+page.svelte
@@ -56,7 +56,6 @@
 	let retention = $state<HistoryRetentionSettings | null>(null);
 	let forecast = $state<StorageForecast | null>(null);
 	let retentionSaving = $state(false);
-	let retentionOpen = $state(false);
 	let insightsOpen = $state(false);
 
 	type Insight = {
@@ -476,63 +475,124 @@
 		serverStatuses={data.serverStatuses}
 		onOpenInsight={handleDashboardInsightClick}
 	/>
-</SettingsPage>
-<details class="mt-4" bind:open={retentionOpen}>
-	<summary class="cursor-pointer text-sm font-medium text-base-content/60 hover:text-base-content"
-		>History Retention</summary
-	>
-	<div class="mt-3 rounded-lg border bg-base-200 p-4">
-		{#if retention}
-			<div class="flex flex-wrap items-end gap-4">
-				<div class="form-control">
-					<label class="label py-0 text-xs" for="h-file">File history</label>
-					<input
-						id="h-file"
-						type="number"
-						class="input input-bordered input-xs w-20"
-						bind:value={retention.fileHistoryDays}
-						min="0"
-						max="3650"
-					/> <span class="text-xs text-base-content/50">days</span>
-				</div>
-				<div class="form-control">
-					<label class="label py-0 text-xs" for="h-lib">Library history</label>
-					<input
-						id="h-lib"
-						type="number"
-						class="input input-bordered input-xs w-20"
-						bind:value={retention.libraryHistoryDays}
-						min="0"
-						max="3650"
-					/> <span class="text-xs text-base-content/50">days</span>
-				</div>
-				<div class="form-control">
-					<label class="label py-0 text-xs" for="h-scan">Scan history</label>
-					<input
-						id="h-scan"
-						type="number"
-						class="input input-bordered input-xs w-20"
-						bind:value={retention.scanHistoryDays}
-						min="0"
-						max="3650"
-					/> <span class="text-xs text-base-content/50">days</span>
-				</div>
-				<button
-					class="btn btn-ghost btn-xs"
-					onclick={handleSaveRetention}
-					disabled={retentionSaving}>Save</button
-				>
+
+	<!-- History Retention -->
+	<div class="card bg-base-200">
+		<div class="card-body gap-4">
+			<div>
+				<h2 class="text-base font-semibold">{m.settings_history_title()}</h2>
+				<p class="mt-0.5 text-sm text-base-content/60">{m.settings_history_description()}</p>
 			</div>
-			{#if forecast}
-				<div class="mt-2 text-xs text-base-content/50">
-					~{formatBytes(forecast.currentEstimatedBytes)} now, ~{formatBytes(
-						forecast.projectedBytes30d
-					)} in 30d
+
+			{#if retention}
+				<div class="divide-y divide-base-300">
+					<div class="flex items-center justify-between gap-4 py-3">
+						<div>
+							<div class="text-sm font-medium">{m.settings_history_file_days()}</div>
+							<div class="text-xs text-base-content/50">{m.settings_history_file_days_help()}</div>
+						</div>
+						<div class="flex shrink-0 items-center gap-2">
+							<input
+								id="h-file"
+								type="number"
+								class="input input-sm input-bordered w-20"
+								bind:value={retention.fileHistoryDays}
+								min="0"
+								max="3650"
+							/>
+							<span class="w-8 text-sm text-base-content/50">days</span>
+						</div>
+					</div>
+
+					<div class="flex items-center justify-between gap-4 py-3">
+						<div>
+							<div class="text-sm font-medium">{m.settings_history_library_days()}</div>
+							<div class="text-xs text-base-content/50">
+								{m.settings_history_library_days_help()}
+							</div>
+						</div>
+						<div class="flex shrink-0 items-center gap-2">
+							<input
+								id="h-lib"
+								type="number"
+								class="input input-sm input-bordered w-20"
+								bind:value={retention.libraryHistoryDays}
+								min="0"
+								max="3650"
+							/>
+							<span class="w-8 text-sm text-base-content/50">days</span>
+						</div>
+					</div>
+
+					<div class="flex items-center justify-between gap-4 py-3">
+						<div>
+							<div class="text-sm font-medium">{m.settings_history_scan_days()}</div>
+							<div class="text-xs text-base-content/50">{m.settings_history_scan_days_help()}</div>
+						</div>
+						<div class="flex shrink-0 items-center gap-2">
+							<input
+								id="h-scan"
+								type="number"
+								class="input input-sm input-bordered w-20"
+								bind:value={retention.scanHistoryDays}
+								min="0"
+								max="3650"
+							/>
+							<span class="w-8 text-sm text-base-content/50">days</span>
+						</div>
+					</div>
+				</div>
+
+				{#if forecast}
+					<div>
+						<div class="mb-2 text-xs font-medium uppercase tracking-wide text-base-content/50">
+							{m.settings_history_forecast()}
+						</div>
+						<div class="grid grid-cols-3 gap-3">
+							<div class="rounded-lg bg-base-300 px-4 py-3">
+								<div class="text-xs text-base-content/50">
+									{m.settings_history_forecast_current()}
+								</div>
+								<div class="mt-0.5 text-sm font-semibold">
+									{formatBytes(forecast.currentEstimatedBytes)}
+								</div>
+							</div>
+							<div class="rounded-lg bg-base-300 px-4 py-3">
+								<div class="text-xs text-base-content/50">{m.settings_history_forecast_30d()}</div>
+								<div class="mt-0.5 text-sm font-semibold">
+									{formatBytes(forecast.projectedBytes30d)}
+								</div>
+							</div>
+							<div class="rounded-lg bg-base-300 px-4 py-3">
+								<div class="text-xs text-base-content/50">{m.settings_history_forecast_90d()}</div>
+								<div class="mt-0.5 text-sm font-semibold">
+									{formatBytes(forecast.projectedBytes90d)}
+								</div>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				<div class="flex justify-end">
+					<button
+						class="btn btn-primary btn-sm"
+						onclick={handleSaveRetention}
+						disabled={retentionSaving}
+					>
+						{#if retentionSaving}
+							<span class="loading loading-spinner loading-xs"></span>
+						{/if}
+						Save
+					</button>
+				</div>
+			{:else}
+				<div class="flex items-center justify-center py-8">
+					<span class="loading loading-spinner loading-sm text-base-content/30"></span>
 				</div>
 			{/if}
-		{/if}
+		</div>
 	</div>
-</details>
+</SettingsPage>
 
 {#if insightsOpen}
 	<dialog

--- a/src/routes/settings/monitoring/status/+page.svelte
+++ b/src/routes/settings/monitoring/status/+page.svelte
@@ -671,13 +671,27 @@
 								{#each groupedItems as group (group.key)}
 									{@const isGroupExpanded = expandedGroupKey === group.key}
 									{@const showGroupActions = s && s.insightType === 'orphaned-files'}
+									{@const flatItem = group.count === 1 ? group.items[0] : null}
+									{@const isFlatExpanded = flatItem !== null && expandedItemId === flatItem.id}
+									{@const flatItemLoading = flatItem !== null && actionLoading.has(flatItem.id)}
 									<div
 										role="button"
 										tabindex="0"
 										class="w-full text-left rounded-lg border border-base-300 bg-base-200/50 px-3 py-2.5 hover:bg-base-200 transition-colors cursor-pointer"
-										onclick={() => (expandedGroupKey = isGroupExpanded ? null : group.key)}
+										onclick={() => {
+											if (flatItem) {
+												expandedItemId = isFlatExpanded ? null : flatItem.id;
+											} else {
+												expandedGroupKey = isGroupExpanded ? null : group.key;
+											}
+										}}
 										onkeydown={(e) => {
-											if (e.key === 'Enter') expandedGroupKey = isGroupExpanded ? null : group.key;
+											if (e.key !== 'Enter') return;
+											if (flatItem) {
+												expandedItemId = isFlatExpanded ? null : flatItem.id;
+											} else {
+												expandedGroupKey = isGroupExpanded ? null : group.key;
+											}
 										}}
 									>
 										<div class="flex items-center gap-3">
@@ -691,8 +705,10 @@
 													{group.label}
 												</div>
 											</div>
-											<span class="badge badge-sm">{group.count}</span>
-											{#if showGroupActions}
+											{#if group.count > 1}
+												<span class="badge badge-sm">{group.count}</span>
+											{/if}
+											{#if showGroupActions && !flatItem}
 												<button
 													class="btn btn-xs btn-ghost text-error"
 													onclick={(e) => {
@@ -708,8 +724,83 @@
 												</button>
 											{/if}
 										</div>
+										<!-- Inline remediation for flat (single) items -->
+										{#if flatItem && isFlatExpanded && s}
+											<div class="mt-2 border-t border-base-300 pt-2">
+												<p class="text-xs text-base-content/70">
+													{getRemediation(s.insightType, flatItem)}
+												</p>
+												<div class="mt-2 flex gap-1">
+													{#if s.insightType === 'quality-below-cutoff'}
+														<button
+															class="btn btn-xs btn-ghost"
+															onclick={(e) => { e.stopPropagation(); handleAutoSearch(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															<Search class="h-3 w-3" /> Auto
+														</button>
+													{/if}
+													{#if s.insightType === 'missing-from-media-server'}
+														<button
+															class="btn btn-xs btn-ghost"
+															onclick={(e) => { e.stopPropagation(); handleAutoSearch(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															<Search class="h-3 w-3" /> Auto
+														</button>
+														<button
+															class="btn btn-xs btn-ghost"
+															onclick={(e) => { e.stopPropagation(); handleInteractiveSearch(flatItem); }}
+														>
+															Interactive
+														</button>
+													{/if}
+													{#if s.insightType === 'unplayed'}
+														<button
+															class="btn btn-xs btn-ghost"
+															onclick={(e) => { e.stopPropagation(); handleUnmonitor(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															Unmonitor
+														</button>
+														<button
+															class="btn btn-xs btn-ghost text-error"
+															onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															Remove
+														</button>
+													{/if}
+													{#if s.insightType === 'broken-paths'}
+														<button
+															class="btn btn-xs btn-ghost text-error"
+															onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															Remove
+														</button>
+													{/if}
+													{#if s.insightType === 'orphaned-files'}
+														<button
+															class="btn btn-xs btn-ghost text-error"
+															onclick={(e) => { e.stopPropagation(); handleDeleteOrphaned(flatItem); }}
+															disabled={flatItemLoading}
+														>
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															Delete
+														</button>
+													{/if}
+												</div>
+											</div>
+										{/if}
 									</div>
-									{#if isGroupExpanded}
+									<!-- Sub-item list only for grouped items (count > 1) -->
+									{#if !flatItem && isGroupExpanded}
 										<div class="space-y-1 pl-6">
 											{#each group.items as item (item.id)}
 												{@const isExpanded = expandedItemId === item.id}
@@ -731,9 +822,7 @@
 															</div>
 														</div>
 														{#if item.sizeBytes}
-															<span class="text-xs text-base-content/50"
-																>{formatBytes(item.sizeBytes)}</span
-															>
+															<span class="text-xs text-base-content/50">{formatBytes(item.sizeBytes)}</span>
 														{/if}
 													</div>
 													{#if isExpanded && s}
@@ -745,38 +834,25 @@
 																{#if s.insightType === 'quality-below-cutoff'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleAutoSearch(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleAutoSearch(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		<Search class="h-3 w-3" /> Auto
 																	</button>
 																{/if}
 																{#if s.insightType === 'missing-from-media-server'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleAutoSearch(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleAutoSearch(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		<Search class="h-3 w-3" /> Auto
 																	</button>
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleInteractiveSearch(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleInteractiveSearch(item); }}
 																	>
 																		Interactive
 																	</button>
@@ -784,58 +860,38 @@
 																{#if s.insightType === 'unplayed'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleUnmonitor(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleUnmonitor(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		Unmonitor
 																	</button>
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleRemoveFromLibrary(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		Remove
 																	</button>
 																{/if}
 																{#if s.insightType === 'broken-paths'}
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleRemoveFromLibrary(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		Remove
 																	</button>
 																{/if}
 																{#if s.insightType === 'orphaned-files'}
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => {
-																			e.stopPropagation();
-																			handleDeleteOrphaned(item);
-																		}}
+																		onclick={(e) => { e.stopPropagation(); handleDeleteOrphaned(item); }}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span
-																				class="loading loading-spinner loading-xs"
-																			></span>{/if}
+																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
 																		Delete
 																	</button>
 																{/if}

--- a/src/routes/settings/monitoring/status/+page.svelte
+++ b/src/routes/settings/monitoring/status/+page.svelte
@@ -734,25 +734,36 @@
 													{#if s.insightType === 'quality-below-cutoff'}
 														<button
 															class="btn btn-xs btn-ghost"
-															onclick={(e) => { e.stopPropagation(); handleAutoSearch(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleAutoSearch(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															<Search class="h-3 w-3" /> Auto
 														</button>
 													{/if}
 													{#if s.insightType === 'missing-from-media-server'}
 														<button
 															class="btn btn-xs btn-ghost"
-															onclick={(e) => { e.stopPropagation(); handleAutoSearch(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleAutoSearch(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															<Search class="h-3 w-3" /> Auto
 														</button>
 														<button
 															class="btn btn-xs btn-ghost"
-															onclick={(e) => { e.stopPropagation(); handleInteractiveSearch(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleInteractiveSearch(flatItem);
+															}}
 														>
 															Interactive
 														</button>
@@ -760,38 +771,54 @@
 													{#if s.insightType === 'unplayed'}
 														<button
 															class="btn btn-xs btn-ghost"
-															onclick={(e) => { e.stopPropagation(); handleUnmonitor(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleUnmonitor(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															Unmonitor
 														</button>
 														<button
 															class="btn btn-xs btn-ghost text-error"
-															onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleRemoveFromLibrary(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															Remove
 														</button>
 													{/if}
 													{#if s.insightType === 'broken-paths'}
 														<button
 															class="btn btn-xs btn-ghost text-error"
-															onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleRemoveFromLibrary(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															Remove
 														</button>
 													{/if}
 													{#if s.insightType === 'orphaned-files'}
 														<button
 															class="btn btn-xs btn-ghost text-error"
-															onclick={(e) => { e.stopPropagation(); handleDeleteOrphaned(flatItem); }}
+															onclick={(e) => {
+																e.stopPropagation();
+																handleDeleteOrphaned(flatItem);
+															}}
 															disabled={flatItemLoading}
 														>
-															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+															{#if flatItemLoading}<span class="loading loading-spinner loading-xs"
+																></span>{/if}
 															Delete
 														</button>
 													{/if}
@@ -822,7 +849,9 @@
 															</div>
 														</div>
 														{#if item.sizeBytes}
-															<span class="text-xs text-base-content/50">{formatBytes(item.sizeBytes)}</span>
+															<span class="text-xs text-base-content/50"
+																>{formatBytes(item.sizeBytes)}</span
+															>
 														{/if}
 													</div>
 													{#if isExpanded && s}
@@ -834,25 +863,38 @@
 																{#if s.insightType === 'quality-below-cutoff'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => { e.stopPropagation(); handleAutoSearch(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleAutoSearch(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		<Search class="h-3 w-3" /> Auto
 																	</button>
 																{/if}
 																{#if s.insightType === 'missing-from-media-server'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => { e.stopPropagation(); handleAutoSearch(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleAutoSearch(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		<Search class="h-3 w-3" /> Auto
 																	</button>
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => { e.stopPropagation(); handleInteractiveSearch(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleInteractiveSearch(item);
+																		}}
 																	>
 																		Interactive
 																	</button>
@@ -860,38 +902,58 @@
 																{#if s.insightType === 'unplayed'}
 																	<button
 																		class="btn btn-xs btn-ghost"
-																		onclick={(e) => { e.stopPropagation(); handleUnmonitor(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleUnmonitor(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		Unmonitor
 																	</button>
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleRemoveFromLibrary(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		Remove
 																	</button>
 																{/if}
 																{#if s.insightType === 'broken-paths'}
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => { e.stopPropagation(); handleRemoveFromLibrary(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleRemoveFromLibrary(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		Remove
 																	</button>
 																{/if}
 																{#if s.insightType === 'orphaned-files'}
 																	<button
 																		class="btn btn-xs btn-ghost text-error"
-																		onclick={(e) => { e.stopPropagation(); handleDeleteOrphaned(item); }}
+																		onclick={(e) => {
+																			e.stopPropagation();
+																			handleDeleteOrphaned(item);
+																		}}
 																		disabled={itemLoading}
 																	>
-																		{#if itemLoading}<span class="loading loading-spinner loading-xs"></span>{/if}
+																		{#if itemLoading}<span
+																				class="loading loading-spinner loading-xs"
+																			></span>{/if}
 																		Delete
 																	</button>
 																{/if}

--- a/src/routes/settings/monitoring/status/+page.svelte
+++ b/src/routes/settings/monitoring/status/+page.svelte
@@ -57,6 +57,10 @@
 	let forecast = $state<StorageForecast | null>(null);
 	let retentionSaving = $state(false);
 	let insightsOpen = $state(false);
+	let scanStarting = $state(false);
+	let syncStarting = $state(false);
+	const isScanning = $derived(layoutState.scanInProgress || scanStarting);
+	const isSyncing = $derived(layoutState.mediaServerSyncing || syncStarting);
 
 	type Insight = {
 		id: string;
@@ -395,21 +399,24 @@
 
 	async function triggerLibraryScan(rootFolderId?: string) {
 		resetScanState();
+		scanStarting = true;
 		try {
 			await scanLibrary(rootFolderId ? { rootFolderId } : { fullScan: true });
 		} catch (error) {
 			scanError = error instanceof Error ? error.message : m.settings_general_failedToStartScan();
+		} finally {
+			scanStarting = false;
 		}
 	}
 
 	async function triggerServerSync() {
-		// Just kick off the sync. The layout's /api/media-server-stats/sync/status
-		// SSE drives layoutState.mediaServerSyncing and calls invalidateAll() on
-		// completion (after the reconcile -> insights chain fires).
+		syncStarting = true;
 		try {
 			await syncMediaServerStats();
 		} catch (error) {
 			toasts.error(error instanceof Error ? error.message : m.status_sync_failed());
+		} finally {
+			syncStarting = false;
 		}
 	}
 </script>
@@ -425,9 +432,9 @@
 				type="button"
 				class="btn btn-sm btn-primary gap-2"
 				onclick={() => void triggerLibraryScan()}
-				disabled={layoutState.scanInProgress || data.rootFolders.length === 0}
+				disabled={isScanning || data.rootFolders.length === 0}
 			>
-				{#if layoutState.scanInProgress}
+				{#if isScanning}
 					<RefreshCw class="h-4 w-4 animate-spin" />
 					{m.settings_general_scanning()}
 				{:else}
@@ -440,10 +447,10 @@
 					type="button"
 					class="btn btn-outline btn-sm gap-2"
 					onclick={() => void triggerServerSync()}
-					disabled={layoutState.mediaServerSyncing}
+					disabled={isSyncing}
 				>
-					<RefreshCw class="h-4 w-4 {layoutState.mediaServerSyncing ? 'animate-spin' : ''}" />
-					Sync Servers
+					<RefreshCw class="h-4 w-4 {isSyncing ? 'animate-spin' : ''}" />
+					{isSyncing ? 'Syncing...' : 'Sync Servers'}
 				</button>
 			{/if}
 			{#if activeInsights.length > 0 || dismissedInsights.length > 0}


### PR DESCRIPTION
## Summary

Batch of fixes and improvements across library scanning, smart lists, collections, and monitoring. Fixes CPU saturation on NAS environments during library scan, resolves a 20-item cap on TMDB smart lists, adds collection assignment to the movie edit flow, and improves the rename preview to warn when collection data is missing.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Disable chokidar `followSymlinks` to prevent CPU spike when scanning on Synology NAS (symlink traversal into shared volumes caused 100% CPU on startup)
- Add `setImmediate` yields in disk scan, match, scheduler, and job worker loops so HTTP requests and logging stay responsive under heavy load
- Fix TMDB smart list cap at 20 items by paginating through all pages using `total_pages` from the API response
- Add `collection` category to the naming token browser so `{Collection}` and `{CleanCollectionTitle}` are visible and searchable
- Add collection assignment to the Edit Movie modal - inline TMDB collection search with debounce, poster thumbnails, clear option; saved as part of the normal edit save
- Warn in rename preview when `{Collection}` is in the folder template but the movie has no collection data; inline Refresh Metadata button fetches from TMDB and reloads the preview without leaving the modal
- Fix libraries-without-root-folder monitoring insight returning empty results; add missing redundant-quality-tiers resolver
- Group untracked episodes insight by series name in the insight modal
- Promote history retention setting to a first-class settings card in Storage & Maintenance
- Add immediate visual feedback to scan and sync buttons
- Make task tables fully responsive on mobile

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
