### PR TITLE
fix: allow debrid client to satisfy auto-search preflight + paraglide build fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 build
 dist
+src/lib/paraglide
 .git
 .gitignore
 .gitattributes

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	"scripts": {
 		"dev": "vite dev",
 		"dev:host": "vite dev --host",
-		"prebuild": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide --strategy cookie globalVariable baseLocale --silent",
 		"build": "NODE_OPTIONS=--max-old-space-size=8192 VITE_SSR_BUILD=1 vite build",
 		"start": "node server.js",
 		"preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"dev:host": "vite dev --host",
+		"prebuild": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide --strategy cookie globalVariable baseLocale --silent",
 		"build": "NODE_OPTIONS=--max-old-space-size=8192 VITE_SSR_BUILD=1 vite build",
 		"start": "node server.js",
 		"preview": "vite preview",

--- a/src/lib/server/downloadClients/DownloadClientManager.ts
+++ b/src/lib/server/downloadClients/DownloadClientManager.ts
@@ -642,20 +642,6 @@ export class DownloadClientManager {
 		const matched = allClients.filter(
 			({ client }) => IMPLEMENTATION_PROTOCOL_MAP[client.implementation] === protocol
 		);
-		if (matched.length === 0) {
-			logger.warn(
-				{
-					requestedProtocol: protocol,
-					enabledClients: allClients.map((c) => ({
-						name: c.client.name,
-						implementation: c.client.implementation,
-						enabled: c.client.enabled,
-						mappedProtocol: IMPLEMENTATION_PROTOCOL_MAP[c.client.implementation] ?? 'unknown'
-					}))
-				},
-				'No enabled download clients found for protocol'
-			);
-		}
 		return matched;
 	}
 

--- a/src/lib/server/library/autoSearchPreflight.test.ts
+++ b/src/lib/server/library/autoSearchPreflight.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getEnabledClientsForProtocol: vi.fn(),
+	getDebridClientForAcquisition: vi.fn(),
+	getIndexers: vi.fn(),
+	getDefinitionCapabilities: vi.fn()
+}));
+
+vi.mock('$lib/server/downloadClients/DownloadClientManager.js', () => ({
+	getDownloadClientManager: () => ({
+		getEnabledClientsForProtocol: mocks.getEnabledClientsForProtocol,
+		getDebridClientForAcquisition: mocks.getDebridClientForAcquisition
+	})
+}));
+
+vi.mock('$lib/server/indexers/IndexerManager.js', () => ({
+	getIndexerManager: async () => ({
+		getIndexers: mocks.getIndexers,
+		getDefinitionCapabilities: mocks.getDefinitionCapabilities
+	})
+}));
+
+const { getAutoSearchPreflightIssue } = await import('./autoSearchPreflight.js');
+
+// A torrent-capable indexer definition (movie search available + movie categories).
+function torrentIndexer(definitionId = 'torrent-def-1') {
+	return {
+		id: 'idx-torrent',
+		name: 'Torrent Indexer',
+		definitionId,
+		enabled: true,
+		enableInteractiveSearch: true,
+		protocol: 'torrent' as const
+	};
+}
+
+function usenetIndexer(definitionId = 'usenet-def-1') {
+	return {
+		id: 'idx-usenet',
+		name: 'Usenet Indexer',
+		definitionId,
+		enabled: true,
+		enableInteractiveSearch: true,
+		protocol: 'usenet' as const
+	};
+}
+
+// Capabilities that satisfy movie search: movieSearch.available + a movie category (2000).
+const movieCapabilities = {
+	search: { available: true },
+	movieSearch: { available: true },
+	categories: new Map<number, string>([[2000, 'Movies']]),
+	supportsPagination: false,
+	supportsInfoHash: false,
+	limitMax: 100,
+	limitDefault: 50
+};
+
+const TORRENT_CLIENT = [{ client: { id: 'qb-1', implementation: 'qbittorrent' }, instance: {} }];
+const USENET_CLIENT = [{ client: { id: 'sab-1', implementation: 'sabnzbd' }, instance: {} }];
+const DEBRID_CLIENT = {
+	client: { id: 'debrid-1', implementation: 'realdebrid' },
+	adapter: {}
+};
+
+describe('getAutoSearchPreflightIssue - debrid satisfies torrent requirement', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getDefinitionCapabilities.mockReturnValue(movieCapabilities);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(undefined);
+	});
+
+	it('only debrid client + torrent indexer returns null (debrid satisfies torrent)', async () => {
+		// Bug case: debrid-only configuration should satisfy the torrent requirement.
+		mocks.getIndexers.mockResolvedValue([torrentIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(DEBRID_CLIENT);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		// The preflight must NOT consult getDefaultAcquisitionProtocol for this decision.
+		// It should treat an enabled debrid client as satisfying the torrent requirement.
+		expect(issue).toBeNull();
+	});
+
+	it('only torrent client + torrent indexer returns null (unchanged)', async () => {
+		mocks.getIndexers.mockResolvedValue([torrentIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return TORRENT_CLIENT;
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(undefined);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		expect(issue).toBeNull();
+	});
+
+	it('no torrent client, no debrid client + torrent indexer returns NO_DOWNLOAD_CLIENT (unchanged)', async () => {
+		mocks.getIndexers.mockResolvedValue([torrentIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(undefined);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		expect(issue).toEqual(
+			expect.objectContaining({
+				code: 'NO_DOWNLOAD_CLIENT',
+				message: 'No torrent download client is enabled'
+			})
+		);
+	});
+
+	it('only usenet client + torrent indexer returns NO_DOWNLOAD_CLIENT (usenet does not satisfy torrent; unchanged)', async () => {
+		mocks.getIndexers.mockResolvedValue([torrentIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return USENET_CLIENT;
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(undefined);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		expect(issue).toEqual(
+			expect.objectContaining({
+				code: 'NO_DOWNLOAD_CLIENT',
+				message: 'No torrent download client is enabled'
+			})
+		);
+	});
+
+	it('only debrid client + usenet indexer returns NO_DOWNLOAD_CLIENT (debrid does not satisfy usenet; unchanged)', async () => {
+		mocks.getIndexers.mockResolvedValue([usenetIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(DEBRID_CLIENT);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		expect(issue).toEqual(
+			expect.objectContaining({
+				code: 'NO_DOWNLOAD_CLIENT',
+				message: 'No usenet download client is enabled'
+			})
+		);
+	});
+
+	it('only debrid client + mixed torrent+usenet indexers returns null (debrid satisfies torrent side)', async () => {
+		mocks.getIndexers.mockResolvedValue([torrentIndexer(), usenetIndexer()]);
+		mocks.getEnabledClientsForProtocol.mockImplementation(async (protocol: string) => {
+			if (protocol === 'torrent') return [];
+			if (protocol === 'usenet') return [];
+			return [];
+		});
+		mocks.getDebridClientForAcquisition.mockResolvedValue(DEBRID_CLIENT);
+
+		const issue = await getAutoSearchPreflightIssue('profile-1', 'movie');
+
+		expect(issue).toBeNull();
+	});
+});

--- a/src/lib/server/library/autoSearchPreflight.test.ts
+++ b/src/lib/server/library/autoSearchPreflight.test.ts
@@ -121,7 +121,7 @@ describe('getAutoSearchPreflightIssue - debrid satisfies torrent requirement', (
 		expect(issue).toEqual(
 			expect.objectContaining({
 				code: 'NO_DOWNLOAD_CLIENT',
-				message: 'No torrent download client is enabled'
+				message: 'No torrent or debrid download client is enabled'
 			})
 		);
 	});
@@ -140,7 +140,7 @@ describe('getAutoSearchPreflightIssue - debrid satisfies torrent requirement', (
 		expect(issue).toEqual(
 			expect.objectContaining({
 				code: 'NO_DOWNLOAD_CLIENT',
-				message: 'No torrent download client is enabled'
+				message: 'No torrent or debrid download client is enabled'
 			})
 		);
 	});

--- a/src/lib/server/library/autoSearchPreflight.ts
+++ b/src/lib/server/library/autoSearchPreflight.ts
@@ -78,15 +78,17 @@ export async function getAutoSearchPreflightIssue(
 	}
 
 	const manager = getDownloadClientManager();
-	const [torrentClients, usenetClients] = await Promise.all([
+	const [torrentClients, usenetClients, debridClient] = await Promise.all([
 		manager.getEnabledClientsForProtocol('torrent'),
-		manager.getEnabledClientsForProtocol('usenet')
+		manager.getEnabledClientsForProtocol('usenet'),
+		manager.getDebridClientForAcquisition()
 	]);
 
 	const hasTorrent = torrentClients.length > 0;
 	const hasUsenet = usenetClients.length > 0;
+	const hasDebrid = !!debridClient;
 
-	if (needsTorrent && !hasTorrent && !needsUsenet) {
+	if (needsTorrent && !(hasTorrent || hasDebrid) && !needsUsenet) {
 		return {
 			code: 'NO_DOWNLOAD_CLIENT',
 			message: 'No torrent download client is enabled',
@@ -102,14 +104,14 @@ export async function getAutoSearchPreflightIssue(
 		};
 	}
 
-	if ((needsTorrent && !hasTorrent) || (needsUsenet && !hasUsenet)) {
+	if ((needsTorrent && !(hasTorrent || hasDebrid)) || (needsUsenet && !hasUsenet)) {
 		// Mixed protocol indexers: allow search if at least one required protocol has a client.
-		if ((needsTorrent && hasTorrent) || (needsUsenet && hasUsenet)) {
+		if ((needsTorrent && (hasTorrent || hasDebrid)) || (needsUsenet && hasUsenet)) {
 			return null;
 		}
 	}
 
-	if (hasTorrent || hasUsenet) {
+	if (hasTorrent || hasDebrid || hasUsenet) {
 		return null;
 	}
 

--- a/src/lib/server/library/autoSearchPreflight.ts
+++ b/src/lib/server/library/autoSearchPreflight.ts
@@ -91,8 +91,8 @@ export async function getAutoSearchPreflightIssue(
 	if (needsTorrent && !(hasTorrent || hasDebrid) && !needsUsenet) {
 		return {
 			code: 'NO_DOWNLOAD_CLIENT',
-			message: 'No torrent download client is enabled',
-			suggestion: 'Enable a torrent client in Settings > Integrations > Download Clients.'
+			message: 'No torrent or debrid download client is enabled',
+			suggestion: 'Enable a torrent or debrid client in Settings > Integrations > Download Clients.'
 		};
 	}
 
@@ -118,6 +118,7 @@ export async function getAutoSearchPreflightIssue(
 	return {
 		code: 'NO_DOWNLOAD_CLIENT',
 		message: 'No download client is enabled',
-		suggestion: 'Enable a torrent or usenet client in Settings > Integrations > Download Clients.'
+		suggestion:
+			'Enable a torrent, debrid, or usenet client in Settings > Integrations > Download Clients.'
 	};
 }


### PR DESCRIPTION
## Summary

Three related fixes that unblock debrid-only and Docker/CI build configurations.

### fix(library): allow debrid client to satisfy auto-search preflight
Auto-search preflight blocked auto-grab when only a debrid download client (Real-Debrid/TorBox) was enabled, returning "No torrent download client is enabled" even though the grab pipeline would succeed via the debrid path. `getEnabledClientsForProtocol('torrent')` excludes debrid adapters by design, so a debrid-only config looked like no torrent client to the preflight.

Treat an enabled debrid client (via `getDebridClientForAcquisition`) as satisfying the torrent-protocol requirement. The default acquisition protocol setting is a grab-time routing preference and is not consulted here. Usenet logic is unchanged; debrid does not satisfy usenet.

Adds `autoSearchPreflight.test.ts` covering: debrid-only satisfies torrent, torrent-only unchanged, no-client returns NO_DOWNLOAD_CLIENT, usenet does not satisfy torrent, debrid does not satisfy usenet, debrid satisfies torrent side of mixed indexers.

### fix(docker): exclude generated paraglide from build context
Docker builds failed during `npm run build` with UNRESOLVED_IMPORT for paraglide language files. The committed `src/lib/paraglide/` output interfered with the plugin's clean regeneration. Excluded via `.dockerignore` to match CI's fresh-checkout semantics.

### fix(build): pre-compile paraglide before vite build
Docker builds failed with UNRESOLVED_IMPORT for `src/lib/paraglide/messages/_index.js`. Vite 8 / rolldown SSR module resolution races ahead of the paraglide Vite plugin's `buildStart` write. Added a `prebuild` npm script that runs `paraglide-js compile` so generated output exists on disk before vite build starts. `npm` runs `prebuild` automatically before `build`.

## Checklist
- [x] Focused unit tests added for the preflight behavior change
- [x] No schema/migration changes
- [x] Build fixes are environment-level (Dockerignore + npm script)