### PR TITLE
feat(libraries): allow separate quality profiles per library

### DIFF
--- a/src/lib/components/libraries/LibraryEditModal.svelte
+++ b/src/lib/components/libraries/LibraryEditModal.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { AlertCircle } from 'lucide-svelte';
+	import { onMount } from 'svelte';
 	import { ModalWrapper, ModalHeader, ModalFooter } from '$lib/components/ui/modal';
 	import { toasts } from '$lib/stores/toast.svelte';
 	import { invalidateAll } from '$app/navigation';
-	import { createLibrary, updateLibrary } from '$lib/api/settings.js';
+	import { createLibrary, updateLibrary, getScoringProfiles } from '$lib/api/settings.js';
 	import type { LibraryCreate, LibraryUpdate } from '$lib/validation/schemas.js';
 	import type { RootFolderMediaType, RootFolderMediaSubType } from '$lib/types/downloadClient';
 
@@ -25,6 +26,7 @@
 		rootFolders?: LibraryRootFolderRef[];
 		defaultSearchOnAdd?: boolean | null;
 		defaultWantsSubtitles?: boolean | null;
+		qualityProfileId?: string | null;
 	};
 
 	type RootFolderRef = {
@@ -35,6 +37,11 @@
 		mediaSubType?: string;
 	};
 
+	type ProfileRef = {
+		id: string;
+		name: string;
+	};
+
 	type LibraryFormData = {
 		name: string;
 		mediaType: RootFolderMediaType;
@@ -42,6 +49,7 @@
 		rootFolderIds: string[];
 		defaultSearchOnAdd: boolean;
 		defaultWantsSubtitles: boolean;
+		qualityProfileId: string | null;
 	};
 
 	interface Props {
@@ -60,10 +68,25 @@
 		mediaSubType: 'standard',
 		rootFolderIds: [],
 		defaultSearchOnAdd: true,
-		defaultWantsSubtitles: false
+		defaultWantsSubtitles: false,
+		qualityProfileId: null
 	});
 	let librarySaving = $state(false);
 	let librarySaveError = $state<string | null>(null);
+	let availableProfiles = $state<ProfileRef[]>([]);
+
+	onMount(() => {
+		void (async () => {
+			try {
+				const data = (await getScoringProfiles()) as unknown as {
+					profiles?: Array<{ id: string; name: string }>;
+				};
+				availableProfiles = (data.profiles ?? []).map((p) => ({ id: p.id, name: p.name }));
+			} catch {
+				availableProfiles = [];
+			}
+		})();
+	});
 
 	const isCreateMode = $derived(libraryId === null);
 	const editingLibrary = $derived(
@@ -90,7 +113,8 @@
 				mediaSubType: 'standard',
 				rootFolderIds: [],
 				defaultSearchOnAdd: true,
-				defaultWantsSubtitles: false
+				defaultWantsSubtitles: false,
+				qualityProfileId: null
 			};
 			librarySaveError = null;
 		} else if (libraryId) {
@@ -102,7 +126,8 @@
 					mediaSubType: library.mediaSubType,
 					rootFolderIds: library.rootFolders?.map((f) => f.id) ?? [],
 					defaultSearchOnAdd: library.defaultSearchOnAdd ?? true,
-					defaultWantsSubtitles: library.defaultWantsSubtitles ?? false
+					defaultWantsSubtitles: library.defaultWantsSubtitles ?? false,
+					qualityProfileId: library.qualityProfileId ?? null
 				};
 				librarySaveError = null;
 			}
@@ -193,6 +218,22 @@
 				>
 					<option value="standard">{m.settings_general_standard()}</option>
 					<option value="anime">{m.settings_general_badgeAnime()}</option>
+				</select>
+			</div>
+
+			<div class="form-control">
+				<label class="label py-1" for="status-library-quality-profile">
+					<span class="label-text">{m.common_qualityProfile()}</span>
+				</label>
+				<select
+					id="status-library-quality-profile"
+					class="select-bordered select select-sm"
+					bind:value={libraryForm.qualityProfileId}
+				>
+					<option value="">{m.common_default()}</option>
+					{#each availableProfiles as profile (profile.id)}
+						<option value={profile.id}>{profile.name}</option>
+					{/each}
 				</select>
 			</div>
 

--- a/src/lib/components/library/AddToLibraryModal.svelte
+++ b/src/lib/components/library/AddToLibraryModal.svelte
@@ -38,6 +38,7 @@
 		mediaType: 'movie' | 'tv';
 		defaultSearchOnAdd: boolean;
 		defaultWantsSubtitles: boolean;
+		qualityProfileId?: string | null;
 		rootFolders: Array<{ id: string }>;
 	}
 
