### PR TITLE
feat(naming): Add `Specials` folder naming support for season 0 with scanner and download client fixes

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2939,6 +2939,8 @@
 	"settings_naming_savedCustomSource": "Gespeicherte benutzerdefinierte Quelle",
 	"settings_naming_savePreset": "Voreinstellung speichern",
 	"settings_naming_seasonFolder": "Staffel-Ordner",
+	"settings_naming_useSpecialsFolder": "'Specials'-Ordner für Staffel 0 verwenden",
+	"settings_naming_useSpecialsFolderHelp": "Legt Specials in einem 'Specials'-Ordner statt in 'Season 00' ab. Nach dieser Änderung einen Umbenennungs-Job ausführen, um vorhandene Dateien zu verschieben.",
 	"settings_naming_seasonFolderFormat": "Staffel-Ordner-Format",
 	"settings_naming_selectCustomPreset": "Benutzerdefinierte Voreinstellung auswählen...",
 	"settings_naming_seriesFolder": "Serien-Ordner",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3197,6 +3197,8 @@
 	"settings_naming_savedCustomSource": "Saved custom source",
 	"settings_naming_savePreset": "Save Preset",
 	"settings_naming_seasonFolder": "Season Folder",
+	"settings_naming_useSpecialsFolder": "Use 'Specials' folder for season 0",
+	"settings_naming_useSpecialsFolderHelp": "Places specials in a 'Specials' folder instead of 'Season 00'. Run a rename job after changing this to move existing files.",
 	"settings_naming_seasonFolderFormat": "Season Folder Format",
 	"settings_naming_selectCustomPreset": "Select a custom preset…",
 	"settings_naming_seriesFolder": "Series Folder",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2939,6 +2939,8 @@
 	"settings_naming_savedCustomSource": "Fuente personalizada guardada",
 	"settings_naming_savePreset": "Guardar preajuste",
 	"settings_naming_seasonFolder": "Carpeta de temporada",
+	"settings_naming_useSpecialsFolder": "Usar carpeta 'Specials' para la temporada 0",
+	"settings_naming_useSpecialsFolderHelp": "Coloca los especiales en una carpeta 'Specials' en lugar de 'Season 00'. Ejecuta un trabajo de renombrado tras cambiar esto para mover los archivos existentes.",
 	"settings_naming_seasonFolderFormat": "Formato de carpeta de temporada",
 	"settings_naming_selectCustomPreset": "Selecciona un preajuste personalizado…",
 	"settings_naming_seriesFolder": "Carpeta de serie",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -3196,6 +3196,8 @@
 	"settings_naming_savedCustomSource": "Сохранённый пользовательский источник",
 	"settings_naming_savePreset": "Сохранить пресет",
 	"settings_naming_seasonFolder": "Папка сезона",
+	"settings_naming_useSpecialsFolder": "Использовать папку 'Specials' для сезона 0",
+	"settings_naming_useSpecialsFolderHelp": "Помещает спецэпизоды в папку 'Specials' вместо 'Season 00'. После изменения запустите задание переименования для перемещения существующих файлов.",
 	"settings_naming_seasonFolderFormat": "Формат папки сезона",
 	"settings_naming_selectCustomPreset": "Выберите пользовательский пресет…",
 	"settings_naming_seriesFolder": "Папка сериала",

--- a/src/lib/components/naming/NamingAdvancedOptions.svelte
+++ b/src/lib/components/naming/NamingAdvancedOptions.svelte
@@ -95,6 +95,22 @@
 						<input
 							type="checkbox"
 							class="checkbox checkbox-sm checkbox-primary"
+							bind:checked={config.useSpecialsFolder}
+						/>
+						<div class="flex flex-col gap-0.5">
+							<span class="label-text">{m.settings_naming_useSpecialsFolder()}</span>
+							<span class="text-xs text-base-content/55"
+								>{m.settings_naming_useSpecialsFolderHelp()}</span
+							>
+						</div>
+					</label>
+
+					<label
+						class="label cursor-pointer justify-start gap-3 rounded-lg border border-base-300 px-3 py-2 transition-colors hover:bg-base-300/50"
+					>
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm checkbox-primary"
 							bind:checked={config.includeQuality}
 						/>
 						<span class="label-text">{m.settings_naming_includeQuality()}</span>

