### PR TITLE
feat(search): add sort controls and overhaul Interactive Search mobile/landscape UX

### DIFF
--- a/src/lib/components/library/MovieEditModal.svelte
+++ b/src/lib/components/library/MovieEditModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { X, FolderOpen, Search } from 'lucide-svelte';
+	import { X, FolderOpen, Search, Layers, Trash2, Pencil, Info } from 'lucide-svelte';
 	import { FolderBrowser } from '$lib/components/library';
 	import type { LibraryMovie, DesiredQuality } from '$lib/types/library';
 	import { ModalWrapper, ModalFooter } from '$lib/components/ui/modal';
@@ -368,7 +368,7 @@
 			<div class="space-y-3">
 				<div class="grid grid-cols-2 gap-3">
 					<label class="label cursor-pointer">
-						<span class="label-text text-xs text-base-content/60">{m.common_monitored()}</span>
+						<span class="label-text text-xs text-base-content/80">{m.common_monitored()}</span>
 						<input
 							type="checkbox"
 							class="toggle toggle-primary toggle-sm"
@@ -376,7 +376,7 @@
 						/>
 					</label>
 					<label class="label cursor-pointer">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_editMovie_autoDownloadSubtitles()}</span
 						>
 						<input
@@ -389,7 +389,7 @@
 				<div class="grid grid-cols-2 gap-3">
 					<div class="form-control w-full">
 						<label class="label py-0.5" for="movie-quality-profile">
-							<span class="label-text text-xs text-base-content/60"
+							<span class="label-text text-xs text-base-content/80"
 								>{m.common_qualityProfile()}</span
 							>
 						</label>
@@ -409,9 +409,9 @@
 						</select>
 					</div>
 					<div class="form-control w-full">
-						<label class="label py-0.5">
-							<span class="label-text text-xs text-base-content/60">Desired Qualities</span>
-						</label>
+						<div class="label py-0.5">
+							<span class="label-text text-xs text-base-content/80">Desired Qualities</span>
+						</div>
 						<div class="flex flex-wrap gap-1.5 pt-0.5">
 							{#each resolutionOptions as option (option.value)}
 								<button
@@ -452,14 +452,14 @@
 			<div class="grid grid-cols-3 gap-3">
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="movie-delay-profile">
-						<span class="label-text text-xs text-base-content/60">Delay Profile</span>
+						<span class="label-text text-xs text-base-content/80">Delay Profile</span>
 					</label>
 					<select
 						id="movie-delay-profile"
 						bind:value={delayProfileId}
 						class="select-bordered select w-full select-sm"
 					>
-						<option value={null}>None (global default)</option>
+						<option value={null}>None</option>
 						{#each delayProfiles as profile (profile.id)}
 							<option value={profile.id}>{profile.name}</option>
 						{/each}
@@ -467,7 +467,7 @@
 				</div>
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="movie-min-availability">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_minimumAvailability()}</span
 						>
 					</label>
@@ -483,7 +483,7 @@
 				</div>
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="movie-availability-delay">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_availabilityDelay_label()}</span
 						>
 					</label>
@@ -496,7 +496,7 @@
 							max="365"
 							bind:value={availabilityDelay}
 						/>
-						<span class="text-xs text-base-content/60">{m.library_availabilityDelay_unit()}</span>
+						<span class="text-xs text-base-content/80">{m.library_availabilityDelay_unit()}</span>
 					</div>
 				</div>
 			</div>
@@ -510,122 +510,127 @@
 				Files
 			</h4>
 			<div class="space-y-3">