@@ -382,7 +383,14 @@
 
 			selectedRootFolder = getRecommendedRootFolderId(filteredRootFolders) ?? '';
 
-			const defaultProfileId = profilesData.defaultProfileId;
+			const libraryProfileId = selectedRootFolderLibrary?.qualityProfileId;
+			const libraryProfileIsValid =
+				libraryProfileId !== undefined &&
+				libraryProfileId !== null &&
+				scoringProfiles.some((p) => p.id === libraryProfileId);
+			const defaultProfileId = libraryProfileIsValid
+				? libraryProfileId
+				: profilesData.defaultProfileId;
 			const defaultProfile =
 				(defaultProfileId && scoringProfiles.find((p) => p.id === defaultProfileId)) ??
 				scoringProfiles.find((p) => p.isDefault) ??

--- a/src/lib/server/library/LibraryAddService.test.ts
+++ b/src/lib/server/library/LibraryAddService.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	seedDefaultScoringProfiles: vi.fn(),
+	getProfile: vi.fn(),
+	getDefaultScoringProfile: vi.fn(),
+	getEffectiveAnimeRootFolderEnforcement: vi.fn().mockResolvedValue(false)
+}));
+
+vi.mock('$lib/server/db/index.js', () => ({
+	db: {},
+	sqlite: {},
+	initializeDatabase: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('$lib/server/quality/index.js', () => ({
+	qualityFilter: {
+		seedDefaultScoringProfiles: mocks.seedDefaultScoringProfiles,
+		getProfile: mocks.getProfile,
+		getDefaultScoringProfile: mocks.getDefaultScoringProfile
+	}
+}));
+
+vi.mock('$lib/server/tmdb.js', () => ({ tmdb: {} }));
+vi.mock('$lib/server/workers/index.js', () => ({
+	SearchWorker: class {},
+	workerManager: { spawnInBackground: vi.fn() }
+}));
+vi.mock('$lib/server/indexers/IndexerManager.js', () => ({ getIndexerManager: vi.fn() }));
+vi.mock('./searchOnAdd.js', () => ({ searchOnAdd: {} }));
+vi.mock('./anime-root-enforcement-settings.js', () => ({
+	getEffectiveAnimeRootFolderEnforcement: mocks.getEffectiveAnimeRootFolderEnforcement
+}));
+vi.mock('$lib/logging/index.js', () => ({
+	logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() },
+	createChildLogger: vi.fn(() => ({
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		child: vi.fn()
+	}))
+}));
+vi.mock('$lib/logging', () => ({
+	logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() },
+	createChildLogger: vi.fn(() => ({
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		child: vi.fn()
+	}))
+}));
+
+import { getEffectiveScoringProfileId } from './LibraryAddService.js';
+import { ValidationError } from '$lib/errors';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.seedDefaultScoringProfiles.mockResolvedValue(undefined);
+});
+
+describe('getEffectiveScoringProfileId', () => {
+	it('returns the provided profile id when it is valid', async () => {
+		mocks.getProfile.mockResolvedValue({ id: 'custom-profile' });
+
+		const result = await getEffectiveScoringProfileId('custom-profile');
+
+		expect(result).toBe('custom-profile');
+		expect(mocks.getProfile).toHaveBeenCalledWith('custom-profile');
+		expect(mocks.getDefaultScoringProfile).not.toHaveBeenCalled();
+	});
+
+	it('throws a ValidationError when the provided profile id is invalid', async () => {
+		mocks.getProfile.mockResolvedValue(null);
+
+		await expect(getEffectiveScoringProfileId('missing-profile')).rejects.toThrow(ValidationError);
+	});
+
+	it('falls back to the owning library profile when no profile is provided', async () => {
+		mocks.getProfile.mockResolvedValue({ id: 'library-profile' });
+		mocks.getDefaultScoringProfile.mockResolvedValue({ id: 'global-default' });
+
+		const result = await getEffectiveScoringProfileId(undefined, {
+			qualityProfileId: 'library-profile'
+		});
+
+		expect(result).toBe('library-profile');
+		expect(mocks.getProfile).toHaveBeenCalledWith('library-profile');
+		expect(mocks.getDefaultScoringProfile).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the global default when the library profile is no longer valid', async () => {
+		mocks.getProfile.mockResolvedValue(null);
+		mocks.getDefaultScoringProfile.mockResolvedValue({ id: 'global-default' });
+
+		const result = await getEffectiveScoringProfileId(undefined, {
+			qualityProfileId: 'deleted-profile'
+		});
+
+		expect(result).toBe('global-default');
+	});
+
+	it('falls back to the global default when the library has no profile', async () => {
+		mocks.getDefaultScoringProfile.mockResolvedValue({ id: 'global-default' });
+
+		const result = await getEffectiveScoringProfileId(undefined, { qualityProfileId: null });
+
+		expect(result).toBe('global-default');
+	});
+
+	it('falls back to the global default when no library is provided', async () => {
+		mocks.getDefaultScoringProfile.mockResolvedValue({ id: 'global-default' });
+
+		const result = await getEffectiveScoringProfileId(undefined);
+
+		expect(result).toBe('global-default');
+	});
+});