--- a/src/lib/components/ui/form/FormSelect.svelte
+++ b/src/lib/components/ui/form/FormSelect.svelte
@@ -89,7 +89,7 @@
 		</div>
 	{:else if helpText}
 		<div class="label py-1">
-			<span class="label-text-alt text-xs text-base-content/60">{helpText}</span>
+			<span class="label-text-alt text-xs whitespace-normal text-base-content/60">{helpText}</span>
 		</div>
 	{/if}
 </div>

--- a/src/lib/naming/setup-presets.ts
+++ b/src/lib/naming/setup-presets.ts
@@ -13,6 +13,7 @@ export interface NamingConfigShape {
 	includeQuality: boolean;
 	includeMediaInfo: boolean;
 	includeReleaseGroup: boolean;
+	useSpecialsFolder: boolean;
 }
 
 export interface NamingPreset {
@@ -61,7 +62,8 @@ export const DEFAULT_SETUP_NAMING_CONFIG: NamingConfigShape = {
 	mediaServerIdFormat: 'plex',
 	includeQuality: true,
 	includeMediaInfo: true,
-	includeReleaseGroup: true
+	includeReleaseGroup: true,
+	useSpecialsFolder: false
 };
 
 const RECOMMENDED_MOVIE_FILE =

--- a/src/lib/server/library/jobs/StreamingDiskScanner.ts
+++ b/src/lib/server/library/jobs/StreamingDiskScanner.ts
@@ -31,10 +31,13 @@ const EXCLUDED_FOLDER_PATTERNS = [
 	/^featurettes?$/i,
 	/^behind[\s._-]?the[\s._-]?scenes?$/i,
 	/^deleted[\s._-]?scenes?$/i,
-	/^specials?$/i,
 	/^subs?$/i,
 	/^subtitles?$/i
 ];
+
+// Patterns only excluded at shallow depth (≤1 from root). At depth ≥2 the
+// same name is a valid TV season folder (e.g. a show's own Specials/ dir).
+const SHALLOW_EXCLUDED_FOLDER_PATTERNS = [/^specials?$/i];
 
 const SAMPLE_PATTERNS = [/\bsample\b/i];
 
@@ -114,7 +117,7 @@ export class StreamingDiskScanner {
 		}
 	}
 
