### PR TITLE
feat: collection section overhaul, multi-episode import fixes, and QOL improvements

### DIFF
--- a/src/lib/components/library/import/GroupEditorPanel.svelte
+++ b/src/lib/components/library/import/GroupEditorPanel.svelte
@@ -93,6 +93,13 @@
 	$effect(() => {
 		showMatchList = !selectedMatch && !routeImportContext;
 	});
+
+	let episodeOverrideActive = $state(false);
+	$effect(() => {
+		// Reset override when switching to a different group (track by id)
+		const _id = activeGroup?.id;
+		episodeOverrideActive = false;
+	});
 </script>
 
 {#if activeGroup}
@@ -193,16 +200,63 @@
 							onchange={onSeasonNumberChange}
 						/>
 					</label>
-					<label class="form-control">
-						<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
-						<input
-							type="number"
-							min="1"
-							class="input-bordered input input-sm w-20"
-							bind:value={episodeNumber}
-							onchange={onEpisodeNumberChange}
-						/>
-					</label>
+					{#if activeGroup?.parsedEpisodes && activeGroup.parsedEpisodes.length > 1 && !episodeOverrideActive}
+						<div class="form-control">
+							<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
+							<div class="flex h-8 items-center gap-1.5">
+								<div
+									class="flex h-full items-center rounded-md border border-base-300 bg-base-200/60 px-2.5 text-xs text-base-content/70"
+								>
+									E{activeGroup.parsedEpisodes[0]}-E{activeGroup.parsedEpisodes[
+										activeGroup.parsedEpisodes.length - 1
+									]}
+									<span class="ml-1.5 text-base-content/40">(auto)</span>
+								</div>
+								<button
+									type="button"
+									class="btn btn-ghost btn-xs text-base-content/50"
+									onclick={() => (episodeOverrideActive = true)}
+								>
+									Override
+								</button>
+							</div>
+						</div>
+					{:else if activeGroup?.parsedEpisodes && activeGroup.parsedEpisodes.length > 1 && episodeOverrideActive}
+						<div class="form-control">
+							<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
+							<div class="flex h-8 items-center gap-1.5">
+								<input
+									type="number"
+									min="1"
+									class="input-bordered input input-sm w-20"
+									bind:value={episodeNumber}
+									onchange={onEpisodeNumberChange}
+								/>
+								<button
+									type="button"
+									class="btn btn-ghost btn-xs text-base-content/50"
+									onclick={() => {
+										episodeOverrideActive = false;
+										episodeNumber = activeGroup?.parsedEpisodes?.[0] ?? episodeNumber;
+										onEpisodeNumberChange();
+									}}
+								>
+									Auto
+								</button>
+							</div>
+						</div>
+					{:else}
+						<label class="form-control">
+							<span class="label-text text-xs">{m.library_import_episodeLabel()}</span>
+							<input
+								type="number"
+								min="1"
+								class="input-bordered input input-sm w-20"
+								bind:value={episodeNumber}
+								onchange={onEpisodeNumberChange}
+							/>
+						</label>
+					{/if}
 					{#if canApplyActiveSeasonOverride()}
 						<button type="button" class="btn btn-ghost btn-sm" onclick={onSeasonNumberChange}>
 							{m.action_apply()}

--- a/src/lib/components/library/import/Step3SingleImport.svelte
+++ b/src/lib/components/library/import/Step3SingleImport.svelte
@@ -277,7 +277,13 @@
 						{/if}
 					{:else}
 						<span class="text-base-content/60">{m.library_import_summaryEpisode()}</span>
-						S{seasonNumber}E{episodeNumber}
+						{#if activeGroup.parsedEpisodes && activeGroup.parsedEpisodes.length > 1}
+							S{seasonNumber}E{activeGroup.parsedEpisodes[0]}-E{activeGroup.parsedEpisodes[
+								activeGroup.parsedEpisodes.length - 1
+							]}
+						{:else}
+							S{seasonNumber}E{episodeNumber}
+						{/if}
 					{/if}
 				</div>
 			{/if}

--- a/src/lib/components/library/import/types.ts
+++ b/src/lib/components/library/import/types.ts
@@ -27,6 +27,7 @@ export interface DetectionGroup {
 	parsedYear?: number;
 	parsedSeason?: number;
 	parsedEpisode?: number;
+	parsedEpisodes?: number[];
 	inferredMediaType: MediaType;
 	matches?: MatchResult[];
 }

--- a/src/lib/components/naming/NamingFormatField.svelte
+++ b/src/lib/components/naming/NamingFormatField.svelte
@@ -94,7 +94,7 @@
 			<textarea
 				{id}
 				bind:this={inputRef}
-				class="textarea min-h-[120px] w-full resize-y textarea-ghost font-mono text-sm leading-relaxed [font-variant-ligatures:none] focus:bg-base-200/50"
+				class="textarea min-h-30 w-full resize-y textarea-ghost font-mono text-sm leading-relaxed [font-variant-ligatures:none] focus:bg-base-200/50"
 				{placeholder}
 				aria-label={label}
 				aria-describedby={describedBy}

--- a/src/lib/server/library/manual-import-service.ts
+++ b/src/lib/server/library/manual-import-service.ts
@@ -70,6 +70,7 @@ interface ManualImportDetectionData {
 	parsedYear?: number;
 	parsedSeason?: number;
 	parsedEpisode?: number;
+	parsedEpisodes?: number[];
 	inferredMediaType: MediaType;
 	matches: ManualImportMatch[];
 }
@@ -266,6 +267,10 @@ export class ManualImportService {
 					: tvIdentifier?.numbering === 'absolute'
 						? tvIdentifier.absoluteEpisode
 						: undefined,
+			parsedEpisodes:
+				tvIdentifier?.numbering === 'standard' && tvIdentifier.episodeNumbers.length > 1
+					? tvIdentifier.episodeNumbers
+					: undefined,
 			inferredMediaType,
 			matches: enrichedMatches
 		};
@@ -591,10 +596,11 @@ export class ManualImportService {
 					);
 				}
 
+				const primaryEpisodeNumber = fileMapping.episodeNumbers[0];
 				const episodeMeta = await this.getEpisodeMetaCached(
 					request.tmdbId,
 					fileMapping.seasonNumber,
-					fileMapping.episodeNumber,
+					primaryEpisodeNumber,
 					episodeMetaCache,
 					tvContext.existingSeriesDbId,
 					tvContext.tmdbSeriesSeasons
@@ -604,7 +610,7 @@ export class ManualImportService {
 					parsed,
 					tvContext.namingInfoBase,
 					fileMapping.seasonNumber,
-					fileMapping.episodeNumber,
+					fileMapping.episodeNumbers,
 					episodeMeta.title,
 					episodeMeta.absoluteNumber,
 					episodeMeta.airDate
@@ -638,7 +644,7 @@ export class ManualImportService {
 					parsedTitle: parsed.cleanTitle || sourceBaseName,
 					parsedYear: parsed.year,
 					parsedSeason: fileMapping.seasonNumber,
-					parsedEpisode: fileMapping.episodeNumber,
+					parsedEpisode: primaryEpisodeNumber,
 					tmdbId: request.tmdbId
 				});
 
@@ -646,7 +652,7 @@ export class ManualImportService {
 				unmatchedIds.push(unmatchedId);
 				episodeMapping[unmatchedId] = {
 					season: fileMapping.seasonNumber,
-					episode: fileMapping.episodeNumber
+					episode: primaryEpisodeNumber
 				};
 			}
 		}
@@ -1411,7 +1417,7 @@ export class ManualImportService {
 		request: ExecuteManualImportRequest,
 		totalFiles: number,
 		sourceFilePath: string
-	): { seasonNumber: number; episodeNumber: number } | null {
+	): { seasonNumber: number; episodeNumbers: number[] } | null {
 		const resolved = resolveTvEpisodeIdentifier({
 			filePath: sourceFilePath,
 			parsed,
@@ -1421,7 +1427,7 @@ export class ManualImportService {
 		if (resolved?.numbering === 'standard') {
 			return {
 				seasonNumber: resolved.seasonNumber,
-				episodeNumber: resolved.episodeNumbers[0]
+				episodeNumbers: resolved.episodeNumbers
 			};
 		}
 
@@ -1431,7 +1437,7 @@ export class ManualImportService {
 
 		return {
 			seasonNumber: request.seasonNumber ?? 1,
-			episodeNumber: request.episodeNumber ?? 1
+			episodeNumbers: request.episodeNumber != null ? [request.episodeNumber] : [1]
 		};
 	}
 
@@ -1545,7 +1551,7 @@ export class ManualImportService {
 		parsed: ReturnType<typeof parseRelease>,
 		namingInfoBase: MediaNamingInfo,
 		seasonNumber: number,
-		episodeNumber: number,
+		episodeNumbers: number[],
 		episodeTitle?: string,
 		absoluteNumber?: number,
 		airDate?: string
@@ -1555,7 +1561,7 @@ export class ManualImportService {
 			{
 				...namingInfoBase,
 				seasonNumber,
-				episodeNumbers: [episodeNumber],
+				episodeNumbers,
 				episodeTitle,
 				absoluteNumber,
 				airDate

--- a/src/lib/server/logging/log-history.ts
+++ b/src/lib/server/logging/log-history.ts
@@ -392,6 +392,21 @@ class LogHistoryService {
 		return result.entries;
 	}
 
+	async clearAllFiles(): Promise<void> {
+		if (!existsSync(LOGS_DIR)) return;
+		const directory = await opendir(LOGS_DIR);
+		for await (const entry of directory) {
+			if (!entry.isFile()) continue;
+			if (!parseLogFileDate(entry.name)) continue;
+			const filePath = join(LOGS_DIR, entry.name);
+			if (filePath === this.currentFilePath) {
+				this.closeStream();
+				this.currentFilePath = null;
+			}
+			await unlink(filePath);
+		}
+	}
+
 	async cleanupOldFiles(retentionDays?: number): Promise<void> {
 		const resolvedRetention = retentionDays ?? (await this.getRetentionDays());
 		if (!existsSync(LOGS_DIR)) return;

--- a/src/routes/api/library/collections/[tmdbId]/track/+server.ts
+++ b/src/routes/api/library/collections/[tmdbId]/track/+server.ts
@@ -1,0 +1,207 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { db } from '$lib/server/db/index.js';
+import { movies } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
+import { tmdb } from '$lib/server/tmdb.js';
+import { requireAuth } from '$lib/server/auth/authorization.js';
+import { logger } from '$lib/logging';
+import { buildMovieFolderName } from '$lib/server/library/naming/naming-helpers.js';
+import { namingSettingsService } from '$lib/server/library/naming/NamingSettingsService.js';
+import {
+	extractLanguageCodes,
+	resolveLocalizedTitles
+} from '$lib/server/library/naming/localization.js';
+import {
+	validateRootFolder,
+	getAnimeSubtypeEnforcement,
+	getEffectiveScoringProfileId,
+	getLanguageProfileId,
+	fetchMovieDetails,
+	fetchMovieExternalIds,
+	triggerMovieSearch
+} from '$lib/server/library/LibraryAddService.js';
+import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
+import { fetchAndStoreMovieAlternateTitles } from '$lib/server/services/AlternateTitleService.js';
+import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
+import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+
+const trackSchema = z.object({
+	rootFolderId: z.string().min(1),
+	scoringProfileId: z.string().optional(),
+	monitored: z.boolean().default(true),
+	searchOnAdd: z.boolean().default(false)
+});
+
+export const POST: RequestHandler = async (event) => {
+	const authError = requireAuth(event);
+	if (authError) return authError;
+
+	const tmdbCollectionId = parseInt(event.params.tmdbId, 10);
+	if (isNaN(tmdbCollectionId)) {
+		return json({ success: false, error: 'Invalid collection ID' }, { status: 400 });
+	}
+
+	const body = await event.request.json().catch(() => null);
+	const parsed = trackSchema.safeParse(body);
+	if (!parsed.success) {
+		return json({ success: false, error: 'Invalid request body' }, { status: 400 });
+	}
+
+	const { rootFolderId, scoringProfileId, monitored, searchOnAdd: shouldSearch } = parsed.data;
+
+	const collection = await tmdb.getCollection(tmdbCollectionId).catch((err) => {
+		logger.warn(
+			{ tmdbCollectionId, error: err instanceof Error ? err.message : String(err) },
+			'[TrackCollection] Failed to fetch collection from TMDB'
+		);
+		return null;
+	});
+
+	if (!collection) {
+		return json({ success: false, error: 'Collection not found on TMDB' }, { status: 404 });
+	}
+
+	const parts = collection.parts ?? [];
+	if (parts.length === 0) {
+		return json({ success: true, added: 0, skipped: 0, errors: [] });
+	}
+
+	// Find which parts are already in the library
+	const existingTmdbIds = new Set(
+		(
+			await db
+				.select({ tmdbId: movies.tmdbId })
+				.from(movies)
+				.where(eq(movies.tmdbCollectionId, tmdbCollectionId))
+		).map((m) => m.tmdbId)
+	);
+
+	const missing = parts.filter((p) => !existingTmdbIds.has(p.id));
+
+	if (missing.length === 0) {
+		return json({ success: true, added: 0, skipped: parts.length, errors: [] });
+	}
+
+	const enforceAnimeSubtype = await getAnimeSubtypeEnforcement();
+	const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId);
+	const namingConfig = namingSettingsService.getConfigSync();
+	const langCodes = [
+		...new Set([
+			...extractLanguageCodes(namingConfig.movieFolderFormat),
+			...extractLanguageCodes(namingConfig.movieFileFormat)
+		])
+	];
+
+	const results = { added: 0, skipped: existingTmdbIds.size, errors: [] as string[] };
+
+	for (const part of missing) {
+		try {
+			const movieDetails = await fetchMovieDetails(part.id);
+
+			const isAnimeMedia = isLikelyAnimeMedia({
+				genres: movieDetails.genres,
+				originalLanguage: movieDetails.original_language,
+				originCountries: movieDetails.production_countries?.map((c) => c.iso_3166_1),
+				productionCountries: movieDetails.production_countries,
+				title: movieDetails.title,
+				originalTitle: movieDetails.original_title
+			});
+
+			await validateRootFolder(rootFolderId, 'movie', {
+				enforceAnimeSubtype,
+				isAnimeMedia,
+				mediaTitle: movieDetails.title
+			});
+
+			const owningLibrary = await getLibraryEntityService().resolveOwningLibraryForRootFolder(
+				rootFolderId,
+				'movie'
+			);
+
+			const year = movieDetails.release_date
+				? new Date(movieDetails.release_date).getFullYear()
+				: undefined;
+
+			const collectionData = movieDetails.belongs_to_collection;
+
+			const localizedTitles =
+				langCodes.length > 0 ? await resolveLocalizedTitles(part.id, langCodes) : undefined;
+
+			const folderName = buildMovieFolderName(
+				movieDetails.title,
+				year,
+				part.id,
+				collectionData?.name,
+				localizedTitles,
+				movieDetails.original_title
+			);
+
+			const { imdbId } = await fetchMovieExternalIds(part.id);
+			const languageProfileId = await getLanguageProfileId(true, part.id);
+
+			const [newMovie] = await db
+				.insert(movies)
+				.values({
+					tmdbId: part.id,
+					imdbId,
+					title: movieDetails.title,
+					originalTitle: movieDetails.original_title,
+					year,
+					overview: movieDetails.overview,
+					posterPath: movieDetails.poster_path,
+					backdropPath: movieDetails.backdrop_path,
+					runtime: movieDetails.runtime,
+					genres: movieDetails.genres?.map((g) => g.name) ?? [],
+					path: folderName,
+					libraryId: owningLibrary.id,
+					rootFolderId,
+					scoringProfileId: effectiveProfileId,
+					monitored,
+					minimumAvailability: 'released',
+					availabilityDelay: 0,
+					hasFile: false,
+					wantsSubtitles: true,
+					languageProfileId,
+					tmdbCollectionId: collectionData?.id ?? tmdbCollectionId,
+					collectionName: collectionData?.name ?? collection.name,
+					releaseDate: movieDetails.release_date ?? null
+				})
+				.returning();
+
+			fetchAndStoreMovieAlternateTitles(newMovie.id, part.id).catch(() => {});
+
+			if (shouldSearch) {
+				await triggerMovieSearch({
+					movieId: newMovie.id,
+					tmdbId: part.id,
+					imdbId,
+					title: movieDetails.title,
+					year,
+					scoringProfileId: effectiveProfileId
+				}).catch(() => {});
+			}
+
+			libraryMediaEvents.emitLibraryDataChanged({
+				source: 'movie',
+				reason: 'movie-added',
+				entityId: newMovie.id
+			});
+
+			results.added++;
+		} catch (err) {
+			logger.warn(
+				{
+					tmdbId: part.id,
+					title: part.title,
+					error: err instanceof Error ? err.message : String(err)
+				},
+				'[TrackCollection] Failed to add collection part'
+			);
+			results.errors.push(`${part.title}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+		}
+	}
+
+	return json({ success: true, ...results });
+};

--- a/src/routes/api/settings/logs/history/+server.ts
+++ b/src/routes/api/settings/logs/history/+server.ts
@@ -31,3 +31,16 @@ export const GET: RequestHandler = async (event) => {
 		return json({ success: false, error: 'Failed to load log history' }, { status: 500 });
 	}
 };
+
+export const DELETE: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	try {
+		await logHistoryService.clearAllFiles();
+		return json({ success: true });
+	} catch (error) {
+		logger.error({ err: error }, 'Failed to clear log history');
+		return json({ success: false, error: 'Failed to clear log history' }, { status: 500 });
+	}
+};

--- a/src/routes/discover/+page.svelte
+++ b/src/routes/discover/+page.svelte
@@ -354,8 +354,9 @@
 	let filteredOutResults = $state<ResultsType>([]);
 	let debugLoading = $state(false);
 
+	let debugResultsLoaded = $state(false);
 	$effect(() => {
-		if (debugMode && filteredOutResults.length === 0 && !debugLoading) {
+		if (debugMode && !debugResultsLoaded && !debugLoading) {
 			loadDebugResults();
 		}
 	});
@@ -380,6 +381,7 @@
 			toasts.error('Failed to load debug results');
 		} finally {
 			debugLoading = false;
+			debugResultsLoaded = true;
 		}
 	}
 
@@ -387,9 +389,11 @@
 		debugMode = !debugMode;
 		localStorage.setItem('discover_debugMode', String(debugMode));
 		if (debugMode) {
+			debugResultsLoaded = false;
 			loadDebugResults();
 		} else {
 			filteredOutResults = [];
+			debugResultsLoaded = false;
 		}
 	}
 

--- a/src/routes/library/import/+page.svelte
+++ b/src/routes/library/import/+page.svelte
@@ -898,6 +898,7 @@
 			parsedYear: result.parsedYear,
 			parsedSeason: result.parsedSeason,
 			parsedEpisode: result.parsedEpisode,
+			parsedEpisodes: result.parsedEpisodes,
 			inferredMediaType: result.inferredMediaType,
 			matches: result.matches ?? []
 		};

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -28,6 +28,26 @@ export interface QueueItemInfo {
 	progress: number | null;
 }
 
+export interface CollectionPart {
+	tmdbId: number;
+	title: string;
+	year: number | null;
+	posterPath: string | null;
+	releaseDate: string | null;
+	inLibrary: boolean;
+	movieId: string | null;
+	hasFile: boolean | null;
+	hasSubtitles: boolean;
+}
+
+export interface CollectionInfo {
+	tmdbId: number;
+	name: string;
+	posterPath: string | null;
+	backdropPath: string | null;
+	parts: CollectionPart[];
+}
+
 export interface LibraryMoviePageData {
 	movie: LibraryMovie;
 	librarySlug: string | null;
@@ -58,14 +78,7 @@ export interface LibraryMoviePageData {
 		anilist: boolean;
 		mal: boolean;
 	};
-	collectionMovies: {
-		id: string;
-		title: string;
-		year: number | null;
-		posterPath: string | null;
-		hasFile: boolean | null;
-		monitored: boolean | null;
-	}[];
+	collection: CollectionInfo | null;
 }
 
 function isAnimeMovieSignal(input: {
@@ -269,27 +282,67 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 				}
 			: null;
 
-	let collectionMovies: {
-		id: string;
-		title: string;
-		year: number | null;
-		posterPath: string | null;
-		hasFile: boolean | null;
-		monitored: boolean | null;
-	}[] = [];
+	let collection: CollectionInfo | null = null;
 	if (movie.tmdbCollectionId) {
-		collectionMovies = await db
-			.select({
-				id: movies.id,
-				title: movies.title,
-				year: movies.year,
-				posterPath: movies.posterPath,
-				hasFile: movies.hasFile,
-				monitored: movies.monitored
-			})
-			.from(movies)
-			.where(eq(movies.tmdbCollectionId, movie.tmdbCollectionId));
-		collectionMovies = collectionMovies.filter((m) => m.id !== movie.id);
+		const [tmdbCollection, libraryMembers] = await Promise.all([
+			tmdb.getCollection(movie.tmdbCollectionId).catch((err) => {
+				logger.warn(
+					{
+						collectionId: movie.tmdbCollectionId,
+						error: err instanceof Error ? err.message : String(err)
+					},
+					'[LibraryMovie] Failed to fetch TMDB collection'
+				);
+				return null;
+			}),
+			db
+				.select({
+					id: movies.id,
+					tmdbId: movies.tmdbId,
+					hasFile: movies.hasFile
+				})
+				.from(movies)
+				.where(eq(movies.tmdbCollectionId, movie.tmdbCollectionId))
+		]);
+
+		if (tmdbCollection) {
+			const libraryByTmdbId = new Map(libraryMembers.map((m) => [m.tmdbId, m]));
+
+			const libraryMovieIds = libraryMembers.map((m) => m.id);
+			const subtitleMovieIds =
+				libraryMovieIds.length > 0
+					? new Set(
+							(
+								await db
+									.selectDistinct({ movieId: subtitles.movieId })
+									.from(subtitles)
+									.where(inArray(subtitles.movieId, libraryMovieIds))
+							).map((r) => r.movieId)
+						)
+					: new Set<string>();
+
+			const parts: CollectionPart[] = (tmdbCollection.parts ?? []).map((part) => {
+				const lib = libraryByTmdbId.get(part.id);
+				return {
+					tmdbId: part.id,
+					title: part.title,
+					year: part.release_date ? new Date(part.release_date).getFullYear() : null,
+					posterPath: part.poster_path,
+					releaseDate: part.release_date ?? null,
+					inLibrary: !!lib,
+					movieId: lib?.id ?? null,
+					hasFile: lib?.hasFile ?? null,
+					hasSubtitles: lib ? subtitleMovieIds.has(lib.id) : false
+				};
+			});
+			collection = {
+				tmdbId: tmdbCollection.id,
+				name: tmdbCollection.name,
+				posterPath: tmdbCollection.poster_path,
+				backdropPath: tmdbCollection.backdrop_path,
+				parts
+			};
+		}
 	}
 
 	const isSearching = isMovieSearching(id);
@@ -331,6 +384,6 @@ export const load: PageServerLoad = async ({ params }): Promise<LibraryMoviePage
 		queueItem,
 		isSearching,
 		configuredMetadataProviders,
-		collectionMovies
+		collection
 	};
 };

--- a/src/routes/library/movie/[id]/+page.svelte
+++ b/src/routes/library/movie/[id]/+page.svelte
@@ -30,9 +30,20 @@
 	} from '$lib/api/library.js';
 	import { apiGetStream } from '$lib/api';
 	import type { MovieEditData } from '$lib/components/library/MovieEditModal.svelte';
-	import { FileEdit, Loader2, RefreshCw, Captions } from 'lucide-svelte';
+	import {
+		FileEdit,
+		Loader2,
+		RefreshCw,
+		Captions,
+		Layers,
+		Plus,
+		Zap,
+		Eye,
+		EyeOff,
+		Info
+	} from 'lucide-svelte';
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import { resolvePath } from '$lib/utils/routing';
 	import { createDynamicSSE } from '$lib/sse';
 	import { getFileName } from '$lib/utils/format.js';
@@ -128,10 +139,12 @@
 				movie.files = [...movie.files, payload.file];
 			}
 			movie.hasFile = movie.files.length > 0;
+			invalidateAll();
 		},
 		'file:removed': (payload) => {
 			movie.files = movie.files.filter((f) => f.id !== payload.fileId);
 			movie.hasFile = movie.files.length > 0;
+			invalidateAll();
 		}
 	});
 
@@ -194,6 +207,81 @@
 	let scoreLoading = $state(false);
 	let scoreFetched = $state(false);
 	let collectionSubtitleAutoSearching = $state(false);
+	let collectionSearching = $state(false);
+	let trackPanelOpen = $state(false);
+	let trackAction = $state<'monitor-search' | 'monitor' | 'add'>('monitor-search');
+	let tracking = $state(false);
+	let addingPart = $state<{ tmdbId: number; title: string } | null>(null);
+	let hoveredPartTmdbId = $state<number | null>(null);
+	let addPartAction = $state<'monitor-search' | 'monitor' | 'add'>('monitor-search');
+	let addingPartLoading = $state(false);
+
+	const collectionParts = $derived(
+		(data.collection?.parts ?? []).filter((p) => p.tmdbId !== movie.tmdbId)
+	);
+	const missingParts = $derived(collectionParts.filter((p) => !p.inLibrary));
+	const trackedMissingFile = $derived(collectionParts.filter((p) => p.inLibrary && !p.hasFile));
+	const trackedMissingSubtitles = $derived(
+		collectionParts.filter((p) => p.inLibrary && p.hasFile && !p.hasSubtitles)
+	);
+
+	async function handleAddPart() {
+		if (!addingPart || !movie.rootFolderId) return;
+		addingPartLoading = true;
+		try {
+			const res = await fetch('/api/library/movies', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					tmdbId: addingPart.tmdbId,
+					rootFolderId: movie.rootFolderId,
+					scoringProfileId: movie.scoringProfileId ?? undefined,
+					monitored: addPartAction !== 'add',
+					searchOnAdd: addPartAction === 'monitor-search',
+					minimumAvailability: 'released',
+					availabilityDelay: 0,
+					wantsSubtitles: true
+				})
+			});
+			const result = await res.json();
+			if (!res.ok) throw new Error(result.error ?? 'Failed to add movie');
+			toasts.success(`${addingPart.title} added to library`);
+			addingPart = null;
+			await invalidateAll();
+		} catch (err) {
+			showActionError('Failed to add movie', err);
+		} finally {
+			addingPartLoading = false;
+		}
+	}
+
+	async function handleTrackCollection() {
+		if (!data.collection || !movie.rootFolderId) return;
+		tracking = true;
+		try {
+			const res = await fetch(`/api/library/collections/${data.collection.tmdbId}/track`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					rootFolderId: movie.rootFolderId,
+					scoringProfileId: movie.scoringProfileId ?? undefined,
+					monitored: trackAction !== 'add',
+					searchOnAdd: trackAction === 'monitor-search'
+				})
+			});
+			const result = await res.json();
+			if (!res.ok) throw new Error(result.error ?? 'Failed to add collection');
+			if (result.added > 0) {
+				toasts.success(`Added ${result.added} movie${result.added === 1 ? '' : 's'} to library`);
+				trackPanelOpen = false;
+				await invalidateAll();
+			}
+		} catch (err) {
+			showActionError('Failed to add collection', err);
+		} finally {
+			tracking = false;
+		}
+	}
 
 	const subtitleProgress = createSubtitleProgress();
 
@@ -629,6 +717,32 @@
 		}
 	}
 
+	async function handleCollectionSearch(): Promise<void> {
+		if (trackedMissingFile.length === 0) return;
+		collectionSearching = true;
+		let searched = 0;
+		try {
+			await Promise.all(
+				trackedMissingFile
+					.filter((p) => p.movieId)
+					.map((p) =>
+						fetch(`/api/library/movies/${p.movieId}/auto-search`, { method: 'POST' })
+							.then((r) => {
+								if (r.ok) searched++;
+							})
+							.catch(() => {})
+					)
+			);
+			if (searched > 0) {
+				toasts.success(`Triggered search for ${searched} movie${searched > 1 ? 's' : ''}`);
+			}
+		} catch (error) {
+			showActionError('Failed to trigger search', error);
+		} finally {
+			collectionSearching = false;
+		}
+	}
+
 	function handleSubtitleDownloaded(subtitle: {
 		id: string;
 		language: string;
@@ -785,70 +899,274 @@
 				/>
 			</div>
 
-			{#if data.collectionMovies && data.collectionMovies.length > 0}
-				<div class="mt-4 hidden rounded-xl bg-base-200 p-4 md:mt-6 md:block md:p-6">
-					<div class="mb-4 flex items-center justify-between">
-						<h2 class="text-lg font-semibold">
-							{m.library_movieDetail_otherMoviesInCollection()}
-						</h2>
-						<button
-							class="btn gap-2 btn-ghost btn-sm"
-							onclick={handleCollectionSubtitleAutoSearch}
-							disabled={collectionSubtitleAutoSearching}
-							title="Auto-download subtitles for all movies in collection"
-						>
-							{#if collectionSubtitleAutoSearching}
-								<Loader2 size={16} class="animate-spin" />
-							{:else}
-								<Captions size={16} />
-							{/if}
-						</button>
-					</div>
-					<div class="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-						{#each data.collectionMovies as collMovie (collMovie.id)}
-							<a
-								href={resolvePath(`/library/movie/${collMovie.id}`)}
-								class="flex min-w-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
-							>
-								<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
-									{#if collMovie.posterPath}
-										<img
-											src="https://image.tmdb.org/t/p/w185{collMovie.posterPath}"
-											alt={collMovie.title}
-											class="h-full w-full object-cover"
-											loading="lazy"
-										/>
+			{#if data.collection}
+				{@const col = data.collection}
+				<div class="mt-4 hidden rounded-xl bg-base-200 md:mt-6 md:block">
+					<!-- Header -->
+					<div class="flex items-center justify-between p-4 md:p-6 pb-3">
+						<div class="flex items-center gap-2">
+							<Layers class="h-4 w-4 text-primary shrink-0" />
+							<h2 class="text-lg font-semibold">
+								Part of <span class="text-primary">{col.name}</span>
+							</h2>
+						</div>
+						<div class="flex items-center gap-1">
+							{#if trackedMissingFile.length > 0}
+								<button
+									class="btn btn-ghost btn-sm gap-2"
+									onclick={handleCollectionSearch}
+									disabled={collectionSearching}
+									title="Search for missing movies in this collection"
+								>
+									{#if collectionSearching}
+										<Loader2 size={16} class="animate-spin" />
 									{:else}
-										<div
-											class="flex h-full w-full items-center justify-center text-base-content/30"
-										></div>
+										<Zap size={16} />
 									{/if}
-									{#if collMovie.hasFile}
-										<span
-											class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
-										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												class="h-2.5 w-2.5"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-												stroke-width="3"
-											>
-												<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-											</svg>
-										</span>
+								</button>
+							{/if}
+							{#if trackedMissingSubtitles.length > 0}
+								<button
+									class="btn btn-ghost btn-sm gap-2"
+									onclick={handleCollectionSubtitleAutoSearch}
+									disabled={collectionSubtitleAutoSearching}
+									title="Auto-download missing subtitles for movies in this collection"
+								>
+									{#if collectionSubtitleAutoSearching}
+										<Loader2 size={16} class="animate-spin" />
+									{:else}
+										<Captions size={16} />
 									{/if}
-								</div>
-								<span class="line-clamp-2 text-center text-xs leading-tight font-medium">
-									{collMovie.title}
-								</span>
-								{#if collMovie.year}
-									<span class="text-[10px] text-base-content/50">{collMovie.year}</span>
-								{/if}
-							</a>
-						{/each}
+								</button>
+							{/if}
+						</div>
 					</div>
+
+					<!-- Parts grid -->
+					<div class="px-4 md:px-6 pb-4">
+						<div class="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
+							{#each collectionParts as part (part.tmdbId)}
+								{#if part.inLibrary && part.movieId}
+									<a
+										href={resolvePath(`/library/movie/${part.movieId}`)}
+										class="flex min-w-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
+									>
+										<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
+											{#if part.posterPath}
+												<img
+													src="https://image.tmdb.org/t/p/w185{part.posterPath}"
+													alt={part.title}
+													class="h-full w-full object-cover"
+													loading="lazy"
+												/>
+											{/if}
+											{#if part.hasFile}
+												<span
+													class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
+												>
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														class="h-2.5 w-2.5"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke="currentColor"
+														stroke-width="3"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															d="M5 13l4 4L19 7"
+														/>
+													</svg>
+												</span>
+											{/if}
+										</div>
+										<span class="line-clamp-2 text-center text-xs leading-tight font-medium"
+											>{part.title}</span
+										>
+										{#if part.year}<span class="text-[10px] text-base-content/50">{part.year}</span
+											>{/if}
+									</a>
+								{:else}
+									<div
+										role="group"
+										class="flex min-w-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300/60"
+										onmouseenter={() => (hoveredPartTmdbId = part.tmdbId)}
+										onmouseleave={() => (hoveredPartTmdbId = null)}
+									>
+										<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
+											{#if part.posterPath}
+												<img
+													src="https://image.tmdb.org/t/p/w185{part.posterPath}"
+													alt={part.title}
+													class="h-full w-full object-cover opacity-40 transition-opacity {hoveredPartTmdbId ===
+													part.tmdbId
+														? 'opacity-60'
+														: ''}"
+													loading="lazy"
+												/>
+											{:else}
+												<div class="h-full w-full opacity-40"></div>
+											{/if}
+											<div
+												class="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/20 transition-opacity {hoveredPartTmdbId ===
+												part.tmdbId
+													? 'opacity-100'
+													: 'opacity-0'}"
+											>
+												<button
+													type="button"
+													class="rounded-full bg-primary p-1.5 text-primary-content shadow-lg hover:bg-primary/80"
+													title="Add to library"
+													onclick={() => {
+														addingPart = { tmdbId: part.tmdbId, title: part.title };
+														addPartAction = 'monitor-search';
+														trackPanelOpen = false;
+													}}
+												>
+													<Plus class="h-3.5 w-3.5" />
+												</button>
+												<a
+													href={resolvePath(`/discover/movie/${part.tmdbId}`)}
+													class="rounded-full bg-base-100/80 p-1.5 text-base-content shadow-lg hover:bg-base-100"
+													title="View in Discover"
+												>
+													<Info class="h-3.5 w-3.5" />
+												</a>
+											</div>
+										</div>
+										<span
+											class="line-clamp-2 text-center text-xs leading-tight font-medium text-base-content/50"
+											>{part.title}</span
+										>
+										{#if part.year}<span class="text-[10px] text-base-content/40">{part.year}</span
+											>{/if}
+									</div>
+								{/if}
+							{/each}
+						</div>
+					</div>
+
+					<!-- Bottom panel: per-movie add or track-all -->
+					{#if addingPart || missingParts.length > 0}
+						<div class="border-t border-base-300 px-4 md:px-6 py-4">
+							{#if addingPart}
+								<!-- Per-movie add panel -->
+								<div class="space-y-4">
+									<div class="flex items-center justify-between">
+										<p class="text-sm font-medium">
+											Add <span class="text-primary">{addingPart.title}</span>
+										</p>
+										<button class="btn btn-ghost btn-xs" onclick={() => (addingPart = null)}
+											>✕</button
+										>
+									</div>
+									<div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
+										{#each [{ value: 'monitor-search', Icon: Zap, label: 'Monitor & Search', desc: 'Add and start searching for releases immediately' }, { value: 'monitor', Icon: Eye, label: 'Monitor Only', desc: 'Add and monitor for releases automatically' }, { value: 'add', Icon: EyeOff, label: 'Add Unmonitored', desc: 'Add without automatic searching or monitoring' }] as opt (opt)}
+											<button
+												type="button"
+												class="flex items-start gap-3 rounded-xl border-2 p-3 text-left transition-colors {addPartAction ===
+												opt.value
+													? 'border-primary bg-primary/5'
+													: 'border-base-300 hover:border-base-content/30 hover:bg-base-300/40'}"
+												onclick={() => (addPartAction = opt.value as typeof addPartAction)}
+											>
+												<div
+													class="mt-0.5 shrink-0 rounded-lg p-1.5 {addPartAction === opt.value
+														? 'bg-primary/15 text-primary'
+														: 'bg-base-300 text-base-content/50'}"
+												>
+													<opt.Icon class="h-4 w-4" />
+												</div>
+												<div class="min-w-0">
+													<p class="text-sm font-semibold leading-tight">{opt.label}</p>
+													<p class="mt-0.5 text-xs text-base-content/55 leading-snug">{opt.desc}</p>
+												</div>
+											</button>
+										{/each}
+									</div>
+									<div class="flex gap-2">
+										<button
+											class="btn btn-primary btn-sm gap-2"
+											onclick={handleAddPart}
+											disabled={addingPartLoading}
+										>
+											{#if addingPartLoading}<Loader2
+													class="h-3.5 w-3.5 animate-spin"
+												/>{:else}<Plus class="h-3.5 w-3.5" />{/if}
+											Confirm
+										</button>
+										<button class="btn btn-ghost btn-sm" onclick={() => (addingPart = null)}
+											>Cancel</button
+										>
+									</div>
+								</div>
+							{:else if !trackPanelOpen}
+								<button
+									class="btn btn-primary btn-sm gap-2"
+									onclick={() => (trackPanelOpen = true)}
+								>
+									<Plus class="h-4 w-4" />
+									Add collection
+									<span class="badge badge-primary-content badge-sm"
+										>{missingParts.length} missing</span
+									>
+								</button>
+							{:else}
+								<div class="space-y-4">
+									<p class="text-sm text-base-content/70">
+										{missingParts.length} movie{missingParts.length === 1 ? '' : 's'} from this collection
+										{missingParts.length === 1 ? 'is' : 'are'} not in your library. How would you like
+										to add {missingParts.length === 1 ? 'it' : 'them'}?
+									</p>
+
+									<div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
+										{#each [{ value: 'monitor-search', Icon: Zap, label: 'Monitor & Search', desc: 'Add and start searching for releases immediately' }, { value: 'monitor', Icon: Eye, label: 'Monitor Only', desc: 'Add and monitor for releases automatically' }, { value: 'add', Icon: EyeOff, label: 'Add Unmonitored', desc: 'Add without automatic searching or monitoring' }] as opt (opt)}
+											<button
+												type="button"
+												class="flex items-start gap-3 rounded-xl border-2 p-3 text-left transition-colors {trackAction ===
+												opt.value
+													? 'border-primary bg-primary/5'
+													: 'border-base-300 hover:border-base-content/30 hover:bg-base-300/40'}"
+												onclick={() => (trackAction = opt.value as typeof trackAction)}
+											>
+												<div
+													class="mt-0.5 shrink-0 rounded-lg p-1.5 {trackAction === opt.value
+														? 'bg-primary/15 text-primary'
+														: 'bg-base-300 text-base-content/50'}"
+												>
+													<opt.Icon class="h-4 w-4" />
+												</div>
+												<div class="min-w-0">
+													<p class="text-sm font-semibold leading-tight">{opt.label}</p>
+													<p class="mt-0.5 text-xs text-base-content/55 leading-snug">{opt.desc}</p>
+												</div>
+											</button>
+										{/each}
+									</div>
+
+									<div class="flex gap-2">
+										<button
+											class="btn btn-primary btn-sm gap-2"
+											onclick={handleTrackCollection}
+											disabled={tracking}
+										>
+											{#if tracking}
+												<Loader2 class="h-3.5 w-3.5 animate-spin" />
+												Adding...
+											{:else}
+												<Plus class="h-3.5 w-3.5" />
+												Confirm
+											{/if}
+										</button>
+										<button class="btn btn-ghost btn-sm" onclick={() => (trackPanelOpen = false)}>
+											Cancel
+										</button>
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
 				</div>
 			{/if}
 		</div>
@@ -937,70 +1255,261 @@
 				</dl>
 			</div>
 
-			{#if data.collectionMovies && data.collectionMovies.length > 0}
-				<div class="rounded-xl bg-base-200 p-4 md:hidden">
-					<div class="mb-4 flex items-center justify-between">
-						<h2 class="text-lg font-semibold">
-							{m.library_movieDetail_otherMoviesInCollection()}
-						</h2>
-						<button
-							class="btn gap-2 btn-ghost btn-sm"
-							onclick={handleCollectionSubtitleAutoSearch}
-							disabled={collectionSubtitleAutoSearching}
-							title="Auto-download subtitles for all movies in collection"
-						>
-							{#if collectionSubtitleAutoSearching}
-								<Loader2 size={16} class="animate-spin" />
-							{:else}
-								<Captions size={16} />
-							{/if}
-						</button>
-					</div>
-					<div class="-mx-1 flex max-w-full gap-3 overflow-x-auto overscroll-x-contain px-1 pb-2">
-						{#each data.collectionMovies as collMovie (collMovie.id)}
-							<a
-								href={resolvePath(`/library/movie/${collMovie.id}`)}
-								class="flex w-24 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
-							>
-								<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
-									{#if collMovie.posterPath}
-										<img
-											src="https://image.tmdb.org/t/p/w185{collMovie.posterPath}"
-											alt={collMovie.title}
-											class="h-full w-full object-cover"
-											loading="lazy"
-										/>
+			{#if data.collection}
+				{@const col = data.collection}
+				<div class="rounded-xl bg-base-200 md:hidden">
+					<div class="flex items-center justify-between p-4 pb-3">
+						<div class="flex items-center gap-2 min-w-0">
+							<Layers class="h-4 w-4 text-primary shrink-0" />
+							<h2 class="text-base font-semibold truncate">
+								Part of <span class="text-primary">{col.name}</span>
+							</h2>
+						</div>
+						<div class="flex items-center gap-1 shrink-0">
+							{#if trackedMissingFile.length > 0}
+								<button
+									class="btn btn-ghost btn-sm gap-2"
+									onclick={handleCollectionSearch}
+									disabled={collectionSearching}
+									title="Search for missing movies in this collection"
+								>
+									{#if collectionSearching}
+										<Loader2 size={16} class="animate-spin" />
 									{:else}
-										<div
-											class="flex h-full w-full items-center justify-center text-base-content/30"
-										></div>
+										<Zap size={16} />
 									{/if}
-									{#if collMovie.hasFile}
-										<span
-											class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
-										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												class="h-2.5 w-2.5"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-												stroke-width="3"
+								</button>
+							{/if}
+							{#if trackedMissingSubtitles.length > 0}
+								<button
+									class="btn btn-ghost btn-sm gap-2"
+									onclick={handleCollectionSubtitleAutoSearch}
+									disabled={collectionSubtitleAutoSearching}
+									title="Auto-download missing subtitles for movies in this collection"
+								>
+									{#if collectionSubtitleAutoSearching}
+										<Loader2 size={16} class="animate-spin" />
+									{:else}
+										<Captions size={16} />
+									{/if}
+								</button>
+							{/if}
+						</div>
+					</div>
+
+					<!-- Horizontal scroll strip -->
+					<div class="-mx-1 flex max-w-full gap-3 overflow-x-auto overscroll-x-contain px-3 pb-3">
+						{#each collectionParts as part (part.tmdbId)}
+							{#if part.inLibrary && part.movieId}
+								<a
+									href={resolvePath(`/library/movie/${part.movieId}`)}
+									class="flex w-24 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300"
+								>
+									<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
+										{#if part.posterPath}
+											<img
+												src="https://image.tmdb.org/t/p/w185{part.posterPath}"
+												alt={part.title}
+												class="h-full w-full object-cover"
+												loading="lazy"
+											/>
+										{/if}
+										{#if part.hasFile}
+											<span
+												class="absolute right-0.5 bottom-0.5 rounded-full bg-success/80 p-0.5 text-success-content"
 											>
-												<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-											</svg>
-										</span>
-									{/if}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													class="h-2.5 w-2.5"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke="currentColor"
+													stroke-width="3"
+												>
+													<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+												</svg>
+											</span>
+										{/if}
+									</div>
+									<span class="line-clamp-2 text-center text-xs leading-tight font-medium"
+										>{part.title}</span
+									>
+									{#if part.year}<span class="text-[10px] text-base-content/50">{part.year}</span
+										>{/if}
+								</a>
+							{:else}
+								<div
+									role="group"
+									class="flex w-24 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-base-300/60"
+									onmouseenter={() => (hoveredPartTmdbId = part.tmdbId)}
+									onmouseleave={() => (hoveredPartTmdbId = null)}
+								>
+									<div class="relative aspect-2/3 w-full overflow-hidden rounded bg-base-300">
+										{#if part.posterPath}
+											<img
+												src="https://image.tmdb.org/t/p/w185{part.posterPath}"
+												alt={part.title}
+												class="h-full w-full object-cover opacity-40 transition-opacity {hoveredPartTmdbId ===
+												part.tmdbId
+													? 'opacity-60'
+													: ''}"
+												loading="lazy"
+											/>
+										{:else}
+											<div class="h-full w-full opacity-40"></div>
+										{/if}
+										<div
+											class="absolute inset-0 flex items-center justify-center gap-1 bg-black/20 transition-opacity {hoveredPartTmdbId ===
+											part.tmdbId
+												? 'opacity-100'
+												: 'opacity-0'}"
+										>
+											<button
+												type="button"
+												class="rounded-full bg-primary p-1.5 text-primary-content shadow-lg hover:bg-primary/80"
+												onclick={() => {
+													addingPart = { tmdbId: part.tmdbId, title: part.title };
+													addPartAction = 'monitor-search';
+													trackPanelOpen = false;
+												}}
+												title="Add to library"
+											>
+												<Plus class="h-3 w-3" />
+											</button>
+											<a
+												href={resolvePath(`/discover/movie/${part.tmdbId}`)}
+												class="rounded-full bg-base-100/80 p-1.5 text-base-content shadow-lg hover:bg-base-100"
+												title="View in Discover"
+											>
+												<Info class="h-3 w-3" />
+											</a>
+										</div>
+									</div>
+									<span
+										class="line-clamp-2 text-center text-xs leading-tight font-medium text-base-content/50"
+										>{part.title}</span
+									>
+									{#if part.year}<span class="text-[10px] text-base-content/40">{part.year}</span
+										>{/if}
 								</div>
-								<span class="line-clamp-2 text-center text-xs leading-tight font-medium">
-									{collMovie.title}
-								</span>
-								{#if collMovie.year}
-									<span class="text-[10px] text-base-content/50">{collMovie.year}</span>
-								{/if}
-							</a>
+							{/if}
 						{/each}
 					</div>
+
+					<!-- Mobile bottom panel: per-movie add or track-all -->
+					{#if addingPart || missingParts.length > 0}
+						<div class="border-t border-base-300 p-4">
+							{#if addingPart}
+								<div class="space-y-4">
+									<div class="flex items-center justify-between">
+										<p class="text-sm font-medium">
+											Add <span class="text-primary">{addingPart.title}</span>
+										</p>
+										<button class="btn btn-ghost btn-xs" onclick={() => (addingPart = null)}
+											>✕</button
+										>
+									</div>
+									<div class="flex flex-col gap-2">
+										{#each [{ value: 'monitor-search', Icon: Zap, label: 'Monitor & search', desc: 'Add and start searching for releases immediately' }, { value: 'monitor', Icon: Eye, label: 'Monitor only', desc: 'Add and wait for future releases automatically' }, { value: 'add', Icon: EyeOff, label: 'Add unmonitored', desc: 'Add without automatic searching or monitoring' }] as opt (opt)}
+											<button
+												type="button"
+												class="flex items-start gap-3 rounded-xl border-2 p-3 text-left transition-colors {addPartAction ===
+												opt.value
+													? 'border-primary bg-primary/5'
+													: 'border-base-300 hover:border-base-content/30'}"
+												onclick={() => (addPartAction = opt.value as typeof addPartAction)}
+											>
+												<div
+													class="mt-0.5 shrink-0 rounded-lg p-1.5 {addPartAction === opt.value
+														? 'bg-primary/15 text-primary'
+														: 'bg-base-300 text-base-content/50'}"
+												>
+													<opt.Icon class="h-4 w-4" />
+												</div>
+												<div class="min-w-0">
+													<p class="text-sm font-semibold leading-tight">{opt.label}</p>
+													<p class="mt-0.5 text-xs text-base-content/55 leading-snug">{opt.desc}</p>
+												</div>
+											</button>
+										{/each}
+									</div>
+									<div class="flex gap-2">
+										<button
+											class="btn btn-primary btn-sm flex-1 gap-2"
+											onclick={handleAddPart}
+											disabled={addingPartLoading}
+										>
+											{#if addingPartLoading}<Loader2
+													class="h-3.5 w-3.5 animate-spin"
+												/>{:else}<Plus class="h-3.5 w-3.5" />{/if}
+											Confirm
+										</button>
+										<button class="btn btn-ghost btn-sm" onclick={() => (addingPart = null)}
+											>Cancel</button
+										>
+									</div>
+								</div>
+							{:else if !trackPanelOpen}
+								<button
+									class="btn btn-primary btn-sm w-full gap-2"
+									onclick={() => (trackPanelOpen = true)}
+								>
+									<Plus class="h-4 w-4" />
+									Add collection
+									<span class="badge badge-primary-content badge-sm"
+										>{missingParts.length} missing</span
+									>
+								</button>
+							{:else}
+								<div class="space-y-4">
+									<p class="text-sm text-base-content/70">
+										{missingParts.length} movie{missingParts.length === 1 ? '' : 's'} from this collection
+										{missingParts.length === 1 ? 'is' : 'are'} not in your library. How would you like
+										to add {missingParts.length === 1 ? 'it' : 'them'}?
+									</p>
+									<div class="flex flex-col gap-2">
+										{#each [{ value: 'monitor-search', Icon: Zap, label: 'Monitor & search', desc: 'Add and start searching for releases immediately' }, { value: 'monitor', Icon: Eye, label: 'Monitor only', desc: 'Add and wait for future releases automatically' }, { value: 'add', Icon: EyeOff, label: 'Add unmonitored', desc: 'Add without automatic searching or monitoring' }] as opt (opt)}
+											<button
+												type="button"
+												class="flex items-start gap-3 rounded-xl border-2 p-3 text-left transition-colors {trackAction ===
+												opt.value
+													? 'border-primary bg-primary/5'
+													: 'border-base-300 hover:border-base-content/30'}"
+												onclick={() => (trackAction = opt.value as typeof trackAction)}
+											>
+												<div
+													class="mt-0.5 shrink-0 rounded-lg p-1.5 {trackAction === opt.value
+														? 'bg-primary/15 text-primary'
+														: 'bg-base-300 text-base-content/50'}"
+												>
+													<opt.Icon class="h-4 w-4" />
+												</div>
+												<div class="min-w-0">
+													<p class="text-sm font-semibold leading-tight">{opt.label}</p>
+													<p class="mt-0.5 text-xs text-base-content/55 leading-snug">{opt.desc}</p>
+												</div>
+											</button>
+										{/each}
+									</div>
+									<div class="flex gap-2">
+										<button
+											class="btn btn-primary btn-sm flex-1 gap-2"
+											onclick={handleTrackCollection}
+											disabled={tracking}
+										>
+											{#if tracking}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Plus
+													class="h-3.5 w-3.5"
+												/>{/if}
+											Confirm
+										</button>
+										<button class="btn btn-ghost btn-sm" onclick={() => (trackPanelOpen = false)}
+											>Cancel</button
+										>
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
 				</div>
 			{/if}
 		</div>

--- a/src/routes/library/movies/+page.svelte
+++ b/src/routes/library/movies/+page.svelte
@@ -789,13 +789,23 @@
 			</div>
 		{:else if filteredMovies.length === 0 && searchQuery}
 			<!-- Search Empty State -->
-			<div class="flex flex-col items-center justify-center py-20 text-center opacity-50">
-				<Search class="mb-4 h-16 w-16" />
-				<p class="text-2xl font-bold">{m.library_movies_noSearchMatch({ query: searchQuery })}</p>
-				<p class="mt-2">{m.library_movies_tryDifferentSearch()}</p>
-				<button class="btn mt-6 btn-ghost" onclick={() => (searchQuery = '')}>
-					{m.library_movies_clearSearchBtn()}
-				</button>
+			<div class="flex flex-col items-center justify-center py-20 text-center">
+				<div class="opacity-50">
+					<Search class="mb-4 h-16 w-16 mx-auto" />
+					<p class="text-2xl font-bold">{m.library_movies_noSearchMatch({ query: searchQuery })}</p>
+					<p class="mt-2">{m.library_movies_tryDifferentSearch()}</p>
+				</div>
+				<div class="mt-6 flex gap-3">
+					<button class="btn btn-ghost" onclick={() => (searchQuery = '')}>
+						{m.library_movies_clearSearchBtn()}
+					</button>
+					<a
+						href={resolvePath(`/discover?type=movie&q=${encodeURIComponent(searchQuery)}`)}
+						class="btn btn-primary"
+					>
+						Search in Discover
+					</a>
+				</div>
 			</div>
 		{:else if data.movies.length === 0}
 			<!-- Empty State -->

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -700,13 +700,23 @@
 			</div>
 		{:else if filteredSeries.length === 0 && searchQuery}
 			<!-- Search Empty State -->
-			<div class="flex flex-col items-center justify-center py-20 text-center opacity-50">
-				<Search class="mb-4 h-16 w-16" />
-				<p class="text-2xl font-bold">{m.library_tv_noSearchMatch({ query: searchQuery })}</p>
-				<p class="mt-2">{m.library_tv_tryDifferentSearch()}</p>
-				<button class="btn mt-6 btn-ghost" onclick={() => (searchQuery = '')}>
-					{m.library_tv_clearSearchBtn()}
-				</button>
+			<div class="flex flex-col items-center justify-center py-20 text-center">
+				<div class="opacity-50">
+					<Search class="mb-4 h-16 w-16 mx-auto" />
+					<p class="text-2xl font-bold">{m.library_tv_noSearchMatch({ query: searchQuery })}</p>
+					<p class="mt-2">{m.library_tv_tryDifferentSearch()}</p>
+				</div>
+				<div class="mt-6 flex gap-3">
+					<button class="btn btn-ghost" onclick={() => (searchQuery = '')}>
+						{m.library_tv_clearSearchBtn()}
+					</button>
+					<a
+						href={resolvePath(`/discover?type=tv&q=${encodeURIComponent(searchQuery)}`)}
+						class="btn btn-primary"
+					>
+						Search in Discover
+					</a>
+				</div>
 			</div>
 		{:else if data.series.length === 0}
 			<!-- Empty State -->

--- a/src/routes/settings/library/naming/+page.svelte
+++ b/src/routes/settings/library/naming/+page.svelte
@@ -387,6 +387,10 @@
 		FORMAT_FIELDS.filter((field) => (validationResults[field]?.warnings.length ?? 0) > 0)
 	);
 	const canSave = $derived(!saving && hasChanges && invalidFormatFields.length === 0);
+	const movieFolderUsesBackslash = $derived(config.movieFolderFormat.includes('\\'));
+	const seriesFolderUsesBackslash = $derived(
+		config.seriesFolderFormat.includes('\\') || config.seasonFolderFormat.includes('\\')
+	);
 
 	$effect(() => {
 		const currentSignature = `${selectedServerPresetId}|${selectedStylePresetId}|${selectedDetailPresetId}`;
@@ -831,6 +835,32 @@
 								onReset={() => resetField('movieFolderFormat')}
 								onFocus={handleFieldFocus}
 							/>
+							{#if movieFolderUsesBackslash}
+								<div
+									class="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-base-content/75"
+								>
+									<Info class="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+									<span
+										>Backslash <code class="rounded bg-base-300 px-1 font-mono text-xs">\</code> is
+										treated as an illegal character and will be <strong>stripped</strong> from
+										folder names, merging the segments into one. Use
+										<code class="rounded bg-base-300 px-1 font-mono text-xs">/</code> instead; it creates
+										subfolders correctly on all platforms.</span
+									>
+								</div>
+							{:else}
+								<div
+									class="flex items-start gap-2 rounded-lg border border-info/30 bg-info/10 px-3 py-2 text-sm text-base-content/75"
+								>
+									<Info class="mt-0.5 h-4 w-4 shrink-0 text-info" />
+									<span
+										>Use <code class="rounded bg-base-300 px-1 font-mono text-xs">/</code> to create
+										subfolders; it works correctly on all platforms. Backslash
+										<code class="rounded bg-base-300 px-1 font-mono text-xs">\</code> is treated as an
+										illegal character and will be stripped from folder names.</span
+									>
+								</div>
+							{/if}
 							<NamingFormatField
 								id="movieFileFormat"
 								label={m.settings_naming_fileFormat()}
@@ -893,6 +923,32 @@
 								onReset={() => resetField('seasonFolderFormat')}
 								onFocus={handleFieldFocus}
 							/>
+							{#if seriesFolderUsesBackslash}
+								<div
+									class="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-base-content/75"
+								>
+									<Info class="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+									<span
+										>Backslash <code class="rounded bg-base-300 px-1 font-mono text-xs">\</code> is
+										treated as an illegal character and will be <strong>stripped</strong> from
+										folder names, merging the segments into one. Use
+										<code class="rounded bg-base-300 px-1 font-mono text-xs">/</code> instead; it creates
+										subfolders correctly on all platforms.</span
+									>
+								</div>
+							{:else}
+								<div
+									class="flex items-start gap-2 rounded-lg border border-info/30 bg-info/10 px-3 py-2 text-sm text-base-content/75"
+								>
+									<Info class="mt-0.5 h-4 w-4 shrink-0 text-info" />
+									<span
+										>Use <code class="rounded bg-base-300 px-1 font-mono text-xs">/</code> to create
+										subfolders; it works correctly on all platforms. Backslash
+										<code class="rounded bg-base-300 px-1 font-mono text-xs">\</code> is treated as an
+										illegal character and will be stripped from folder names.</span
+									>
+								</div>
+							{/if}
 							<NamingFormatField
 								id="episodeFileFormat"
 								label={m.settings_naming_standardEpisode()}

--- a/src/routes/settings/monitoring/logs/+page.svelte
+++ b/src/routes/settings/monitoring/logs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SvelteMap, SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
-	import { Download, Loader2, Search, CalendarSync, CalendarClock, X } from 'lucide-svelte';
+	import { Download, Loader2, Search, CalendarSync, CalendarClock, X, Trash2 } from 'lucide-svelte';
+	import { ConfirmationModal } from '$lib/components/ui/modal';
 
 	import * as m from '$lib/paraglide/messages.js';
 	import { SettingsPage } from '$lib/components/ui/settings';
@@ -403,6 +404,30 @@
 		}
 	}
 
+	let clearingLogs = $state(false);
+	let clearConfirmOpen = $state(false);
+
+	async function executeClearAllLogs(): Promise<void> {
+		clearingLogs = true;
+		try {
+			const res = await fetch('/api/settings/logs/history', { method: 'DELETE' });
+			const payload = await res.json();
+			if (!payload.success) throw new Error(payload.error ?? 'Failed to clear logs');
+			entries = [];
+			pendingLiveEntries = [];
+			historyTotal = 0;
+			historyHasMore = false;
+			historyPagesLoaded.clear();
+			selectedEntryId = null;
+			toasts.success('Log history cleared');
+		} catch (error) {
+			toasts.error(error instanceof Error ? error.message : 'Failed to clear log history');
+		} finally {
+			clearingLogs = false;
+			clearConfirmOpen = false;
+		}
+	}
+
 	async function saveRetentionDays(): Promise<void> {
 		retentionSaving = true;
 		try {
@@ -759,6 +784,19 @@
 					<span class="sm:inline">Export</span>
 				</button>
 
+				<button
+					class="btn text-xs btn-ghost btn-sm text-error"
+					onclick={() => (clearConfirmOpen = true)}
+					disabled={clearingLogs}
+				>
+					{#if clearingLogs}
+						<Loader2 class="h-3.5 w-3.5 animate-spin" />
+					{:else}
+						<Trash2 class="h-3.5 w-3.5" />
+					{/if}
+					<span class="sm:inline">Clear all</span>
+				</button>
+
 				{#if hasActiveFilters}
 					<button class="btn gap-1 text-error btn-ghost btn-xs" onclick={resetFilters}>
 						<X class="h-3 w-3" />
@@ -957,3 +995,14 @@
 		{@render inspectorBody(selectedEntry)}
 	</div>
 {/if}
+
+<ConfirmationModal
+	open={clearConfirmOpen}
+	title="Clear all logs"
+	message="This will permanently delete all log history and cannot be undone."
+	confirmLabel="Clear all"
+	confirmVariant="error"
+	loading={clearingLogs}
+	onConfirm={executeClearAllLogs}
+	onCancel={() => (clearConfirmOpen = false)}
+/>


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

- Overhauled the movie collection section: reactive SSE refresh, contextual search/subtitle buttons, "Part of [Collection Name]" header, and exclude the currently-viewed movie from its own collection box
- Fixed multi-episode files during manual import; files like S01E02-E03 now name and link all covered episodes correctly, with a range display (E1-E2) in the import UI and an override escape hatch
- Added "Search in Discover" button on empty library search results for both movies and TV
- Added "Clear all logs" button to the monitoring logs page
- Fixed an infinite GET /api/discover request loop triggered by the debug mode effect
- Added path separator hint below folder format fields in naming settings


## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Replaced CSS `group-hover` with JS hover state on collection cards; added `invalidateAll()` on `file:added`/`file:removed` SSE events to refresh collection without reload
- Added `hasSubtitles` to `CollectionPart` and a `selectDistinct` subtitle membership query in the movie page server load
- Contextual search and subtitle buttons on collection header hidden when no tracked movies are missing files/subtitles; current movie filtered out of collection display
- `resolveTvEpisodeMapping` now returns full `episodeNumbers[]`; `buildEpisodeNamingInfo` accepts the array so multi-episode files are named with the correct range
- Added `parsedEpisodes?: number[]` to `ManualImportDetectionData` and `DetectionGroup`; `GroupEditorPanel` shows E1-E2 (auto) badge with Override/Auto toggle; `Step3SingleImport` summary renders the full range
- Empty library search state for movies and TV now includes a "Search in Discover" button linking to `/discover?type=...&q=...`
- Added `clearAllFiles()` to `logHistoryService`, a DELETE handler to `/api/settings/logs/history`, and a "Clear all" button backed by `ConfirmationModal` on the logs page
- Added `debugResultsLoaded` flag to guard the debug mode `$effect` from re-firing when `filteredOutResults` is empty after a fetch
- Added path separator info/warning hints below folder format fields in naming settings

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->