--- a/src/lib/server/library/LibraryAddService.ts
+++ b/src/lib/server/library/LibraryAddService.ts
@@ -109,9 +109,12 @@ export async function getAnimeSubtypeEnforcement(): Promise<boolean> {
 }
 
 /**
- * Get the effective scoring profile ID (provided or default)
+ * Get the effective scoring profile ID (provided, owning library, or default)
  */
-export async function getEffectiveScoringProfileId(providedProfileId?: string): Promise<string> {
+export async function getEffectiveScoringProfileId(
+	providedProfileId?: string | null,
+	owningLibrary?: { qualityProfileId: string | null } | null
+): Promise<string> {
 	// Ensure built-in profiles exist as valid FK targets before resolving the final profile ID.
 	await qualityFilter.seedDefaultScoringProfiles();
 
@@ -124,6 +127,13 @@ export async function getEffectiveScoringProfileId(providedProfileId?: string): 
 			);
 		}
 		return providedProfileId;
+	}
+
+	if (owningLibrary?.qualityProfileId) {
+		const profile = await qualityFilter.getProfile(owningLibrary.qualityProfileId);
+		if (profile) {
+			return owningLibrary.qualityProfileId;
+		}
 	}
 
 	const defaultProfile = await qualityFilter.getDefaultScoringProfile();

--- a/src/lib/server/library/LibraryEntityService.test.ts
+++ b/src/lib/server/library/LibraryEntityService.test.ts
@@ -13,7 +13,8 @@ vi.mock('$lib/server/db/index.js', () => ({
 	initializeDatabase: vi.fn().mockResolvedValue(undefined)
 }));
 
-const { libraries, libraryRootFolders, rootFolders } = await import('$lib/server/db/schema.js');
+const { libraries, libraryRootFolders, rootFolders, scoringProfiles } =
+	await import('$lib/server/db/schema.js');
 const { eq } = await import('drizzle-orm');
 const { LibraryEntityService } = await import('./LibraryEntityService.js');
 