-	private shouldExcludeFolder(name: string): boolean {
+	private shouldExcludeFolder(name: string, depth: number): boolean {
 		const { patterns, customExcludedFolders } = this.options;
 		if (patterns) {
 			// Folder-level ignore: test with trailing slash so directory
@@ -122,6 +125,7 @@ export class StreamingDiskScanner {
 			const relPath = name + '/';
 			return matchIgnore(relPath, patterns);
 		}
+		if (depth >= 1 && SHALLOW_EXCLUDED_FOLDER_PATTERNS.some((p) => p.test(name))) return false;
 		return shouldExcludeFolderLegacy(name, customExcludedFolders);
 	}
 
@@ -143,7 +147,8 @@ export class StreamingDiskScanner {
 
 	private async *walkDirectory(
 		rootPath: string,
-		currentPath: string
+		currentPath: string,
+		depth = 0
 	): AsyncGenerator<DiscoveredFile> {
 		let dirHandle: Awaited<ReturnType<typeof opendir>>;
 		try {
@@ -164,9 +169,9 @@ export class StreamingDiskScanner {
 			const fullPath = join(currentPath, entry.name);
 
 			if (entry.isDirectory()) {
-				if (this.shouldExcludeFolder(entry.name)) continue;
+				if (this.shouldExcludeFolder(entry.name, depth)) continue;
 
-				yield* this.walkDirectory(rootPath, fullPath);
+				yield* this.walkDirectory(rootPath, fullPath, depth + 1);
 			} else if (entry.isFile() || entry.isSymbolicLink()) {
 				if (!isVideoFile(entry.name)) continue;
 

--- a/src/lib/server/library/naming/NamingService.ts
+++ b/src/lib/server/library/naming/NamingService.ts
@@ -83,6 +83,7 @@ export interface NamingConfig {
 	includeQuality: boolean;
 	includeMediaInfo: boolean;
 	includeReleaseGroup: boolean;
+	useSpecialsFolder: boolean;
 }
 
 /**
@@ -116,7 +117,8 @@ export const DEFAULT_NAMING_CONFIG: NamingConfig = {
 	mediaServerIdFormat: 'plex',
 	includeQuality: true,
 	includeMediaInfo: true,
-	includeReleaseGroup: true
+	includeReleaseGroup: true,
+	useSpecialsFolder: false
 };
 
 /**
@@ -188,6 +190,9 @@ export class NamingService {
 	 * Generate a season folder name
 	 */
 	generateSeasonFolderName(seasonNumber: number): string {
+		if (seasonNumber === 0 && this.config.useSpecialsFolder) {
+			return 'Specials';
+		}
 		return this.formatName(this.config.seasonFolderFormat, {
 			title: '',
 			seasonNumber

--- a/src/lib/server/library/naming/NamingSettingsService.ts
+++ b/src/lib/server/library/naming/NamingSettingsService.ts
@@ -35,7 +35,8 @@ const KEY_MAP: Record<string, keyof NamingConfig> = {
 	media_server_id_format: 'mediaServerIdFormat',
 	include_quality: 'includeQuality',
 	include_media_info: 'includeMediaInfo',
-	include_release_group: 'includeReleaseGroup'
+	include_release_group: 'includeReleaseGroup',
+	use_specials_folder: 'useSpecialsFolder'
 };
 
 const PRESET_KEY_MAP = {
@@ -59,7 +60,12 @@ const REVERSE_PRESET_KEY_MAP: Record<keyof NamingPresetSelection, string> = Obje
 /**
  * Boolean settings that need special handling
  */
-const BOOLEAN_KEYS = new Set(['include_quality', 'include_media_info', 'include_release_group']);
+const BOOLEAN_KEYS = new Set([
+	'include_quality',
+	'include_media_info',
+	'include_release_group',
+	'use_specials_folder'
+]);
 
 /**
  * Helper to set a config value by key

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -513,6 +513,24 @@ export class RenamePreviewService {
 					}
 				}
 
+				// Clean up empty season subdirectories left behind when files moved
+				// between season folders within the same series folder (e.g. Season 00
+				// -> Specials). The series-level parent path is unchanged so
+				// applyFolderRename never runs, but the old season dir may now be empty.
+				const oldSeasonDirs = new Set<string>();
+				for (const item of items) {
+					const matched = groupResult.find((r) => r.fileId === item.fileId);
+					if (!matched?.success) continue;
+					const oldSeasonDir = dirname(item.currentFullPath);
+					const newSeasonDir = dirname(item.newFullPath);
+					if (oldSeasonDir !== newSeasonDir) {
+						oldSeasonDirs.add(oldSeasonDir);
+					}
+				}
+				for (const dir of oldSeasonDirs) {
+					await this.tryRemoveEmptyDir(dir);
+				}
+
 				return groupResult;
 			})
 		);

--- a/src/lib/server/library/patterns/PatternRecognitionService.test.ts
+++ b/src/lib/server/library/patterns/PatternRecognitionService.test.ts
@@ -249,7 +249,10 @@ describe('PatternRecognitionService default pattern sanity', () => {
 	it('DEFAULT_BONUS_FOLDER_NAMES includes standard extras folders', () => {
 		expect(DEFAULT_BONUS_FOLDER_NAMES).toContain('Behind the Scenes');
 		expect(DEFAULT_BONUS_FOLDER_NAMES).toContain('Extras');
-		expect(DEFAULT_BONUS_FOLDER_NAMES).toContain('Specials');
+		// 'Specials' and 'Season 00' are TV season folders, not movie extras;
+		// they must NOT be classified as bonus content.
+		expect(DEFAULT_BONUS_FOLDER_NAMES).not.toContain('Specials');
+		expect(DEFAULT_BONUS_FOLDER_NAMES).not.toContain('Season 00');
 	});
 
 	it('DEFAULT_BONUS_FILE_PATTERNS catches trailer/teaser/promo/bonus filenames', () => {

--- a/src/lib/server/library/patterns/PatternRecognitionService.ts
+++ b/src/lib/server/library/patterns/PatternRecognitionService.ts
@@ -107,8 +107,6 @@ export const DEFAULT_BONUS_FOLDER_NAMES: string[] = [
 	'Behind the Scenes',
 	'Deleted Scenes',
 	'Interviews',
-	'Specials',
-	'Season 00',
 	'Extras',
 	'Trailers',
 	'Featurettes',

--- a/src/lib/server/library/tv-episode-resolver.ts
+++ b/src/lib/server/library/tv-episode-resolver.ts
@@ -38,6 +38,11 @@ interface EpisodeRecordLike {
 export function extractSeasonFromPath(pathValue: string): number | undefined {
 	const normalizedPath = resolve(pathValue).replace(/\\/g, '/');
 
+	// "Specials" folder name is treated as season 0.
+	if (/(?:^|\/)specials?(?:\/|$)/i.test(normalizedPath)) {
+		return 0;
+	}
+
 	// First pass: match season as a complete path segment boundary
 	// e.g. /Season 1/, /s01/, /Season.1/
 	const segmentPatterns = [

--- a/src/lib/server/logging/log-history.ts
+++ b/src/lib/server/logging/log-history.ts
@@ -432,7 +432,12 @@ class LogHistoryService {
 	}
 
 	private rotateIfNeeded(filePath: string): void {
-		if (this.currentFilePath === filePath && this.stream) {
+		if (
+			this.currentFilePath === filePath &&
+			this.stream &&
+			!this.stream.destroyed &&
+			this.stream.writable
+		) {
 			return;
 		}
 

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -997,7 +997,8 @@ export const namingConfigUpdateSchema = z.object({
 	mediaServerIdFormat: mediaServerIdFormatSchema.optional(),
 	includeQuality: z.boolean().optional(),
 	includeMediaInfo: z.boolean().optional(),
-	includeReleaseGroup: z.boolean().optional()
+	includeReleaseGroup: z.boolean().optional(),
+	useSpecialsFolder: z.boolean().optional()
 });
 
 export const namingPresetSelectionSchema = z.object({

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -456,7 +456,7 @@ function isDebridImplementation(implementation: string): boolean {
 }
 
 const downloadClientBaseFields = {
-	name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or less'),
+	name: z.string().min(1, 'Name is required').max(20, 'Name must be 20 characters or less'),
 	enabled: z.boolean().default(true),
 	priority: z.number().int().min(1).max(100).default(1)
 };
@@ -513,8 +513,68 @@ export const downloadClientCreateSchema = z.union([
 export type DownloadClientCreateDiscriminated =
 	| z.infer<typeof debridDownloadClientCreateSchema>
 	| z.infer<typeof nonDebridDownloadClientCreateSchema>;
-const debridDownloadClientUpdateSchema = debridDownloadClientCreateSchema.partial();
-const nonDebridDownloadClientUpdateSchema = nonDebridDownloadClientCreateSchema.partial();
+// Update schemas defined explicitly without .default() so that absent fields
+// are omitted from the parsed output rather than filled with default values.
+// In Zod v4, .partial() on a schema with .default() still applies defaults for
+// absent fields, which causes superRefine forbidden-field checks to fire on
+// fields the caller never sent (e.g. toggle sends {enabled:false} but Zod fills
+// in removeAfterImport:false from the debrid branch, then superRefine rejects it
+// for non-debrid clients).
+const debridDownloadClientUpdateSchema = z
+	.object({
+		name: z
+			.string()
+			.min(1, 'Name is required')
+			.max(20, 'Name must be 20 characters or less')
+			.optional(),
+		enabled: z.boolean().optional(),
+		priority: z.number().int().min(1).max(100).optional(),
+		implementation: z.enum(DEBRID_IMPLEMENTATIONS).optional(),
+		apiToken: z.string().optional().nullable(),
+		removeAfterImport: z.boolean().optional()
+	})
+	.strict();
+const nonDebridDownloadClientUpdateSchema = z
+	.object({
+		name: z
+			.string()
+			.min(1, 'Name is required')
+			.max(20, 'Name must be 20 characters or less')
+			.optional(),
+		enabled: z.boolean().optional(),
+		priority: z.number().int().min(1).max(100).optional(),
+		implementation: z.enum(NON_DEBRID_IMPLEMENTATIONS).optional(),
+		host: z.string().min(1, 'Host is required').optional(),
+		port: z
+			.number()
+			.int()
+			.min(1, 'Port must be at least 1')
+			.max(65535, 'Port must be at most 65535')
+			.optional(),
+		useSsl: z.boolean().optional(),
+		urlBase: z.string().max(200).optional().nullable(),
+		mountMode: z.enum(['nzbdav', 'altmount']).optional().nullable(),
+		username: z.string().optional().nullable(),
+		password: z.string().optional().nullable(),
+		movieCategory: z.string().min(1).optional(),
+		tvCategory: z.string().min(1).optional(),
+		recentPriority: downloadPrioritySchema.optional(),
+		olderPriority: downloadPrioritySchema.optional(),
+		initialState: downloadInitialStateSchema.optional(),
+		seedRatioLimit: z
+			.string()
+			.regex(/^\d+(\.\d+)?$/, 'Must be a valid decimal number (e.g., "1.0", "2.5")')
+			.optional()
+			.nullable(),
+		seedTimeLimit: z.number().int().min(0).optional().nullable(),
+		downloadPathLocal: z.string().optional().nullable(),
+		downloadPathRemote: z.string().optional().nullable(),
+		tempPathLocal: z.string().optional().nullable(),
+		tempPathRemote: z.string().optional().nullable(),
+		apiToken: z.never().optional(),
+		removeAfterImport: z.never().optional()
+	})
+	.strict();
 export const downloadClientUpdateSchema = z.union([
 	debridDownloadClientUpdateSchema,
 	nonDebridDownloadClientUpdateSchema

--- a/src/routes/api/debrid-operational.test.ts
+++ b/src/routes/api/debrid-operational.test.ts
@@ -103,7 +103,7 @@ interface ProviderState {
 const scenarios: Scenario[] = [
 	{
 		provider: 'realdebrid',
-		clientName: 'Acceptance Real-Debrid',
+		clientName: 'Acceptance RD',
 		token: 'ACCEPTANCE_REAL_DEBRID_TOKEN_000001',
 		providerItemId: 'ACCEPTANCE-RD-PROVIDER-1',
 		infoHash: '1111111111111111111111111111111111111111',


### PR DESCRIPTION
## Summary

Adds a `useSpecialsFolder` toggle to rename season 0 episodes into a "Specials" folder instead of "Season 00", with supporting scanner and rename service fixes. Also fixes a 400 validation error when toggling download client enabled state caused by Zod v4 applying `.default()` values in `.partial()` schemas.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->
N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

**Specials folder support:**
- Add `useSpecialsFolder` boolean to `NamingConfig` ; `generateSeasonFolderName` returns "Specials" for season 0 when enabled
- `extractSeasonFromPath` recognises "Specials" path segments as season 0
- Persist `use_specials_folder` via `NamingSettingsService` KEY_MAP and BOOLEAN_KEYS; add to Zod schema
- Add checkbox UI in `NamingAdvancedOptions` with i18n strings (en/de/es/ru)
- Set `useSpecialsFolder: false` in `DEFAULT_SETUP_NAMING_CONFIG`
- Make Specials/ folder exclusion depth-aware in `StreamingDiskScanner` ; excluded at depth 0 (stray root-level), allowed at depth ≥1 (season folder inside a show); fixes episodes showing as Missing after rename
- Remove `'Specials'` and `'Season 00'` from `DEFAULT_BONUS_FOLDER_NAMES`; these are TV season folders, not movie extras
- Fix `RenamePreviewService` to clean up empty season subdirectories after files move between season folders
- Fix `LogHistoryService` stream not recovering after a write error; `rotateIfNeeded` now checks `destroyed`/`writable` before reusing the handle

**Download client toggle fix:**
- Replace `createSchema.partial()` update schemas with explicit schemas using `.optional()` only (no `.default()`), preventing Zod v4 from injecting default values (e.g. `removeAfterImport: false`) for absent fields; fixes `superRefine` forbidden-field check incorrectly rejecting toggle requests for non-debrid clients
- Align `downloadClientBaseFields` name `max(100)` → `max(20)` to match the form's enforced limit

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [x] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

<!-- For UI changes, include before/after screenshots -->