-				<div class="grid grid-cols-2 gap-3">
-					<div class="form-control w-full">
-						<label class="label py-0.5" for="movie-root-folder">
-							<span class="label-text text-xs text-base-content/60">{m.common_rootFolder()}</span>
-						</label>
-						<select
-							id="movie-root-folder"
-							bind:value={rootFolderId}
-							class="select-bordered select w-full select-sm"
-						>
-							{#if !rootFolderId}
-								<option value="" disabled>{m.common_notSet()}</option>
-							{/if}
-							{#if selectedRootFolderOutOfPolicy && selectedRootFolderObj}
-								<option value={selectedRootFolderObj.id}
-									>{selectedRootFolderObj.path} (current)</option
-								>
-							{/if}
-							{#each eligibleRootFolders as folder (folder.id)}
-								<option value={folder.id}>
-									{folder.path}
-									{#if folder.freeSpaceBytes}
-										({m.library_add_rootFolderFree({ free: formatBytes(folder.freeSpaceBytes) })})
-									{/if}
-								</option>
-							{/each}
-						</select>
-						{#if enforceAnimeSubtype}
-							<div class="text-xs text-base-content/70 mt-1">
-								Limited to <strong>{requiredMediaSubType === 'anime' ? 'Anime' : 'Standard'}</strong
-								> root folders.
-							</div>
+				<div class="form-control w-full">
+					<label class="label py-0.5" for="movie-root-folder">
+						<span class="label-text text-xs text-base-content/80">{m.common_rootFolder()}</span>
+					</label>
+					<select
+						id="movie-root-folder"
+						bind:value={rootFolderId}
+						class="select-bordered select w-full select-sm"
+					>
+						{#if !rootFolderId}
+							<option value="" disabled>{m.common_notSet()}</option>
 						{/if}
-					</div>
-					<div class="form-control w-full">
-						<label class="label py-0.5">
-							<span class="label-text text-xs text-base-content/60">Collection</span>
-						</label>
-						{#if collectionSearchOpen}
-							<div class="rounded-lg border border-base-300 bg-base-200 p-2 space-y-1.5">
-								<div class="relative">
-									<input
-										type="text"
-										placeholder="Search TMDB collections..."
-										class="input input-xs w-full rounded-full border-base-content/20 bg-base-100 pl-8 pr-7"
-										bind:value={collectionQuery}
-										oninput={handleCollectionQueryInput}
-									/>
-									<Search
-										class="pointer-events-none absolute top-1/2 left-2.5 h-3 w-3 -translate-y-1/2 text-base-content/40"
-									/>
-									{#if collectionQuery}
-										<button
-											type="button"
-											class="absolute top-1/2 right-1.5 -translate-y-1/2 text-base-content/40 hover:text-base-content text-xs"
-											onclick={() => {
-												collectionQuery = '';
-												collectionResults = [];
-											}}>x</button
-										>
-									{/if}
-								</div>
-								{#if collectionResults.length > 0}
-									<ul class="max-h-32 overflow-y-auto space-y-0.5">
-										{#each collectionResults as col (col.id)}
-											<li>
-												<button
-													type="button"
-													class="flex w-full items-center gap-1.5 rounded p-1 text-left text-xs hover:bg-base-300"
-													onclick={() => pickCollection(col.id, col.name)}
-												>
-													<span class="truncate">{col.name}</span>
-												</button>
-											</li>
-										{/each}
-									</ul>
-								{/if}
-								<button
-									type="button"
-									class="btn btn-ghost btn-xs w-full"
-									onclick={() => {
-										collectionSearchOpen = false;
-										collectionQuery = '';
-										collectionResults = [];
-									}}>Cancel</button
-								>
-							</div>
-						{:else}
-							<div
-								class="flex items-center gap-1.5 rounded border border-base-300 bg-base-200 px-2 py-1.5 text-xs"
+						{#if selectedRootFolderOutOfPolicy && selectedRootFolderObj}
+							<option value={selectedRootFolderObj.id}
+								>{selectedRootFolderObj.path} (current)</option
 							>
-								<span
-									class="min-w-0 flex-1 truncate {collectionName
-										? ''
-										: 'italic text-base-content/40'}"
-								>
-									{collectionName ?? 'No collection'}
-								</span>
-								{#if collectionName}
+						{/if}
+						{#each eligibleRootFolders as folder (folder.id)}
+							<option value={folder.id}>
+								{folder.path}
+								{#if folder.freeSpaceBytes}
+									({m.library_add_rootFolderFree({ free: formatBytes(folder.freeSpaceBytes) })})
+								{/if}
+							</option>
+						{/each}
+					</select>
+					{#if enforceAnimeSubtype}
+						<div class="mt-1 text-xs text-base-content/70">
+							Limited to <strong>{requiredMediaSubType === 'anime' ? 'Anime' : 'Standard'}</strong> root
+							folders.
+						</div>
+					{/if}
+				</div>
+				<div class="form-control w-full">
+					<div class="label py-0.5">
+						<span class="label-text text-xs text-base-content/80">Collection</span>
+					</div>
+					{#if collectionSearchOpen}
+						<div class="space-y-1.5 rounded-lg border border-base-300 bg-base-200 p-2">
+							<div class="relative">
+								<input
+									type="text"
+									placeholder="Search TMDB collections..."
+									class="input input-xs w-full rounded-full border-base-content/20 bg-base-100 pl-8 pr-7"
+									bind:value={collectionQuery}
+									oninput={handleCollectionQueryInput}
+								/>
+								<Search
+									class="pointer-events-none absolute top-1/2 left-2.5 h-3 w-3 -translate-y-1/2 text-base-content/40"
+								/>
+								{#if collectionQuery}
 									<button
 										type="button"
-										class="text-error hover:underline text-xs"
+										class="absolute top-1/2 right-1.5 -translate-y-1/2 text-base-content/40 hover:text-base-content text-xs"
 										onclick={() => {
-											collectionId = null;
-											collectionName = null;
+											collectionQuery = '';
+											collectionResults = [];
 										}}>x</button
 									>
 								{/if}
+							</div>
+							{#if collectionResults.length > 0}
+								<ul class="max-h-32 space-y-0.5 overflow-y-auto">
+									{#each collectionResults as col (col.id)}
+										<li>
+											<button
+												type="button"
+												class="flex w-full items-center gap-1.5 rounded p-1 text-left text-xs hover:bg-base-300"
+												onclick={() => pickCollection(col.id, col.name)}
+											>
+												<span class="truncate">{col.name}</span>
+											</button>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+							<button
+								type="button"
+								class="btn btn-ghost btn-xs w-full"
+								onclick={() => {
+									collectionSearchOpen = false;
+									collectionQuery = '';
+									collectionResults = [];
+								}}>Cancel</button
+							>
+						</div>
+					{:else}
+						<div
+							class="flex items-center gap-2 rounded-lg border border-base-300 bg-base-200 px-3 py-2 text-sm"
+						>
+							<Layers class="h-4 w-4 shrink-0 text-primary" />
+							<span
+								class="min-w-0 flex-1 truncate {collectionName
+									? ''
+									: 'italic text-base-content/40'}"
+							>
+								{collectionName ?? 'No collection'}
+							</span>
+							{#if collectionName}
 								<button
 									type="button"
-									class="btn btn-ghost btn-xs text-xs h-auto min-h-0 py-0"
-									onclick={openCollectionSearch}>change</button
+									class="btn btn-ghost btn-xs text-error"
+									onclick={() => {
+										collectionId = null;
+										collectionName = null;
+									}}
+									title="Remove collection"
 								>
-							</div>
-						{/if}
-					</div>
+									<Trash2 class="h-3.5 w-3.5" />
+								</button>
+							{/if}
+							<button
+								type="button"
+								class="btn btn-ghost btn-xs"
+								onclick={openCollectionSearch}
+								title="Change collection"
+							>
+								<Pencil class="h-3.5 w-3.5" />
+							</button>
+						</div>
+					{/if}
 				</div>
 
 				{#if canMoveExistingFiles}
@@ -647,7 +652,15 @@
 				{#if movie.path}
 					<div class="form-control w-full">
 						<label class="label py-0.5" for="movie-folder-path">
-							<span class="label-text text-xs text-base-content/60">Folder name</span>
+							<span class="flex items-center gap-1 label-text text-xs text-base-content/80">
+								Folder name
+								<span
+									class="tooltip tooltip-right"
+									data-tip="Folder name relative to the root folder. Edit only if the name on disk no longer matches; saving will update the database and trigger a rescan to re-link existing files."
+								>
+									<Info class="h-3 w-3 text-base-content/40" />
+								</span>
+							</span>
 						</label>
 						{#if showFolderPicker}
 							<FolderBrowser
@@ -703,7 +716,7 @@
 			<div class="grid grid-cols-2 gap-3">
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="movie-metadata-language">
-						<span class="label-text text-xs text-base-content/60">Language</span>
+						<span class="label-text text-xs text-base-content/80">Language</span>
 					</label>
 					<select
 						id="movie-metadata-language"
@@ -737,7 +750,7 @@
 					</select>
 				</div>
 				<label class="label cursor-pointer">
-					<span class="label-text text-xs text-base-content/60">Prefer Original Title</span>
+					<span class="label-text text-xs text-base-content/80">Prefer Original Title</span>
 					<input
 						type="checkbox"
 						class="toggle toggle-primary toggle-sm"

--- a/src/lib/components/library/SeriesEditModal.svelte
+++ b/src/lib/components/library/SeriesEditModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { X, FolderOpen } from 'lucide-svelte';
+	import { X, FolderOpen, Info } from 'lucide-svelte';
 	import { FolderBrowser } from '$lib/components/library';
 	import { ModalWrapper, ModalFooter } from '$lib/components/ui/modal';
 	import { sortRootFoldersForMediaType } from '$lib/utils/root-folders.js';
@@ -361,7 +361,7 @@
 			<div class="space-y-3">
 				<div class="grid grid-cols-2 gap-3">
 					<label class="label cursor-pointer">
-						<span class="label-text text-xs text-base-content/60">{m.common_monitored()}</span>
+						<span class="label-text text-xs text-base-content/80">{m.common_monitored()}</span>
 						<input
 							type="checkbox"
 							class="toggle toggle-primary toggle-sm"
@@ -369,7 +369,7 @@
 						/>
 					</label>
 					<label class="label cursor-pointer">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_seriesEdit_autoDownloadSubtitles()}</span
 						>
 						<input
@@ -381,7 +381,7 @@
 				</div>
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="series-quality-profile">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_seriesEdit_qualityProfile()}</span
 						>
 					</label>
@@ -401,7 +401,7 @@
 				<div class="grid grid-cols-2 gap-3">
 					<div class="form-control w-full">
 						<label class="label py-0.5" for="series-type">
-							<span class="label-text text-xs text-base-content/60"
+							<span class="label-text text-xs text-base-content/80"
 								>{m.library_seriesEdit_seriesType()}</span
 							>
 						</label>
@@ -417,7 +417,7 @@
 					</div>
 					<div class="form-control w-full">
 						<label class="label py-0.5" for="episode-group">
-							<span class="label-text text-xs text-base-content/60">Episode Ordering</span>
+							<span class="label-text text-xs text-base-content/80">Episode Ordering</span>
 						</label>
 						{#if episodeGroupsLoading}
 							<select id="episode-group" disabled class="select-bordered select w-full select-sm">
@@ -452,14 +452,14 @@
 				</h4>
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="series-delay-profile">
-						<span class="label-text text-xs text-base-content/60">Delay Profile</span>
+						<span class="label-text text-xs text-base-content/80">Delay Profile</span>
 					</label>
 					<select
 						id="series-delay-profile"
 						bind:value={delayProfileId}
 						class="select-bordered select w-full select-sm"
 					>
-						<option value={null}>None (global default)</option>
+						<option value={null}>None</option>
 						{#each delayProfiles as profile (profile.id)}
 							<option value={profile.id}>{profile.name}</option>
 						{/each}
@@ -477,7 +477,7 @@
 			</h4>
 			<div class="space-y-3">
 				<label class="label cursor-pointer">
-					<span class="label-text text-xs text-base-content/60"
+					<span class="label-text text-xs text-base-content/80"
 						>{m.library_seriesEdit_seasonFolders()}</span
 					>
 					<input
@@ -489,7 +489,7 @@
 
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="series-root-folder">
-						<span class="label-text text-xs text-base-content/60"
+						<span class="label-text text-xs text-base-content/80"
 							>{m.library_seriesEdit_rootFolder()}</span
 						>
 					</label>
@@ -542,7 +542,15 @@
 				{#if series.path}
 					<div class="form-control w-full">
 						<label class="label py-0.5" for="series-folder-path">
-							<span class="label-text text-xs text-base-content/60">Folder name</span>
+							<span class="flex items-center gap-1 label-text text-xs text-base-content/80">
+								Folder name
+								<span
+									class="tooltip tooltip-right"
+									data-tip="Folder name relative to the root folder. Edit only if the name on disk no longer matches; saving will update the database and trigger a rescan to re-link existing files."
+								>
+									<Info class="h-3 w-3 text-base-content/40" />
+								</span>
+							</span>
 						</label>
 						{#if showFolderPicker}
 							<FolderBrowser
@@ -598,7 +606,7 @@
 			<div class="grid grid-cols-2 gap-3">
 				<div class="form-control w-full">
 					<label class="label py-0.5" for="series-metadata-language">
-						<span class="label-text text-xs text-base-content/60">Language</span>
+						<span class="label-text text-xs text-base-content/80">Language</span>
 					</label>
 					<select
 						id="series-metadata-language"
@@ -632,7 +640,7 @@
 					</select>
 				</div>
 				<label class="label cursor-pointer">
-					<span class="label-text text-xs text-base-content/60">Prefer Original Title</span>
+					<span class="label-text text-xs text-base-content/80">Prefer Original Title</span>
 					<input
 						type="checkbox"
 						class="toggle toggle-primary toggle-sm"

--- a/src/lib/components/search/InteractiveSearchModal.svelte
+++ b/src/lib/components/search/InteractiveSearchModal.svelte
@@ -546,7 +546,7 @@
 		{blockedIds}
 	/>
 
-	<div class="modal-action shrink-0 border-t border-base-300 pt-3">
+	<div class="modal-action mt-0 shrink-0 border-t border-base-300 pt-3">
 		<button class="btn" onclick={onClose}>Close</button>
 	</div>
 </ModalWrapper>

--- a/src/lib/components/search/SearchFilters.svelte
+++ b/src/lib/components/search/SearchFilters.svelte
@@ -26,7 +26,7 @@
 	}: Props = $props();
 </script>
 
-<div class="mb-3 flex flex-wrap items-center gap-2 sm:gap-4">
+<div class="mb-1 flex flex-wrap items-center gap-2 sm:mb-3 sm:gap-4">
 	<div class="form-control w-full sm:w-auto">
 		<input
 			type="text"

--- a/src/lib/components/search/SearchFilters.svelte
+++ b/src/lib/components/search/SearchFilters.svelte
@@ -63,4 +63,51 @@
 			{sortDir === 'desc' ? '↓' : '↑'}
 		</button>
 	</div>
+
+	<div class="ml-auto hidden items-center gap-2 sm:flex">
+		<span class="text-xs text-base-content/60">{m.search_label_sort()}</span>
+		<div class="join">
+			<button
+				class="btn btn-xs join-item {sortBy === 'score'
+					? 'btn-primary'
+					: 'btn-ghost border border-base-content/20'}"
+				onclick={() => onSortByChange('score')}
+			>
+				{m.search_sort_score()}
+			</button>
+			<button
+				class="btn btn-xs join-item {sortBy === 'seeders'
+					? 'btn-primary'
+					: 'btn-ghost border border-base-content/20'}"
+				onclick={() => onSortByChange('seeders')}
+			>
+				{m.search_sort_seeders()}
+			</button>
+			<button
+				class="btn btn-xs join-item {sortBy === 'size'
+					? 'btn-primary'
+					: 'btn-ghost border border-base-content/20'}"
+				onclick={() => onSortByChange('size')}
+			>
+				{m.search_sort_size()}
+			</button>
+			<button
+				class="btn btn-xs join-item {sortBy === 'age'
+					? 'btn-primary'
+					: 'btn-ghost border border-base-content/20'}"
+				onclick={() => onSortByChange('age')}
+			>
+				Age
+			</button>
+		</div>
+		<button
+			class="btn btn-ghost btn-xs"
+			onclick={onSortDirToggle}
+			title={sortDir === 'desc'
+				? 'Descending - click for ascending'
+				: 'Ascending - click for descending'}
+		>
+			{sortDir === 'desc' ? '↓' : '↑'}
+		</button>
+	</div>
 </div>

--- a/src/lib/components/search/SearchHeader.svelte
+++ b/src/lib/components/search/SearchHeader.svelte
@@ -14,7 +14,7 @@
 	let { title, searchMode, searching, onRefresh, onClose }: Props = $props();
 </script>
 
-<div class="mb-3 flex items-start justify-between gap-2">
+<div class="mb-1 flex items-start justify-between gap-2 sm:mb-3">
 	<div class="min-w-0 flex-1">
 		<h3
 			id="interactive-search-modal-title"

--- a/src/lib/components/search/SearchResultRow.svelte
+++ b/src/lib/components/search/SearchResultRow.svelte
@@ -206,176 +206,301 @@
 		: 'border-base-300'} {release.rejected ? 'opacity-50' : ''}"
 >
 	<!-- Main row - always visible -->
-	<div class="flex items-center gap-3 p-3">
-		<!-- Score - inline with title -->
-		{#if release.totalScore !== undefined}
-			<span
-				class="shrink-0 rounded px-1.5 py-0.5 text-sm font-semibold {getScoreColor(
-					release.totalScore
-				)}"
-				title={m.search_qualityScore()}
-			>
-				{release.totalScore}
-			</span>
-		{/if}
+	<div class="p-3">
+		<!-- Mobile layout: two compact lines -->
+		<div class="sm:hidden">
+			<!-- Line 1: score + title + grab + expand -->
+			<div class="flex items-center gap-2">
+				{#if release.totalScore !== undefined}
+					<span
+						class="shrink-0 rounded px-1.5 py-0.5 text-sm font-semibold {getScoreColor(
+							release.totalScore
+						)}"
+						title={m.search_qualityScore()}
+					>
+						{release.totalScore}
+					</span>
+				{/if}
+				<p class="min-w-0 flex-1 truncate text-sm font-medium" title={release.title}>
+					{release.title}
+				</p>
+				<div class="flex shrink-0 items-center gap-1">
+					{#if blocked}
+						<span class="badge gap-1 badge-warning badge-sm"><Ban size={10} /></span>
+					{:else if grabbed}
+						<span class="badge gap-1 badge-success badge-sm"><Check size={10} /></span>
+					{:else if error}
+						<span class="badge gap-1 badge-error badge-sm" title={error}><X size={10} /></span>
+					{:else}
+						{#if release.protocol === 'usenet' && showUsenetStreamButton}
+							<button
+								class="btn btn-xs btn-accent"
+								onclick={handleStream}
+								disabled={grabbing || streaming || !canUsenetStream}
+								title={canUsenetStream
+									? m.search_stream()
+									: (usenetStreamUnavailableReason ?? m.search_unavailable())}
+							>
+								{#if streaming}
+									<Loader2 size={12} class="animate-spin" />
+								{:else}
+									<Play size={12} />
+								{/if}
+							</button>
+						{/if}
+						<button
+							class="btn btn-xs btn-primary"
+							onclick={handleGrab}
+							disabled={grabbing || streaming}
+						>
+							{#if grabbing}
+								<Loader2 size={12} class="animate-spin" />
+							{:else}
+								<Download size={12} />
+							{/if}
+						</button>
+					{/if}
+					<button
+						class="btn btn-ghost btn-xs"
+						onclick={() => (expanded = !expanded)}
+						title={expanded ? m.search_collapseDetails() : m.search_expandDetails()}
+					>
+						{#if expanded}
+							<ChevronUp size={12} />
+						{:else}
+							<ChevronDown size={12} />
+						{/if}
+					</button>
+				</div>
+			</div>
 
-		<!-- Title and tags -->
-		<div class="min-w-0 flex-1">
-			<p class="truncate text-sm font-medium" title={release.title}>
-				{release.title}
-			</p>
-			<div class="mt-1 flex flex-wrap items-center gap-1.5">
+			<!-- Line 2: quality badges only -->
+			<div class="mt-1.5 flex flex-wrap items-center gap-1.5">
 				{#each getQualityTags() as tag (tag)}
-					<span class="badge badge-sm badge-primary">{tag}</span>
+					<span class="badge badge-xs badge-primary">{tag}</span>
 				{/each}
 				{#if release.parsed?.releaseGroup && isKnownBadge(release.parsed.releaseGroup)}
-					<span class="badge badge-ghost badge-sm">{release.parsed.releaseGroup}</span>
+					<span class="badge badge-ghost badge-xs">{release.parsed.releaseGroup}</span>
 				{/if}
 				{#if release.torrent?.freeleech || release.torrent?.downloadFactor === 0}
-					<span class="badge badge-sm badge-success">{m.search_freeleechBadge()}</span>
+					<span class="badge badge-xs badge-success">{m.search_freeleechBadge()}</span>
 				{/if}
 				{#if release.rejected && release.rejections?.length}
-					<span class="badge badge-sm badge-error gap-1" title={release.rejections.join('\n')}>
-						<Ban size={10} />
+					<span class="badge badge-xs badge-error gap-1" title={release.rejections.join('\n')}>
+						<Ban size={8} />
 						{release.rejectionReason || release.rejections[0]}
-						{#if release.rejections.length > 1}
-							+{release.rejections.length - 1}
-						{/if}
+						{#if release.rejections.length > 1}+{release.rejections.length - 1}{/if}
 					</span>
 				{/if}
 			</div>
+
+			<!-- Line 3: metadata + secondary actions -->
+			<div class="mt-1 flex items-center gap-2 text-xs text-base-content/50">
+				<span class="h-1.5 w-1.5 shrink-0 rounded-full {getProtocolColor()}"></span>
+				<span class="truncate">{release.indexerName}</span>
+				{#if release.size > 0}<span class="shrink-0">{formatBytes(release.size)}</span>{/if}
+				{#if release.protocol === 'torrent' && release.seeders !== undefined}
+					<span class="text-success">↑{release.seeders}</span>
+				{/if}
+				<span>{formatAge(release.publishDate)}</span>
+				<div class="ml-auto flex shrink-0 items-center gap-0.5 border-l border-base-300 pl-2">
+					{#if onBlock && !blocked}
+						<button
+							class="btn btn-ghost btn-xs text-error/70 hover:text-error"
+							onclick={() => onBlock(release)}
+							title={m.search_blockRelease()}
+						>
+							<Ban size={13} />
+						</button>
+					{/if}
+					{#if release.commentsUrl}
+						<a
+							href={release.commentsUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn btn-ghost btn-xs text-base-content/60 hover:text-base-content"
+							title={m.search_viewComments()}
+						>
+							<ExternalLink size={13} />
+						</a>
+					{/if}
+				</div>
+			</div>
 		</div>
 
-		<!-- Quick stats -->
-		<div class="hidden shrink-0 items-center gap-4 text-xs sm:flex">
-			<!-- Indexer -->
-			<div class="flex items-center gap-1.5">
-				<span class="h-2 w-2 rounded-full {getProtocolColor()}"></span>
-				<span class="text-base-content/60">{release.indexerName}</span>
-				{#if indexerSource === 'prowlarr'}
-					<span class="badge badge-xs badge-primary">Prowlarr</span>
-				{:else if indexerSource === 'jackett'}
-					<span class="badge badge-xs badge-secondary">Jackett</span>
-				{/if}
-			</div>
-
-			<!-- Size -->
-			{#if release.size > 0}
-				<div class="flex items-center gap-1 text-base-content/60">
-					<HardDrive size={12} />
-					<span>{formatBytes(release.size)}</span>
-				</div>
+		<!-- Desktop layout -->
+		<div class="hidden items-center gap-3 sm:flex">
+			<!-- Score - inline with title -->
+			{#if release.totalScore !== undefined}
+				<span
+					class="shrink-0 rounded px-1.5 py-0.5 text-sm font-semibold {getScoreColor(
+						release.totalScore
+					)}"
+					title={m.search_qualityScore()}
+				>
+					{release.totalScore}
+				</span>
 			{/if}
 
-			<!-- Seeders/Leechers -->
-			{#if release.protocol === 'torrent'}
-				{@const availability = getTorrentAvailabilityText()}
-				{#if availability}
-					<div class="flex items-center gap-1">
-						<ArrowUpCircle size={12} class="text-success" />
-						<span class="text-success">{availability.seeders}</span>
-						<span class="text-base-content/30">/</span>
-						<ArrowDownCircle size={12} class="text-error" />
-						<span class="text-error">{availability.leechers}</span>
+			<!-- Title and tags -->
+			<div class="min-w-0 flex-1">
+				<p class="truncate text-sm font-medium" title={release.title}>
+					{release.title}
+				</p>
+				<div class="mt-1 flex flex-wrap items-center gap-1.5">
+					{#each getQualityTags() as tag (tag)}
+						<span class="badge badge-sm badge-primary">{tag}</span>
+					{/each}
+					{#if release.parsed?.releaseGroup && isKnownBadge(release.parsed.releaseGroup)}
+						<span class="badge badge-ghost badge-sm">{release.parsed.releaseGroup}</span>
+					{/if}
+					{#if release.torrent?.freeleech || release.torrent?.downloadFactor === 0}
+						<span class="badge badge-sm badge-success">{m.search_freeleechBadge()}</span>
+					{/if}
+					{#if release.rejected && release.rejections?.length}
+						<span class="badge badge-sm badge-error gap-1" title={release.rejections.join('\n')}>
+							<Ban size={10} />
+							{release.rejectionReason || release.rejections[0]}
+							{#if release.rejections.length > 1}
+								+{release.rejections.length - 1}
+							{/if}
+						</span>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Quick stats -->
+			<div class="shrink-0 flex items-center gap-4 text-xs">
+				<!-- Indexer -->
+				<div class="flex items-center gap-1.5">
+					<span class="h-2 w-2 rounded-full {getProtocolColor()}"></span>
+					<span class="text-base-content/60">{release.indexerName}</span>
+					{#if indexerSource === 'prowlarr'}
+						<span class="badge badge-xs badge-primary">Prowlarr</span>
+					{:else if indexerSource === 'jackett'}
+						<span class="badge badge-xs badge-secondary">Jackett</span>
+					{/if}
+				</div>
+
+				<!-- Size -->
+				{#if release.size > 0}
+					<div class="flex items-center gap-1 text-base-content/60">
+						<HardDrive size={12} />
+						<span>{formatBytes(release.size)}</span>
 					</div>
 				{/if}
-			{/if}
 
-			<!-- Age -->
-			<div class="flex items-center gap-1 text-base-content/60">
-				<Calendar size={12} />
-				<span>{formatAge(release.publishDate)}</span>
+				<!-- Seeders/Leechers -->
+				{#if release.protocol === 'torrent'}
+					{@const availability = getTorrentAvailabilityText()}
+					{#if availability}
+						<div class="flex items-center gap-1">
+							<ArrowUpCircle size={12} class="text-success" />
+							<span class="text-success">{availability.seeders}</span>
+							<span class="text-base-content/30">/</span>
+							<ArrowDownCircle size={12} class="text-error" />
+							<span class="text-error">{availability.leechers}</span>
+						</div>
+					{/if}
+				{/if}
+
+				<!-- Age -->
+				<div class="flex items-center gap-1 text-base-content/60">
+					<Calendar size={12} />
+					<span>{formatAge(release.publishDate)}</span>
+				</div>
 			</div>
-		</div>
 
-		<!-- Actions -->
-		<div class="flex shrink-0 items-center gap-1">
-			{#if blocked}
-				<span class="badge gap-1 badge-warning">
-					<Ban size={12} />
-					{m.search_releaseBlocked()}
-				</span>
-			{/if}
-			{#if grabbed}
-				<span class="badge gap-1 badge-success">
-					<Check size={12} />
-					{m.search_grabbedBadge()}
-				</span>
-			{:else if error}
-				<span class="badge gap-1 badge-error" title={error}>
-					<X size={12} />
-					{m.search_failedBadge()}
-				</span>
-			{:else if !blocked}
-				{#if release.protocol === 'usenet' && showUsenetStreamButton}
+			<!-- Actions -->
+			<div class="flex shrink-0 items-center gap-1">
+				{#if blocked}
+					<span class="badge gap-1 badge-warning">
+						<Ban size={12} />
+						{m.search_releaseBlocked()}
+					</span>
+				{/if}
+				{#if grabbed}
+					<span class="badge gap-1 badge-success">
+						<Check size={12} />
+						{m.search_grabbedBadge()}
+					</span>
+				{:else if error}
+					<span class="badge gap-1 badge-error" title={error}>
+						<X size={12} />
+						{m.search_failedBadge()}
+					</span>
+				{:else if !blocked}
+					{#if release.protocol === 'usenet' && showUsenetStreamButton}
+						<button
+							class="btn btn-sm btn-accent"
+							onclick={handleStream}
+							disabled={grabbing || streaming || !canUsenetStream}
+							title={canUsenetStream
+								? m.search_stream()
+								: (usenetStreamUnavailableReason ?? m.search_unavailable())}
+						>
+							{#if streaming}
+								<Loader2 size={14} class="animate-spin" />
+							{:else}
+								<Play size={14} />
+							{/if}
+						</button>
+					{/if}
 					<button
-						class="btn btn-sm btn-accent"
-						onclick={handleStream}
-						disabled={grabbing || streaming || !canUsenetStream}
-						title={canUsenetStream
-							? m.search_stream()
-							: (usenetStreamUnavailableReason ?? m.search_unavailable())}
+						class="btn btn-sm btn-primary"
+						onclick={handleGrab}
+						disabled={grabbing || streaming}
 					>
-						{#if streaming}
+						{#if grabbing}
 							<Loader2 size={14} class="animate-spin" />
 						{:else}
-							<Play size={14} />
+							<Download size={14} />
 						{/if}
 					</button>
 				{/if}
+
+				{#if onBlock && !blocked}
+					<button
+						class="btn btn-ghost btn-sm text-error"
+						onclick={() => onBlock(release)}
+						title={m.search_blockRelease()}
+					>
+						<Ban size={14} />
+					</button>
+				{/if}
+
+				{#if release.commentsUrl}
+					<a
+						href={release.commentsUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="btn btn-ghost btn-sm"
+						title={m.search_viewComments()}
+					>
+						<ExternalLink size={14} />
+					</a>
+				{/if}
+
+				<!-- Expand toggle -->
 				<button
-					class="btn btn-sm btn-primary"
-					onclick={handleGrab}
-					disabled={grabbing || streaming}
+					class="btn btn-ghost btn-sm"
+					onclick={() => (expanded = !expanded)}
+					title={expanded ? m.search_collapseDetails() : m.search_expandDetails()}
 				>
-					{#if grabbing}
-						<Loader2 size={14} class="animate-spin" />
+					{#if expanded}
+						<ChevronUp size={14} />
 					{:else}
-						<Download size={14} />
+						<ChevronDown size={14} />
 					{/if}
 				</button>
-			{/if}
-
-			{#if onBlock && !blocked}
-				<button
-					class="btn btn-ghost btn-sm"
-					onclick={() => onBlock(release)}
-					title={m.search_blockRelease()}
-				>
-					<Ban size={14} />
-				</button>
-			{/if}
-
-			{#if release.commentsUrl}
-				<a
-					href={release.commentsUrl}
-					target="_blank"
-					rel="noopener noreferrer"
-					class="btn btn-ghost btn-sm"
-					title={m.search_viewComments()}
-				>
-					<ExternalLink size={14} />
-				</a>
-			{/if}
-
-			<!-- Expand toggle -->
-			<button
-				class="btn btn-ghost btn-sm"
-				onclick={() => (expanded = !expanded)}
-				title={expanded ? m.search_collapseDetails() : m.search_expandDetails()}
-			>
-				{#if expanded}
-					<ChevronUp size={14} />
-				{:else}
-					<ChevronDown size={14} />
-				{/if}
-			</button>
+			</div>
 		</div>
 	</div>
 
 	<!-- Expanded content -->
 	{#if expanded}
 		<div class="border-t border-base-300 bg-base-100 p-4">
+			<p class="mb-3 break-all text-xs text-base-content/70 sm:hidden">{release.title}</p>
 			<!-- Score breakdown section -->
 			{#if release.scoringResult?.breakdown}
 				<div class="mb-4">

--- a/src/lib/components/ui/modal/ModalWrapper.svelte
+++ b/src/lib/components/ui/modal/ModalWrapper.svelte
@@ -85,8 +85,8 @@
 	>
 		<div
 			bind:this={modalBoxRef}
-			class="modal-box max-h-[90vh] wrap-break-word {flexContent
-				? 'flex flex-col overflow-hidden'
+			class="modal-box max-h-dvh sm:max-h-[90dvh] wrap-break-word {flexContent
+				? 'flex flex-col overflow-hidden modal-flex-content'
 				: 'overflow-x-hidden overflow-y-auto'} {maxWidthClasses[maxWidth]}"
 		>
 			{@render children()}
@@ -101,3 +101,24 @@
 		></button>
 	</div>
 {/if}
+
+<style>
+	/*
+	 * On small landscape screens (phones), release the flex lock so the entire modal
+	 * scrolls as one unit. This avoids the fixed-header + tiny/inaccessible results
+	 * view problem when viewport height < 600px.
+	 */
+	@media (orientation: landscape) and (max-height: 600px) {
+		:global(.modal-flex-content) {
+			display: block !important;
+			overflow-y: auto !important;
+			overflow-x: hidden !important;
+		}
+		/* Remove flex grow/shrink constraints from all direct children */
+		:global(.modal-flex-content > *) {
+			flex: none !important;
+			min-height: auto !important;
+			overflow: visible !important;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds desktop sort controls to Interactive Search and completely redesigns the result row and modal layout for mobile and landscape screens, fixing unusable portrait view (stacked badges, truncated titles, cramped actions) and inaccessible landscape view.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Add desktop sort button group (Score / Seeders / Size / Age + asc/desc toggle) to `SearchFilters`; mobile keeps existing select dropdown
- Redesign `SearchResultRow` mobile layout into three distinct rows: (1) score + title + grab + expand, (2) quality badges only, (3) metadata (indexer, size, seeders, age) + block/external link actions
- Show full release title in the expanded detail panel on mobile so truncated titles are still readable
- Make block and external link buttons visually distinct on mobile with a left-border separator and red icon for block
- Switch `ModalWrapper` max-height from `90vh` to `max-h-dvh / sm:max-h-[90dvh]` so mobile browser chrome is excluded from the height calculation
- Add CSS media query to `ModalWrapper` that releases the flex scroll lock on small landscape screens (height ≤ 600px), making the entire modal scroll as one unit instead of trapping results in an inaccessible sliver
- Reduce `SearchHeader` and `SearchFilters` bottom margins on mobile for a tighter header

## Areas Affected

- [x] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