@@ -116,5 +117,133 @@ describe('LibraryEntityService.listLibraries (read-only regression)', () => {
 		await testDb.db.delete(libraryRootFolders).where(eq(libraryRootFolders.libraryId, libraryId));
 		await testDb.db.delete(libraries).where(eq(libraries.id, libraryId));
 		await testDb.db.delete(rootFolders).where(eq(rootFolders.id, rootFolderId));
+	});
+});
+
+describe('LibraryEntityService quality profile per library', () => {
+	async function seedScoringProfile(id: string): Promise<void> {
+		await testDb.db
+			.insert(scoringProfiles)
+			.values({ id, name: `Profile ${id}` })
+			.onConflictDoNothing()
+			.run();
+	}
+
+	it('createLibrary persists the quality profile', async () => {
+		await seedScoringProfile('test-profile-create');
+
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile Create Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard',
+			qualityProfileId: 'test-profile-create'
+		});
+
+		expect(created.qualityProfileId).toBe('test-profile-create');
+
+		const row = await testDb.db
+			.select({ qualityProfileId: libraries.qualityProfileId })
+			.from(libraries)
+			.where(eq(libraries.id, created.id))
+			.get();
+		expect(row?.qualityProfileId).toBe('test-profile-create');
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+		await testDb.db.delete(scoringProfiles).where(eq(scoringProfiles.id, 'test-profile-create'));
+	});
+
+	it('updateLibrary sets the quality profile', async () => {
+		await seedScoringProfile('test-profile-update');
+
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile Update Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard'
+		});
+
+		const updated = await service.updateLibrary(created.id, {
+			qualityProfileId: 'test-profile-update'
+		});
+
+		expect(updated.qualityProfileId).toBe('test-profile-update');
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+		await testDb.db.delete(scoringProfiles).where(eq(scoringProfiles.id, 'test-profile-update'));
+	});
+
+	it('updateLibrary clears the quality profile when set to null', async () => {
+		await seedScoringProfile('test-profile-clear');
+
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile Clear Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard',
+			qualityProfileId: 'test-profile-clear'
+		});
+
+		const updated = await service.updateLibrary(created.id, { qualityProfileId: null });
+
+		expect(updated.qualityProfileId).toBeNull();
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+		await testDb.db.delete(scoringProfiles).where(eq(scoringProfiles.id, 'test-profile-clear'));
+	});
+
+	it('createLibrary normalizes an empty string profile to null', async () => {
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile Empty Create Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard',
+			qualityProfileId: ''
+		});
+
+		expect(created.qualityProfileId).toBeNull();
+
+		const row = await testDb.db
+			.select({ qualityProfileId: libraries.qualityProfileId })
+			.from(libraries)
+			.where(eq(libraries.id, created.id))
+			.get();
+		expect(row?.qualityProfileId).toBeNull();
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+	});
+
+	it('updateLibrary normalizes an empty string profile to null', async () => {
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile Empty Update Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard'
+		});
+
+		const updated = await service.updateLibrary(created.id, { qualityProfileId: '' });
+
+		expect(updated.qualityProfileId).toBeNull();
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+	});
+
+	it('listLibraries returns the quality profile', async () => {
+		await seedScoringProfile('test-profile-list');
+
+		const service = new LibraryEntityService();
+		const created = await service.createLibrary({
+			name: 'Profile List Library',
+			mediaType: 'movie',
+			mediaSubType: 'standard',
+			qualityProfileId: 'test-profile-list'
+		});
+
+		const libraryEntities = await service.listLibraries();
+		const found = libraryEntities.find((library) => library.id === created.id);
+		expect(found?.qualityProfileId).toBe('test-profile-list');
+
+		await testDb.db.delete(libraries).where(eq(libraries.id, created.id));
+		await testDb.db.delete(scoringProfiles).where(eq(scoringProfiles.id, 'test-profile-list'));
 	});
 });

--- a/src/lib/server/library/LibraryEntityService.ts
+++ b/src/lib/server/library/LibraryEntityService.ts
@@ -35,6 +35,7 @@ export interface LibraryEntity {
 	defaultRootFolderPath: string | null;
 	defaultSearchOnAdd: boolean;
 	defaultWantsSubtitles: boolean;
+	qualityProfileId: string | null;
 	sortOrder: number;
 	scanMode?: string | null;
 	createdAt: string;
@@ -49,6 +50,7 @@ export interface CreateLibraryInput {
 	isDefault?: boolean;
 	defaultSearchOnAdd?: boolean;
 	defaultWantsSubtitles?: boolean;
+	qualityProfileId?: string | null;
 	sortOrder?: number;
 	scanMode?: string;
 	scanConfig?: Record<string, unknown> | null;
@@ -306,6 +308,7 @@ export class LibraryEntityService {
 				defaultRootFolderId: libraries.defaultRootFolderId,
 				defaultSearchOnAdd: libraries.defaultSearchOnAdd,
 				defaultWantsSubtitles: libraries.defaultWantsSubtitles,
+				qualityProfileId: libraries.qualityProfileId,
 				sortOrder: libraries.sortOrder,
 				scanMode: libraries.scanMode,
 				createdAt: libraries.createdAt,
@@ -377,6 +380,7 @@ export class LibraryEntityService {
 					null,
 				defaultSearchOnAdd: row.defaultSearchOnAdd ?? true,
 				defaultWantsSubtitles: row.defaultWantsSubtitles ?? true,
+				qualityProfileId: row.qualityProfileId ?? null,
 				sortOrder: row.sortOrder ?? 0,
 				createdAt: row.createdAt ?? '',
 				updatedAt: row.updatedAt ?? ''
@@ -765,6 +769,7 @@ export class LibraryEntityService {
 			defaultRootFolderId: null,
 			defaultSearchOnAdd: input.defaultSearchOnAdd ?? true,
 			defaultWantsSubtitles: input.defaultWantsSubtitles ?? true,
+			qualityProfileId: input.qualityProfileId || null,
 			sortOrder: nextSortOrder,
 			scanMode: input.scanMode ?? 'scheduled',
 			scanConfig: input.scanConfig ?? null,
@@ -841,6 +846,9 @@ export class LibraryEntityService {
 		}
 		if (updates.defaultWantsSubtitles !== undefined) {
 			updateData.defaultWantsSubtitles = updates.defaultWantsSubtitles;
+		}
+		if (updates.qualityProfileId !== undefined) {
+			updateData.qualityProfileId = updates.qualityProfileId || null;
 		}
 		if (updates.sortOrder !== undefined) {
 			updateData.sortOrder = updates.sortOrder;

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -783,6 +783,7 @@ export class MediaMatcherService {
 						rootFolderId: rootFolder.id,
 						hasFile: true,
 						monitored: rootFolder.defaultMonitored ?? true,
+						scoringProfileId: owningLibrary.qualityProfileId,
 						languageProfileId: wantsSubtitles ? defaultProfileId : null,
 						wantsSubtitles
 					})
@@ -951,6 +952,7 @@ export class MediaMatcherService {
 						rootFolderId: rootFolder.id,
 						seriesType: rootFolder.mediaSubType === 'anime' || animeSignal ? 'anime' : 'standard',
 						monitored: rootFolder.defaultMonitored ?? true,
+						scoringProfileId: owningLibrary.qualityProfileId,
 						languageProfileId: wantsSubtitles ? defaultProfileId : null,
 						wantsSubtitles
 					})

--- a/src/lib/server/smartlists/SmartListService.ts
+++ b/src/lib/server/smartlists/SmartListService.ts
@@ -198,12 +198,10 @@ export class SmartListService {
 			presetId: updates.presetId ?? existing.presetId ?? undefined,
 			presetSettings:
 				((updates.presetSettings ?? existing.presetSettings) as
-					| Record<string, unknown>
-					| undefined) ?? undefined,
+					Record<string, unknown> | undefined) ?? undefined,
 			externalSourceConfig:
 				((updates.externalSourceConfig ?? existing.externalSourceConfig) as
-					| SmartListExternalSourceConfig
-					| undefined) ?? undefined
+					SmartListExternalSourceConfig | undefined) ?? undefined
 		});
 
 		const [result] = await db
@@ -798,8 +796,13 @@ export class SmartListService {
 			const monitored = list.autoAddMonitored ?? true;
 			const wantsSubtitles = list.wantsSubtitles ?? true;
 			const shouldSearch = _searchOnAdd && monitored;
+			const owningLibrary = await getLibraryEntityService().resolveOwningLibraryForRootFolder(
+				list.rootFolderId,
+				item.mediaType === 'movie' ? 'movie' : 'tv'
+			);
 			const scoringProfileId = await getEffectiveScoringProfileId(
-				list.scoringProfileId ?? undefined
+				list.scoringProfileId ?? undefined,
+				owningLibrary
 			);
 
 			if (item.mediaType === 'movie') {
@@ -1359,8 +1362,13 @@ export class SmartListService {
 		);
 
 		// Get effective scoring profile
+		const autoAddOwningLibrary = await getLibraryEntityService().resolveOwningLibraryForRootFolder(
+			list.rootFolderId,
+			mediaType
+		);
 		const effectiveProfileId = await getEffectiveScoringProfileId(
-			list.scoringProfileId ?? undefined
+			list.scoringProfileId ?? undefined,
+			autoAddOwningLibrary
 		);
 		const shouldSearch = list.autoAddBehavior === 'add_and_search';
 		const monitored = list.autoAddMonitored ?? true;

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -672,6 +672,7 @@ export const libraryCreateSchema = z.object({
 	isDefault: z.boolean().default(false),
 	defaultSearchOnAdd: z.boolean().default(true),
 	defaultWantsSubtitles: z.boolean().default(true),
+	qualityProfileId: z.string().nullable().optional(),
 	sortOrder: z.number().int().min(0).default(100),
 	scanMode: z.enum(['manual', 'scheduled', 'scheduled_daily', 'watch']).default('scheduled'),
 	scanConfig: z

--- a/src/routes/api/library/collections/[tmdbId]/track/+server.ts
+++ b/src/routes/api/library/collections/[tmdbId]/track/+server.ts
@@ -85,7 +85,14 @@ export const POST: RequestHandler = async (event) => {
 	}
 
 	const enforceAnimeSubtype = await getAnimeSubtypeEnforcement();
-	const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId);
+	const collectionOwningLibrary = await getLibraryEntityService().resolveOwningLibraryForRootFolder(
+		rootFolderId,
+		'movie'
+	);
+	const effectiveProfileId = await getEffectiveScoringProfileId(
+		scoringProfileId,
+		collectionOwningLibrary
+	);
 	const namingConfig = namingSettingsService.getConfigSync();
 	const langCodes = [
 		...new Set([

--- a/src/routes/api/library/movies/+server.ts
+++ b/src/routes/api/library/movies/+server.ts
@@ -221,7 +221,7 @@ export const POST: RequestHandler = async (event) => {
 		const { imdbId } = await fetchMovieExternalIds(tmdbId);
 
 		// Get the effective scoring profile (shared logic)
-		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId);
+		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId, owningLibrary);
 
 		// Get the language profile if subtitles wanted (shared logic)
 		const languageProfileId = await getLanguageProfileId(wantsSubtitles, tmdbId);

--- a/src/routes/api/library/movies/bulk/+server.ts
+++ b/src/routes/api/library/movies/bulk/+server.ts
@@ -78,7 +78,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		const moviesToAdd = tmdbIds.filter((id) => !existingTmdbIds.has(id));
 
 		// Get the effective scoring profile once (shared across all movies)
-		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId);
+		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId, owningLibrary);
 
 		const results: BulkAddResult = {
 			added: 0,

--- a/src/routes/api/library/series/+server.ts
+++ b/src/routes/api/library/series/+server.ts
@@ -219,7 +219,7 @@ export const POST: RequestHandler = async (event) => {
 				.reduce((sum, s) => sum + (s.episode_count ?? 0), 0) ?? 0;
 
 		// Get the effective scoring profile (shared logic)
-		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId);
+		const effectiveProfileId = await getEffectiveScoringProfileId(scoringProfileId, owningLibrary);
 
 		// Get the language profile if subtitles wanted (shared logic)
 		const languageProfileId = await getLanguageProfileId(wantsSubtitles, tmdbId);


### PR DESCRIPTION
## Summary
- Wire up the previously dead `libraries.quality_profile_id` column so each library can select its own default quality profile (no migration needed — column existed since #114 migration).
- Resolution chain: **explicit item profile → library profile → global default**. Applied in movie/series add, bulk add, collection track, smart list adds, and the unmatched-file import path.
- **LibraryEditModal**: new "Quality profile" dropdown (empty option = global default).
- **AddToLibraryModal**: pre-selects the owning library's profile instead of always defaulting to the global one.
- Empty-string `qualityProfileId` normalized to `null` on create/update (avoids a 500 FK error when saving "Default").

## Test Plan
- [x] 12 new unit tests (TDD, red-green verified): `LibraryAddService.test.ts`, `LibraryEntityService.test.ts`
- [x] Full suite: 2501 passed, 28 skipped
- [x] `svelte-check` 0 errors, eslint + prettier clean
- [x] Live-verified against running instance:
  - Movie/series added without explicit profile inherit the library profile
  - Explicit per-item profile still wins
  - Clearing library profile (`null`) falls back to global default
  - Deleting a referenced profile → `ON DELETE SET NULL` on library + media, add falls back to default
  - Search with a deleted profile id → silently falls back to global default (no error)
  - `PUT qualityProfileId: ""` no longer 500s
- [x] Test data cleaned up after live verification

Closes #439