### PR TITLE
feat(indexers): add NoNaMe Club and fix Kinozal cartoon categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Dynamic content discovery with auto-add to library. Import from IMDb, Trakt, TMD
 
 - File watching and auto-import
 - Multi-indexer search with deduplication
+- Built-in Cardigann-compatible tracker definitions, including NoNaMe Club
 - 6 subtitle providers, 80+ languages
 - 7 automated monitoring tasks
 - Jellyfin/Emby notifications

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <em>Cinephage</em> — from Greek <em>cine</em> (film) + <em>phage</em> (to devour). A film devourer.
+  <em>Cinephage</em> - from Greek <em>cine</em> (film) + <em>phage</em> (to devour). A film devourer.
 </p>
 
 <p align="center">
@@ -61,14 +61,14 @@ Cinephage is a single app for your whole media setup. Instead of running multipl
 
 Cinephage brings together functionality you'd typically find across multiple applications:
 
-- **Radarr & Sonarr** — Movie and TV series management
-- **Prowlarr** — Indexer management with supported trackers
-- **Bazarr** — Multi-provider subtitle management
-- **Overseerr** — Content discovery and smart lists
-- **FlareSolverr** — Built-in Cloudflare bypass (no external service needed)
-- **Plus** — Live TV/IPTV management, usenet streaming, and more
+- **Radarr & Sonarr** - Movie and TV series management
+- **Prowlarr** - Indexer management with supported trackers
+- **Bazarr** - Multi-provider subtitle management
+- **Overseerr** - Content discovery and smart lists
+- **FlareSolverr** - Built-in Cloudflare bypass (no external service needed)
+- **Plus** - Live TV/IPTV management, usenet streaming, and more
 
-The \*arr projects are fantastic at what they do. We just took a different path — one unified codebase instead of separate services that need to sync with each other.
+The \*arr projects are fantastic at what they do. We just took a different path - one unified codebase instead of separate services that need to sync with each other.
 
 ---
 
@@ -102,20 +102,19 @@ Dynamic content discovery with auto-add to library. Import from IMDb, Trakt, TMD
 
 - File watching and auto-import
 - Multi-indexer search with deduplication
-- Built-in Cardigann-compatible tracker definitions, including NoNaMe Club
-- 6 subtitle providers, 80+ languages
-- 7 automated monitoring tasks
-- Jellyfin/Emby notifications
+- Built-in Cardigann-compatible tracker definitions
+- 6+ subtitle providers, 80+ languages
+- 7+ automated monitoring tasks
+- Jellyfin/Emby & Plex notifications
 - TRaSH Guides-compatible naming
 
 ---
 
 ## Requirements
 
-- **TMDB API Key** — Free at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api)
-- **Download Client** (optional) — qBittorrent, SABnzbd, NZBGet, Real-Debrid, or TorBox
-  - Or use streaming mode — no download client needed
-  - Real-Debrid and TorBox accept torrent releases, materialize ready files directly into the resolved library destination, and can optionally remove provider items after a durable import.
+- **TMDB API Key** - Free at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api)
+- **Download Client** (optional) - qBittorrent, SABnzbd, NZBGet, Debrid
+  - Or use streaming mode - no download client needed (USENET Only)
 
 ## Quick Start
 
@@ -132,7 +131,7 @@ curl -O https://raw.githubusercontent.com/MoldyTaint/Cinephage/main/.env.example
 cp .env.example .env
 ```
 
-2. Edit `.env` — at minimum set `BETTER_AUTH_SECRET` (generate one with `openssl rand -base64 32`).
+2. Edit `.env` - at minimum set `BETTER_AUTH_SECRET` (generate one with `openssl rand -base64 32`).
 
 3. Update the volume mounts in `docker-compose.yaml` to point to your media and download directories.
 
@@ -162,7 +161,7 @@ npm run build
 cp .env.example .env
 ```
 
-Edit `.env` — set at minimum:
+Edit `.env` - set at minimum:
 
 ```
 BETTER_AUTH_SECRET=<your-secret>
@@ -230,9 +229,9 @@ Comprehensive documentation is available at **[docs.cinephage.net](https://docs.
 
 ## Community
 
-- **[Discord](https://discord.gg/scGCBTSWEt)** — Chat and support
-- **[GitHub Issues](https://github.com/MoldyTaint/cinephage/issues)** — Bug reports and feature requests
-- **[Contributing](CONTRIBUTING.md)** — Development guidelines
+- **[Discord](https://discord.gg/scGCBTSWEt)** - Chat and support
+- **[GitHub Issues](https://github.com/MoldyTaint/cinephage/issues)** - Bug reports and feature requests
+- **[Contributing](CONTRIBUTING.md)** - Development guidelines
 
 ---
 

--- a/data/indexers/definitions/kinozal-magnet.yaml
+++ b/data/indexers/definitions/kinozal-magnet.yaml
@@ -47,9 +47,13 @@ caps:
     - { id: '16', cat: Movies, desc: 'Movies - Erotica' }
     # Cartoons
     - { id: '1003', cat: TV, desc: 'All Cartoons' }
+    - { id: '1003', cat: Movies, desc: 'All Cartoons' }
     - { id: '21', cat: TV, desc: 'Cartoons' }
+    - { id: '21', cat: Movies, desc: 'Cartoons' }
     - { id: '22', cat: TV, desc: 'Cartoons - Russian' }
+    - { id: '22', cat: Movies, desc: 'Cartoons - Russian' }
     - { id: '20', cat: TV/Anime, desc: 'Cartoons - Anime' }
+    - { id: '20', cat: Movies/Other, desc: 'Cartoons - Anime' }
     # Music
     - { id: '1004', cat: Audio, desc: 'All Music' }
     - { id: '3', cat: Audio, desc: 'Music' }

--- a/data/indexers/definitions/noname-club.yaml
+++ b/data/indexers/definitions/noname-club.yaml
@@ -1,0 +1,997 @@
+---
+id: noname-club
+replaces:
+  - nnm-club
+name: NoNaMe Club
+description: 'NoNaMe Club (NNM-Club) is a RUSSIAN Public Tracker for MOVIES / TV / MUSIC'
+language: ru-RU
+type: public
+encoding: windows-1251
+links:
+  - https://nnmclub.to/
+legacylinks:
+  - https://nnm-club.name/
+  - https://nnm-club.me/
+  - http://nnmclub.to/
+
+caps:
+  categorymappings:
+    # forum
+    - { id: 48, cat: Other, desc: 'Форум Региональные встречи' }
+    # forum tracker
+    - { id: 925, cat: Other, desc: 'Форум-Трекер: Клубные таланты Авторские релизы' }
+    - { id: 872, cat: Other, desc: 'Форум-Трекер: Клубные таланты Архив' }
+    # Everything for children and parents
+    - { id: 724, cat: TV, desc: 'Видео, Кино и Сериалы для детей и родителей' }
+    - { id: 725, cat: TV, desc: ' |- Обучающее Видео для родителей' }
+    - { id: 729, cat: TV, desc: ' |- Развивающее Видео для детей' }
+    - { id: 731, cat: TV, desc: ' |- Отечественные Фильмы и Сериалы для детей (SD)' }
+    - { id: 1345, cat: TV, desc: ' |- Отечественные Фильмы и Сериалы для детей (HD, FHD, UHD)' }
+    - { id: 733, cat: TV, desc: ' |- Зарубежные Фильмы и Сериалы для детей (SD)' }
+    - { id: 1346, cat: TV, desc: ' |- Зарубежные Фильмы и Сериалы для детей (HD, FHD, UHD)' }
+    # Feature-length cartoon sections are movies, not TV episodes.
+    - { id: 1329, cat: Movies, desc: ' |- Отечественные Мультфильмы 20-го века (SD)' }
+    - { id: 1330, cat: Movies, desc: ' |- Отечественные Мультфильмы 20-го века (HD, FHD, UHD)' }
+    - { id: 1331, cat: Movies, desc: ' |- Отечественные Мультфильмы 21-го века (SD)' }
+    - { id: 1332, cat: Movies, desc: ' |- Отечественные Мультфильмы 21-го века (HD, FHD, UHD, 3D)' }
+    - {
+        id: 1340,
+        cat: Movies,
+        desc: ' |- Отечественные Мультфильмы (коллекции, сборники / *логии)'
+      }
+    - { id: 658, cat: TV, desc: ' |- Отечественные Мультсериалы' }
+    - { id: 890, cat: Movies, desc: ' |- Мультфильмы (3D)' }
+    - { id: 1336, cat: Movies, desc: ' |- Зарубежные Мультфильмы 20-го века (SD)' }
+    - { id: 1337, cat: Movies, desc: ' |- Зарубежные Мультфильмы 20-го века (HD, FHD, UHD)' }
+    - { id: 1338, cat: Movies, desc: ' |- Зарубежные Мультфильмы 21-го века (SD)' }
+    - { id: 1339, cat: Movies, desc: ' |- Зарубежные Мультфильмы 21-го века (HD, FHD, UHD)' }
+    - { id: 660, cat: Movies, desc: ' |- Зарубежные Мультфильмы (коллекции, сборники / *логии)' }
+    - { id: 232, cat: Other, desc: ' |- Зарубежные Мультсериалы' }
+    - { id: 734, cat: Other, desc: ' |- Классика для мам и малышей' }
+    - { id: 742, cat: Other, desc: ' |- Музыка и песни для детей' }
+    - { id: 735, cat: Other, desc: ' |- Аудиокниги для детей и родителей' }
+    - { id: 738, cat: Other, desc: ' |- Образование, обучение и развитие детей' }
+    - { id: 967, cat: Other, desc: ' |- Логопедия, Психология, Педиатрия' }
+    - { id: 907, cat: Other, desc: ' |- Журналы для детей и родителей' }
+    - { id: 739, cat: Other, desc: ' |- Детская литература' }
+    - { id: 1109, cat: Other, desc: ' |- Энциклопедии и Познавательная литература для детей' }
+    - { id: 736, cat: Other, desc: ' |- Мультимедийные материалы для родителей' }
+    - { id: 737, cat: Other, desc: ' |- Мультимедийные материалы для детей' }
+    - { id: 898, cat: Other, desc: ' |- Рабочие тетради, прописи и разукрашки' }
+    - { id: 935, cat: Other, desc: ' |- Настольные игры и Поделки' }
+    - { id: 871, cat: Other, desc: ' |- Подвижные Игры' }
+    - { id: 973, cat: Other, desc: ' |- Изобразительное искусство' }
+    - { id: 960, cat: Other, desc: ' |- Прочие материалы для детей и родителей' }
+    - { id: 1239, cat: Other, desc: ' |- ГИА, ОГЭ, ЕГЭ, ЕМЭ, ГВЭ' }
+    - { id: 740, cat: Other, desc: ' |- Развивающие Игры для детей' }
+    - { id: 741, cat: Other, desc: ' |- Детские Игры' }
+    # programs
+    - { id: 503, cat: Other, desc: 'ОС Windows' }
+    - { id: 504, cat: Other, desc: ' |- Оригинальные версии Windows' }
+    - { id: 506, cat: Other, desc: ' |- Оригинальные версии Windows Server' }
+    - { id: 763, cat: Other, desc: ' |- Windows OEM Recovery СD/DVD' }
+    - { id: 1335, cat: Other, desc: ' |- Сборки Windows 11' }
+    - { id: 1241, cat: Other, desc: ' |- Сборки Windows 10' }
+    - { id: 1023, cat: Other, desc: ' |- Сборки Windows 8' }
+    - { id: 717, cat: Other, desc: ' |- Сборки Windows 7' }
+    - { id: 509, cat: Other, desc: ' |- Сборки Windows Vista' }
+    - { id: 508, cat: Other, desc: ' |- Сборки Windows ХР' }
+    - { id: 510, cat: Other, desc: ' |- Сборки Windows - всё в одном' }
+    - { id: 1254, cat: Other, desc: ' |- Сборки Windows для незрячих' }
+    - { id: 1042, cat: Other, desc: ' |- Песочница ПО и сборок Windows' }
+    - { id: 511, cat: Other, desc: ' |- Разное (RC, Beta и Service Packs)' }
+    - { id: 916, cat: Other, desc: ' |- Музей Windows' }
+    - { id: 512, cat: Other, desc: 'Утилиты, Офис, Интернет' }
+    - { id: 561, cat: Other, desc: ' |- ПО для Интернета и сетей' }
+    - { id: 1284, cat: Other, desc: ' |- Оригинальные версии Office' }
+    - { id: 562, cat: Other, desc: ' |- Офисное ПО' }
+    - { id: 513, cat: Other, desc: ' |- Запись, создание, редактирование, эмуляция дисков и...' }
+    - { id: 514, cat: Other, desc: ' |- Диагностика и обслуживание hardware' }
+    - { id: 515, cat: Other, desc: ' |- Резервирование и восстановление данных' }
+    - { id: 516, cat: Other, desc: ' |- Файловые менеджеры и архиваторы' }
+    - { id: 517, cat: Other, desc: ' |- Обслуживание ОС' }
+    - { id: 518, cat: Other, desc: ' |- Разное (Утилиты, Офис, Интернет)' }
+    - { id: 519, cat: Other, desc: 'Безопасность' }
+    - { id: 520, cat: Other, desc: ' |- Firewalls' }
+    - { id: 521, cat: Other, desc: ' |- Антивирусы' }
+    - { id: 522, cat: Other, desc: ' |- Комплексные системы защиты' }
+    - { id: 523, cat: Other, desc: ' |- Разное (остальные программы по безопасности)' }
+    - { id: 524, cat: Other, desc: 'Мультимедиа и Графика' }
+    - { id: 532, cat: Other, desc: ' |- Аудио Плееры и Кодеки' }
+    - { id: 533, cat: Other, desc: ' |- Аудио Граббинг, Мастеринг, Обработка' }
+    - { id: 535, cat: Other, desc: ' |- Прочее ПО для Аудио' }
+    - { id: 530, cat: Other, desc: ' |- Видео Плееры и Кодеки' }
+    - { id: 529, cat: Other, desc: ' |- Нелинейный Видеомонтаж, Авторинг, Кодировщики' }
+    - { id: 525, cat: Other, desc: ' |- Просмотрщики Графики (вьюверы)' }
+    - { id: 526, cat: Other, desc: ' |- Графические редакторы' }
+    - { id: 527, cat: Other, desc: ' |- ПО для моделирования' }
+    - { id: 545, cat: Other, desc: 'Софт и оболочки для специалистов, Прочее' }
+    - { id: 764, cat: Other, desc: ' |- LiveCD/DVD/Flash' }
+    - { id: 765, cat: Other, desc: ' |- WPI' }
+    - { id: 820, cat: Other, desc: ' |- Серверное ПО' }
+    - { id: 552, cat: Other, desc: ' |- Разработка ПО' }
+    - { id: 553, cat: Other, desc: ' |- САПР/ГИС' }
+    - { id: 554, cat: Other, desc: ' |- Остальное ПО для специалистов' }
+    - { id: 550, cat: Other, desc: ' |- Системы навигации и карты' }
+    - { id: 549, cat: Other, desc: ' |- Драйверы' }
+    - { id: 548, cat: Other, desc: ' |- Разное (прочее ПО)' }
+    # Movies
+    - { id: 216, cat: Movies, desc: 'Горячие новинки' }
+    - { id: 270, cat: Movies, desc: ' |- Отечественные Новинки (SD, DVD)' }
+    - { id: 218, cat: Movies, desc: ' |- Зарубежные Новинки (SD, DVD)' }
+    - { id: 219, cat: Movies, desc: ' |- Отечественные Новинки (HD, FHD, UHD, 3D)' }
+    - { id: 954, cat: Movies, desc: ' |- Зарубежные Новинки (HD, FHD, UHD, 3D)' }
+    - { id: 217, cat: Movies, desc: ' |- Экранки' }
+    - { id: 1293, cat: Movies, desc: ' |- Новинки с Рекламой' }
+    - { id: 1298, cat: Movies, desc: ' |- Экранки с рекламой' }
+    - { id: 318, cat: Movies, desc: 'Классика кино и Старые фильмы до 90-х' }
+    - { id: 320, cat: Movies, desc: ' |- Отечественная Классика (SD)' }
+    - { id: 677, cat: Movies, desc: ' |- Отечественная Классика (DVD)' }
+    - { id: 1177, cat: Movies, desc: ' |- Отечественная Классика (HD, FHD, UHD)' }
+    - { id: 319, cat: Movies, desc: ' |- Зарубежная Классика (SD)' }
+    - { id: 678, cat: Movies, desc: ' |- Зарубежная Классика (DVD)' }
+    - { id: 885, cat: Movies, desc: ' |- Зарубежная Классика (HD, FHD, UHD, 3D)' }
+    - { id: 908, cat: Movies, desc: ' |- Старые Отечественные Фильмы (SD)' }
+    - { id: 1310, cat: Movies, desc: ' |- Старые Отечественные Фильмы (DVD)' }
+    - { id: 909, cat: Movies, desc: ' |- Старые Отечественные Фильмы (HD, FHD, UHD)' }
+    - { id: 910, cat: Movies, desc: ' |- Старые Зарубежные Фильмы (SD)' }
+    - { id: 911, cat: Movies, desc: ' |- Старые Зарубежные Фильмы (DVD)' }
+    - { id: 912, cat: Movies, desc: ' |- Старые Зарубежные Фильмы (HD, FHD, UHD, 3D)' }
+    - { id: 220, cat: Movies, desc: 'Отечественное кино' }
+    - { id: 221, cat: Movies, desc: ' |- Отечественные Фильмы (SD)' }
+    - { id: 222, cat: Movies, desc: ' |- Отечественные Фильмы (DVD)' }
+    - { id: 882, cat: Movies, desc: ' |- Отечественные Фильмы (HD, FHD, UHD)' }
+    - { id: 889, cat: Movies, desc: ' |- Отечественные Фильмы (3D)' }
+    - { id: 224, cat: Movies, desc: 'Зарубежное кино' }
+    - { id: 225, cat: Movies, desc: ' |- Зарубежные Фильмы (SD)' }
+    - { id: 226, cat: Movies, desc: ' |- Зарубежные Фильмы (DVD)' }
+    - { id: 227, cat: Movies, desc: ' |- Зарубежные Фильмы (HD, FHD)' }
+    - { id: 1296, cat: Movies, desc: ' |- Зарубежные Фильмы (UHD)' }
+    - { id: 891, cat: Movies, desc: ' |- Зарубежные Фильмы (3D)' }
+    - { id: 1299, cat: Movies, desc: ' |- Фильмы ближнего зарубежья' }
+    - { id: 682, cat: Movies, desc: ' |- Азиатское кино (SD)' }
+    - { id: 694, cat: Movies, desc: ' |- Азиатское кино (DVD)' }
+    - { id: 884, cat: Movies, desc: ' |- Азиатское кино (HD, FHD, UHD)' }
+    - { id: 1211, cat: Movies, desc: ' |- Азиатское кино (3D)' }
+    - { id: 693, cat: Movies, desc: ' |- Индийское кино' }
+    - { id: 913, cat: Movies, desc: ' |- Фильмы с переводом на др. языках' }
+    - { id: 228, cat: Movies, desc: ' |- Фильмы в оригинале (SD, DVD)' }
+    - { id: 1150, cat: Movies, desc: ' |- Фильмы в оригинале (HD, FHD, UHD)' }
+    - { id: 1311, cat: Movies, desc: 'Коллекции / *логии' }
+    - { id: 1313, cat: Movies, desc: ' |- Зарубежное кино (коллекции / *логии)' }
+    - { id: 1312, cat: Movies, desc: ' |- Отечественное кино (коллекции / *логии)' }
+    - { id: 256, cat: Movies, desc: 'Театр и Музыкальное видео' }
+    - { id: 257, cat: Movies, desc: ' |- Музыкальные клипы' }
+    - { id: 258, cat: Movies, desc: ' |- Концерты (SD)' }
+    - { id: 883, cat: Movies, desc: ' |- Концерты (DVD)' }
+    - { id: 955, cat: Movies, desc: ' |- Концерты (HD, FHD, UHD, 3D)' }
+    - { id: 905, cat: Movies, desc: ' |- Театр' }
+    - { id: 271, cat: Movies, desc: ' |- Опера, Балет, Мюзиклы' }
+    - { id: 1210, cat: Movies, desc: ' |- Караоке' }
+    - { id: 264, cat: Movies, desc: 'Остальное' }
+    - { id: 265, cat: Movies, desc: ' |- Звуковые дорожки и субтитры' }
+    - { id: 272, cat: Movies, desc: ' |- Игровое видео' }
+    - { id: 1262, cat: Movies, desc: ' |- hand made * video' }
+    - { id: 266, cat: Movies, desc: ' |- Трейлеры' }
+    - { id: 1294, cat: Movies, desc: ' |- Фильмы с Рекламой' }
+    # TV
+    - { id: 1219, cat: TV, desc: 'Классика сериалов и многосерийное кино до 90-х' }
+    - { id: 1221, cat: TV, desc: ' |- Отечественная классика сериалов и старое многосерийное...' }
+    - { id: 1220, cat: TV, desc: ' |- Зарубежная классика сериалов и старое многосерийное кино...' }
+    - { id: 722, cat: TV, desc: ' |- Чертова служба в госпитале МЭШ / M*A*S*H' }
+    - { id: 768, cat: TV, desc: 'Зарубежные сериалы' }
+    - { id: 1344, cat: Other, desc: ' |- Звездные войны / Star Wars (сериалы по франшизе)' }
+    - { id: 779, cat: TV, desc: " |- Анатомия страсти / Grey's Anatomy" }
+    - {
+        id: 1288,
+        cat: TV,
+        desc: ' |- Во все тяжкие / Breaking Bad; Лучше звоните Солу / Better...'
+      }
+    - { id: 787, cat: TV, desc: ' |- Грань / Fringe' }
+    - { id: 1141, cat: TV, desc: ' |- Дневники вампира / Vampire Diaries; Настоящая кровь /...' }
+    - { id: 777, cat: TV, desc: ' |- Доктор кто / Doctor Who; Торчвуд / Torchwood' }
+    - { id: 786, cat: TV, desc: ' |- Доктор Хаус / House M.D.' }
+    - { id: 776, cat: TV, desc: ' |- Звездные врата / Stargate' }
+    - { id: 785, cat: TV, desc: ' |- Звездный Крейсер Галактика / BattleStar Galactica;...' }
+    - { id: 775, cat: TV, desc: ' |- Звездный путь / Star Trek; Орвилл / The Orville' }
+    - { id: 1265, cat: TV, desc: ' |- Игра престолов / Game of Thrones' }
+    - { id: 1242, cat: TV, desc: ' |- Касл / Castle' }
+    - { id: 1140, cat: TV, desc: ' |- Кости / Bones' }
+    - { id: 782, cat: TV, desc: ' |- Менталист / The Mentalist; Теория Лжи / Lie To Me' }
+    - { id: 773, cat: TV, desc: ' |- Место преступления / CSI' }
+    - { id: 1142, cat: TV, desc: ' |- Морская полиция / Navy NCIS; Военно-юридическая служба /...' }
+    - { id: 772, cat: TV, desc: ' |- Побег / Prison Break' }
+    - { id: 771, cat: TV, desc: ' |- Пуаро / Poirot' }
+    - { id: 783, cat: TV, desc: ' |- Сверхъестественное / Supernatural' }
+    - { id: 1144, cat: TV, desc: ' |- Секретные материалы / X-Files' }
+    - { id: 804, cat: TV, desc: ' |- Теория Большого Взрыва / The Big Bang Theory; Детство...' }
+    - { id: 1290, cat: TV, desc: ' |- Ходячие мертвецы / The Walking Dead; Бойтесь ходячих...' }
+    - { id: 1300, cat: TV, desc: ' |- Сериалы ближнего зарубежья' }
+    - { id: 784, cat: TV, desc: ' |- Сериалы DC Comics' }
+    - { id: 774, cat: TV, desc: ' |- Сериалы Marvel Comics' }
+    - { id: 922, cat: TV, desc: ' |- Азиатские сериалы' }
+    - { id: 770, cat: TV, desc: ' |- Латиноамериканские сериалы' }
+    - { id: 1320, cat: TV, desc: ' |- Турецкие сериалы' }
+    - { id: 780, cat: TV, desc: ' |- Сериалы без русского перевода (украинская озвучка)' }
+    - { id: 781, cat: TV, desc: ' |- Сериалы без перевода' }
+    - { id: 1322, cat: TV, desc: ' |- Сериалы с рекламой' }
+    - { id: 769, cat: TV, desc: 'Отечественные сериалы' }
+    - { id: 799, cat: TV, desc: ' |- Бандитский Петербург' }
+    - { id: 800, cat: TV, desc: ' |- Глухарь' }
+    - { id: 791, cat: TV, desc: ' |- Интерны' }
+    - { id: 793, cat: TV, desc: ' |- Ментовские войны' }
+    - { id: 794, cat: TV, desc: ' |- Менты' }
+    - { id: 796, cat: TV, desc: ' |- Солдаты' }
+    - { id: 795, cat: TV, desc: ' |- Универ' }
+    # Documentary, Telecasts, Sports, Comedy
+    - { id: 713, cat: TV, desc: 'Зарубежные TV-бренды' }
+    - { id: 706, cat: TV, desc: ' |- Animal Planet' }
+    - { id: 577, cat: TV, desc: ' |- BBC' }
+    - { id: 894, cat: TV, desc: ' |- Da Vinci Learning' }
+    - { id: 578, cat: TV, desc: ' |- Discovery' }
+    - { id: 580, cat: TV, desc: ' |- History Channel' }
+    - { id: 579, cat: TV, desc: ' |- National Geographic' }
+    - { id: 953, cat: TV, desc: ' |- PBS' }
+    - { id: 581, cat: TV, desc: ' |- Readers Digest' }
+    - { id: 806, cat: TV, desc: ' |- Интересно обо всем' }
+    - { id: 714, cat: TV, desc: ' |- Мега-Проекты' }
+    - { id: 761, cat: TV, desc: ' |- Доисторический мир' }
+    - { id: 809, cat: TV, desc: ' |- Мир будущего' }
+    - { id: 924, cat: TV, desc: ' |- Одиссея Жака Кусто' }
+    - { id: 812, cat: TV, desc: ' |- Тайны и Загадки' }
+    - { id: 576, cat: TV, desc: 'Документалистика и Телепередачи' }
+    - { id: 590, cat: TV, desc: ' |- Кинолетопись Страны Советской' }
+    - { id: 591, cat: TV, desc: ' |- Вторая Мировая война' }
+    - { id: 588, cat: TV, desc: ' |- Отечественная история' }
+    - { id: 589, cat: TV, desc: ' |- История' }
+    - { id: 598, cat: TV, desc: ' |- Личности в истории' }
+    - { id: 652, cat: TV, desc: ' |- Посвящение искусству' }
+    - { id: 599, cat: TV, desc: ' |- Телешоу' }
+    - { id: 959, cat: TV, desc: ' |- Музыкальные шоу' }
+    - { id: 956, cat: TV, desc: ' |- Интеллектуальные шоу' }
+    - { id: 597, cat: TV, desc: ' |- Непознанное и сверхъестественное' }
+    - { id: 593, cat: TV, desc: ' |- Живая природа' }
+    - { id: 594, cat: TV, desc: ' |- Клуб кинопутешествий' }
+    - { id: 819, cat: TV, desc: ' |- За рулем' }
+    - { id: 595, cat: TV, desc: ' |- Релакс / Relax' }
+    - { id: 587, cat: TV, desc: ' |- Военное дело' }
+    - { id: 584, cat: TV, desc: ' |- Авиация' }
+    - { id: 586, cat: TV, desc: ' |- Космос' }
+    - { id: 585, cat: TV, desc: ' |- Флот' }
+    - { id: 600, cat: TV, desc: ' |- Тележурналистика' }
+    - { id: 596, cat: TV, desc: ' |- Политика и пропаганда, публицистика и экономика' }
+    - { id: 1295, cat: TV, desc: ' |- Общественно-политические и пропагандистские ток-шоу' }
+    - { id: 614, cat: TV, desc: ' |- Религии и культы (Док/TV)' }
+    - { id: 603, cat: TV, desc: 'Спорт и активный отдых' }
+    - { id: 1308, cat: TV, desc: ' |- Хоккей. Чемпионат мира' }
+    - { id: 1309, cat: TV, desc: ' |- Футбол. Чемпионат Европы' }
+    - { id: 1206, cat: TV, desc: ' |- Футбол. Чемпионат Мира' }
+    - { id: 1194, cat: TV, desc: ' |- Летние Олимпийские игры и Паралимпийские игры' }
+    - { id: 1062, cat: TV, desc: ' |- Зимние Олимпийские игры и Паралимпийские игры' }
+    - { id: 974, cat: TV, desc: ' |- Футбол' }
+    - { id: 609, cat: TV, desc: ' |- Баскетбол, Волейбол, Гандбол' }
+    - { id: 1263, cat: TV, desc: ' |- Хоккей' }
+    - { id: 951, cat: TV, desc: ' |- Прочие зимние виды спорта' }
+    - { id: 975, cat: TV, desc: ' |- Бокс' }
+    - { id: 608, cat: TV, desc: ' |- Единоборства, Бои без правил' }
+    - { id: 607, cat: TV, desc: ' |- Гимнастика, Бодибилдинг, Красота тела' }
+    - { id: 606, cat: TV, desc: ' |- Авто, Мото' }
+    - { id: 750, cat: TV, desc: ' |- Формула 1' }
+    - { id: 605, cat: TV, desc: ' |- Экстрим' }
+    - { id: 604, cat: TV, desc: ' |- Рыбалка и Охота' }
+    - { id: 950, cat: TV, desc: ' |- Бильярд' }
+    - { id: 610, cat: TV, desc: 'Юмор (ТВ)' }
+    - { id: 613, cat: TV, desc: ' |- КВН' }
+    - { id: 612, cat: TV, desc: ' |- ПостКВН' }
+    - { id: 653, cat: TV, desc: ' |- Украинские шоу' }
+    - { id: 654, cat: TV, desc: ' |- Маски-шоу' }
+    - { id: 611, cat: TV, desc: ' |- Сатирики' }
+    - { id: 656, cat: TV, desc: ' |- Приколы' }
+    # anime
+    - { id: 615, cat: TV/Anime, desc: 'Манга и Арт' }
+    - { id: 616, cat: TV/Anime, desc: ' |- Манга, Манхва, Маньхуа' }
+    - { id: 617, cat: TV/Anime, desc: ' |- Ранобэ' }
+    - { id: 648, cat: TV/Anime, desc: ' |- Визуальные новеллы' }
+    - { id: 619, cat: TV/Anime, desc: ' |- Аниме арт' }
+    - { id: 620, cat: TV/Anime, desc: 'Аниме с субтитрами' }
+    - { id: 623, cat: TV/Anime, desc: ' |- Онгоинги' }
+    - { id: 622, cat: TV/Anime, desc: ' |- Аниме (SD)' }
+    - { id: 621, cat: TV/Anime, desc: ' |- Аниме (HD)' }
+    - { id: 632, cat: TV/Anime, desc: ' |- Аниме (FullHD)' }
+    - { id: 624, cat: TV/Anime, desc: 'Аниме с озвучкой' }
+    - { id: 627, cat: TV/Anime, desc: ' |- Онгоинги с озвучкой' }
+    - { id: 626, cat: TV/Anime, desc: ' |- Аниме с озвучкой (SD)' }
+    - { id: 625, cat: TV/Anime, desc: ' |- Аниме с озвучкой (HD)' }
+    - { id: 644, cat: TV/Anime, desc: ' |- Аниме с озвучкой (FullHD)' }
+    - { id: 628, cat: TV/Anime, desc: 'Аниме разное' }
+    - { id: 635, cat: TV/Anime, desc: ' |- Аниме DVD' }
+    - { id: 634, cat: TV/Anime, desc: ' |- Аниме Blu-ray, Remux' }
+    - { id: 638, cat: TV/Anime, desc: ' |- Аниме хардсаб' }
+    - { id: 646, cat: TV/Anime, desc: ' |- Аниме прочее' }
+    - { id: 645, cat: TV/Anime, desc: 'Аниме музыка' }
+    - { id: 639, cat: TV/Anime, desc: ' |- Аниме OST (Lossless)' }
+    - { id: 640, cat: TV/Anime, desc: ' |- Аниме OST' }
+    # Books and Training Materials
+    - { id: 432, cat: Books, desc: 'Научная и техническая литература' }
+    - { id: 755, cat: Books, desc: ' |- Учебники' }
+    - { id: 481, cat: Books, desc: ' |- Иностранные языки (литература)' }
+    - { id: 557, cat: Books, desc: ' |- Гуманитарные науки и искусство' }
+    - { id: 442, cat: Books, desc: ' |- Точные и естественные науки' }
+    - { id: 441, cat: Books, desc: ' |- Техническая литература' }
+    - { id: 875, cat: Books, desc: ' |- Военно-историческая литература' }
+    - { id: 1176, cat: Books, desc: ' |- Историческая литература' }
+    - { id: 444, cat: Books, desc: ' |- Научно-популярная литература' }
+    - { id: 443, cat: Books, desc: ' |- Здоровье и медицина' }
+    - { id: 440, cat: Books, desc: ' |- Нормативная документация' }
+    - { id: 1199, cat: Books, desc: ' |- Энциклопедии и словари' }
+    - { id: 433, cat: Books, desc: 'Компьютерная литература' }
+    - { id: 447, cat: Books, desc: ' |- Программирование' }
+    - { id: 445, cat: Books, desc: ' |- Веб-дизайн' }
+    - { id: 817, cat: Books, desc: ' |- 2D графика' }
+    - { id: 818, cat: Books, desc: ' |- 3D графика' }
+    - { id: 434, cat: Books, desc: 'Художественная литература' }
+    - { id: 1349, cat: Books, desc: ' |- Библиотеки' }
+    - { id: 957, cat: Books, desc: ' |- Многоавторские сборники и Библиотеки' }
+    - { id: 931, cat: Books, desc: ' |- Собрания книг русскоязычных авторов' }
+    - { id: 1152, cat: Books, desc: ' |- Собрания книг иностранных авторов' }
+    - { id: 455, cat: Books, desc: ' |- Сатира, Юмор' }
+    - { id: 453, cat: Books, desc: ' |- Боевики, Детективы, Триллеры' }
+    - { id: 1063, cat: Books, desc: ' |- Приключенческая проза ' }
+    - { id: 452, cat: Books, desc: ' |- Историческая проза, Мифы и Легенды' }
+    - { id: 451, cat: Books, desc: ' |- Фантастика, Фэнтези' }
+    - { id: 449, cat: Books, desc: ' |- Современная поэзия и проза' }
+    - { id: 1153, cat: Books, desc: ' |- Классическая поэзия и проза' }
+    - { id: 1347, cat: Books, desc: 'Книги вне издательств, самиздат (все жанры)' }
+    - { id: 482, cat: Books, desc: 'Комиксы и Артбуки' }
+    - { id: 483, cat: Books, desc: ' |- Комиксы на русском языке' }
+    - { id: 484, cat: Books, desc: ' |- Комиксы без перевода' }
+    - { id: 1343, cat: Books, desc: ' |- Артбуки' }
+    - { id: 438, cat: Books, desc: 'Художественные аудиокниги и публицистика' }
+    - { id: 485, cat: Books, desc: ' |- Сатира, Юмор (аудиокниги)' }
+    - { id: 473, cat: Books, desc: ' |- Детектив, Боевик (аудиокниги)' }
+    - { id: 472, cat: Books, desc: ' |- Исторические аудиокниги' }
+    - { id: 471, cat: Books, desc: ' |- Классика (аудиокниги)' }
+    - { id: 895, cat: Books, desc: ' |- Проза, Поэзия (аудиокниги)' }
+    - { id: 470, cat: Books, desc: ' |- Фантастика, Фэнтези (аудиокниги)' }
+    - { id: 896, cat: Books, desc: ' |- Публицистика (аудиокниги)' }
+    - { id: 480, cat: Books, desc: ' |- Другие аудиокниги' }
+    - { id: 436, cat: Audio/Audiobook, desc: 'Обучающие аудиоматериалы' }
+    - { id: 458, cat: Audio/Audiobook, desc: ' |- Бизнес и Менеджмент (аудиоматериалы)' }
+    - { id: 457, cat: Audio/Audiobook, desc: ' |- Иностранные языки (аудиоматериалы)' }
+    - { id: 1342, cat: Audio/Audiobook, desc: ' |- Здоровье и Медицина (аудиоматериалы)' }
+    - {
+        id: 459,
+        cat: Audio/Audiobook,
+        desc: ' |- Популярная психология и саморазвитие (аудиоматериалы)'
+      }
+    - { id: 460, cat: Audio/Audiobook, desc: ' |- Медитации (аудиоматериалы)' }
+    - { id: 461, cat: Audio/Audiobook, desc: ' |- Религия (аудиоматериалы)' }
+    - { id: 462, cat: Audio/Audiobook, desc: ' |- Прочие аудиоматериалы' }
+    - { id: 437, cat: Books, desc: 'Обучающие видеоматериалы' }
+    - { id: 466, cat: TV, desc: ' |- Бизнес и Менеджмент (видеокурсы)' }
+    - { id: 1319, cat: TV, desc: ' |- Иностранные языки (видеокурсы)' }
+    - { id: 463, cat: TV, desc: ' |- IT, Компьютерные видеокурсы' }
+    - { id: 958, cat: TV, desc: ' |- Дизайн, рисование (видеокурсы)' }
+    - { id: 1223, cat: TV, desc: ' |- Фотография и Видео (видеокурсы)' }
+    - { id: 467, cat: TV, desc: ' |- Здоровье и Спорт (видеокурсы)' }
+    - { id: 464, cat: TV, desc: ' |- Психология и саморазвитие (видеокурсы)' }
+    - { id: 465, cat: TV, desc: ' |- Музыка (видеокурсы)' }
+    - { id: 1348, cat: TV, desc: ' |- Домоводство, строительство и ремонт (видеокурсы)' }
+    - { id: 469, cat: TV, desc: ' |- Другие видеокурсы' }
+    - { id: 439, cat: Books, desc: 'Мультимедийные материалы' }
+    - { id: 477, cat: Books, desc: ' |- Образование' }
+    - { id: 476, cat: Books, desc: ' |- Иностранные языки' }
+    - { id: 475, cat: Books, desc: ' |- Компьютеры' }
+    - { id: 474, cat: Books, desc: ' |- Мультимедийные справочники, Энциклопедии' }
+    - { id: 886, cat: Books, desc: ' |- Приложения к журналам' }
+    - { id: 478, cat: Books, desc: ' |- Другие мультимедийные материалы' }
+    - { id: 486, cat: Books, desc: 'Журналы' }
+    - { id: 490, cat: Books, desc: ' |- Мужские журналы' }
+    - { id: 657, cat: Books, desc: ' |- Женские журналы' }
+    - { id: 489, cat: Books, desc: ' |- Игровые журналы' }
+    - { id: 488, cat: Books, desc: ' |- Компьютерные журналы' }
+    - { id: 487, cat: Books, desc: ' |- Научно-популярные журналы' }
+    - { id: 1198, cat: Books, desc: ' |- Журналы по электротехнике и радиоэлектронике' }
+    - { id: 1227, cat: Books, desc: ' |- Кулинарные журналы' }
+    - { id: 893, cat: Books, desc: ' |- Домоводство (журналы)' }
+    - { id: 491, cat: Books, desc: ' |- Хобби (журналы)' }
+    - { id: 767, cat: Books, desc: ' |- Другие журналы' }
+    - { id: 299, cat: Books, desc: 'Автомобили' }
+    - { id: 887, cat: Books, desc: ' |- Автомобильные журналы' }
+    - { id: 301, cat: Books, desc: ' |- Автомобильная литература' }
+    - { id: 1334, cat: Books, desc: ' |- Автомобильные обуч.видео' }
+    - { id: 300, cat: Books, desc: ' |- Автомобильные мультимедийные материалы' }
+    - { id: 1341, cat: Books, desc: ' |- Автомобильные программы и навигаторы' }
+    - { id: 492, cat: Books, desc: 'Разное (категория книг)' }
+    - { id: 558, cat: Books, desc: ' |- Бизнес, Менеджмент, Деловая литература' }
+    - { id: 1173, cat: Books, desc: ' |- Публицистика' }
+    - { id: 1174, cat: Books, desc: ' |- Популярная психология и саморазвитие' }
+    - { id: 1171, cat: Books, desc: ' |- Эзотерика' }
+    - { id: 662, cat: Books, desc: ' |- Религиозная литература' }
+    - { id: 1175, cat: Books, desc: ' |- Нетрадиционная медицина' }
+    - { id: 1172, cat: Books, desc: ' |- Строительство и ремонт' }
+    - { id: 933, cat: Books, desc: ' |- Сад, огород, животноводство' }
+    - { id: 815, cat: Books, desc: ' |- Кулинария' }
+    - { id: 1170, cat: Books, desc: ' |- Спорт, Фитнес, Боевые искусства' }
+    - { id: 398, cat: Books, desc: ' |- Ноты и обучение музыке' }
+    - { id: 816, cat: Books, desc: ' |- На досуге' }
+    # Music
+    - { id: 313, cat: Audio, desc: 'HD Audio и Многоканальная Музыка' }
+    - { id: 1291, cat: Audio, desc: ' |- Blu-ray Audio' }
+    - { id: 680, cat: Audio, desc: ' |- DVD-Audio' }
+    - { id: 1149, cat: Audio, desc: ' |- SACD-R' }
+    - { id: 429, cat: Audio, desc: ' |- DTS-Audio' }
+    - { id: 681, cat: Audio, desc: ' |- Vinyl-Rip и Hand-Made' }
+    - { id: 330, cat: Audio, desc: 'Классика' }
+    - { id: 1256, cat: Audio, desc: ' |- Классика (HD Audio)' }
+    - { id: 1285, cat: Audio/Lossless, desc: ' |- Полные собрания сочинений (Lossless)' }
+    - { id: 370, cat: Audio, desc: ' |- Полные собрания сочинений' }
+    - { id: 1260, cat: Audio/Lossless, desc: ' |- Вокал (Lossless)' }
+    - { id: 371, cat: Audio, desc: ' |- Вокал' }
+    - { id: 1261, cat: Audio/Lossless, desc: ' |- Концерты (Lossless)' }
+    - { id: 375, cat: Audio, desc: ' |- Концерты' }
+    - { id: 1259, cat: Audio/Lossless, desc: ' |- Оркестровая (Lossless)' }
+    - { id: 374, cat: Audio, desc: ' |- Оркестровая' }
+    - { id: 1257, cat: Audio/Lossless, desc: ' |- Камерная (Lossless)' }
+    - { id: 373, cat: Audio, desc: ' |- Камерная' }
+    - { id: 1258, cat: Audio/Lossless, desc: ' |- Фортепиано (Lossless)' }
+    - { id: 372, cat: Audio, desc: ' |- Фортепиано' }
+    - {
+        id: 1160,
+        cat: Audio/Lossless,
+        desc: ' |- В обработке/Classical Crossover/Neoclassical (Lossless)'
+      }
+    - { id: 876, cat: Audio, desc: ' |- В обработке/Classical Crossover/Neoclassical' }
+    - { id: 1255, cat: Audio/Lossless, desc: ' |- Классика (сборники) (Lossless)' }
+    - { id: 376, cat: Audio, desc: ' |- Классика (сборники)' }
+    - { id: 326, cat: Audio, desc: 'Jazz, Blues, Soul' }
+    - { id: 1352, cat: Audio, desc: ' |- Jazz (Hi-Res)' }
+    - { id: 359, cat: Audio/Lossless, desc: ' |- Jazz (Lossless)' }
+    - { id: 358, cat: Audio, desc: ' |- Jazz' }
+    - { id: 1353, cat: Audio, desc: ' |- Blues, Soul (Hi-Res)' }
+    - { id: 1188, cat: Audio/Lossless, desc: ' |- Blues, Soul (Lossless)' }
+    - { id: 1189, cat: Audio, desc: ' |- Blues, Soul' }
+    - { id: 328, cat: Audio, desc: 'Шансон, Авторская и Военная песня' }
+    - { id: 1370, cat: Audio, desc: ' |- Шансон, Авторская и Военная песня (Hi-Res)' }
+    - { id: 1180, cat: Audio/Lossless, desc: ' |- Зарубежный Шансон (Lossless)' }
+    - { id: 1181, cat: Audio, desc: ' |- Зарубежный Шансон' }
+    - { id: 364, cat: Audio/Lossless, desc: ' |- Русский Шансон (Lossless)' }
+    - { id: 363, cat: Audio, desc: ' |- Русский Шансон' }
+    - { id: 1179, cat: Audio/Lossless, desc: ' |- Авторская и Военная песня (Lossless)' }
+    - { id: 879, cat: Audio, desc: ' |- Авторская и Военная песня' }
+    - { id: 322, cat: Audio, desc: 'Rock, Alternative, Punk, Metal' }
+    - { id: 1350, cat: Audio, desc: ' |- Rock (Hi-Res)' }
+    - { id: 962, cat: Audio/Lossless, desc: ' |- Rock (Lossless)' }
+    - { id: 333, cat: Audio, desc: ' |- Rock' }
+    - { id: 1356, cat: Audio, desc: ' |- Alternative, Punk (Hi-Res)' }
+    - { id: 965, cat: Audio/Lossless, desc: ' |- Alternative, Punk (Lossless)' }
+    - { id: 336, cat: Audio, desc: ' |- Alternative, Punk' }
+    - { id: 1362, cat: Audio, desc: ' |- Hard Rock (Hi Res)' }
+    - { id: 337, cat: Audio/Lossless, desc: ' |- Hard Rock (Lossless)' }
+    - { id: 338, cat: Audio, desc: ' |- Hard Rock' }
+    - { id: 1351, cat: Audio, desc: ' |- Metal (Hi-Res)' }
+    - { id: 963, cat: Audio/Lossless, desc: ' |- Metal (Lossless)' }
+    - { id: 334, cat: Audio, desc: ' |- Metal' }
+    - { id: 1357, cat: Audio, desc: ' |- Русский Рок (Hi-Res)' }
+    - { id: 961, cat: Audio/Lossless, desc: ' |- Русский Рок (Lossless)' }
+    - { id: 332, cat: Audio, desc: ' |- Русский рок' }
+    - { id: 325, cat: Audio, desc: 'Pop' }
+    - { id: 1354, cat: Audio, desc: ' |- Pop (Hi-Res)' }
+    - { id: 1355, cat: Audio, desc: ' |- Eurodance, Disco (Hi-Res)' }
+    - { id: 1165, cat: Audio/Lossless, desc: ' |- Eurodance, Euro-House, Technopop (Lossless)' }
+    - { id: 1166, cat: Audio, desc: ' |- Eurodance, Euro-House, Technopop' }
+    - { id: 1168, cat: Audio, desc: ' |- Disco, Italo-Disco, Euro-Disco, Hi-NRG' }
+    - {
+        id: 1167,
+        cat: Audio/Lossless,
+        desc: ' |- Disco, Italo-Disco, Euro-Disco, Hi-NRG (Lossless)'
+      }
+    - { id: 1162, cat: Audio/Lossless, desc: ' |- Отечественная поп-музыка (Lossless)' }
+    - { id: 352, cat: Audio, desc: ' |- Отечественная поп-музыка' }
+    - { id: 1164, cat: Audio/Lossless, desc: ' |- Советская эстрада, Ретро (Lossless)' }
+    - { id: 1163, cat: Audio, desc: ' |- Советская эстрада, Ретро' }
+    - { id: 1161, cat: Audio/Lossless, desc: ' |- Зарубежная поп-музыка (Lossless)' }
+    - { id: 353, cat: Audio, desc: ' |- Зарубежная поп-музыка' }
+    - { id: 324, cat: Audio, desc: 'Electronic' }
+    - { id: 1327, cat: Audio/Lossless, desc: ' |- Psybient, Psychill, Psydub (Lossless)' }
+    - { id: 1328, cat: Audio, desc: ' |- Psybient, Psychill, Psydub' }
+    - { id: 1325, cat: Audio/Lossless, desc: ' |- Downtempo, Trip-Hop, Lounge (Lossless)' }
+    - { id: 1326, cat: Audio, desc: ' |- Downtempo, Trip-Hop, Lounge' }
+    - { id: 1365, cat: Audio, desc: ' |- Downtempo, Ambient (Hi-Res)' }
+    - { id: 1366, cat: Audio, desc: ' |- Experimental, Industrial (Hi-Res)' }
+    - {
+        id: 1323,
+        cat: Audio/Lossless,
+        desc: ' |- Ambient, Experimental, Modern Classical (Lossless)'
+      }
+    - { id: 1324, cat: Audio, desc: ' |- Ambient, Experimental, Modern Classical' }
+    - { id: 976, cat: Audio/Lossless, desc: ' |- Trance (Lossless)' }
+    - { id: 346, cat: Audio, desc: ' |- Trance' }
+    - { id: 1363, cat: Audio, desc: ' |- Trance, House, Techno (Hi-Res)' }
+    - { id: 977, cat: Audio/Lossless, desc: ' |- House, Techno, Electro, Minimal (Lossless)' }
+    - { id: 345, cat: Audio, desc: ' |- House' }
+    - { id: 349, cat: Audio, desc: ' |- Techno, Electro, Minimal' }
+    - { id: 1243, cat: Audio, desc: ' |- Label-Packs' }
+    - { id: 347, cat: Audio, desc: ' |- Easy listening' }
+    - { id: 979, cat: Audio/Lossless, desc: ' |- Industrial, EBM, Dark Electro (Lossless)' }
+    - { id: 673, cat: Audio, desc: ' |- Experimental Electronic' }
+    - { id: 671, cat: Audio, desc: ' |- Industrial, EBM, Dark Electro' }
+    - { id: 1224, cat: Audio/Lossless, desc: ' |- IDM (Lossless)' }
+    - { id: 1225, cat: Audio, desc: ' |- IDM' }
+    - { id: 1367, cat: Audio, desc: ' |- Synthpop, New Wave, Retro (Hi-Res)' }
+    - { id: 980, cat: Audio/Lossless, desc: ' |- Synthpop, New Wave (Lossless)' }
+    - { id: 672, cat: Audio, desc: ' |- Synthpop, New Wave' }
+    - {
+        id: 1316,
+        cat: Audio/Lossless,
+        desc: ' |- Dubstep, Future Garage, Bass Music, UK Garage (Lossless)'
+      }
+    - { id: 1317, cat: Audio, desc: ' |- Dubstep, Future Garage, Bass Music, UK Garage' }
+    - { id: 1364, cat: Audio, desc: " |- Drum'n'Bass, Breakbeat (Hi-Res)" }
+    - {
+        id: 981,
+        cat: Audio/Lossless,
+        desc: " |- Drum'n'Bass, Jungle, Breaks, Breakbeat (Lossless)"
+      }
+    - { id: 344, cat: Audio, desc: " |- Drum'n'Bass, Jungle, Breaks, Breakbeat" }
+    - { id: 1368, cat: Audio, desc: ' |- Hardcore, Extreme (Hi-Res)' }
+    - { id: 983, cat: Audio/Lossless, desc: ' |- Hardstyle, Jumpstyle, Hardcore (Lossless)' }
+    - { id: 984, cat: Audio, desc: ' |- Hardstyle, Jumpstyle, Hardcore' }
+    - { id: 982, cat: Audio/Lossless, desc: ' |- Psychedelic, psytrance, fullon (Lossless)' }
+    - { id: 348, cat: Audio, desc: ' |- Psychedelic, psytrance, fullon' }
+    - { id: 674, cat: Audio, desc: ' |- Radioshow, Live Mixes' }
+    - { id: 323, cat: Audio, desc: 'Rap, Hip-hop, RnB, Reggae' }
+    - { id: 1369, cat: Audio, desc: 'Rap, Hip-hop, RnB, Reggae (Hi-Res)' }
+    - { id: 1187, cat: Audio/Lossless, desc: ' |- Rap, Hip-hop зарубежный (Lossless)' }
+    - { id: 339, cat: Audio, desc: ' |- Rap, Hip-hop зарубежный' }
+    - { id: 1186, cat: Audio/Lossless, desc: ' |- Rap, Hip-hop отечественный (Lossless)' }
+    - { id: 340, cat: Audio, desc: ' |- Rap, Hip-hop отечественный' }
+    - { id: 1185, cat: Audio/Lossless, desc: ' |- RnB, Reggae (Lossless)' }
+    - { id: 341, cat: Audio, desc: ' |- RnB, Reggae' }
+    - { id: 329, cat: Audio, desc: 'East Asian Music' }
+    - { id: 1361, cat: Audio, desc: ' |- Asian Music (Hi-Res)' }
+    - { id: 369, cat: Audio/Lossless, desc: ' |- Asian Traditional, Ethnic (Lossless)' }
+    - { id: 368, cat: Audio, desc: ' |- Asian Traditional, Ethnic' }
+    - { id: 1218, cat: Audio/Lossless, desc: ' |- Asian Pop (Lossless)' }
+    - { id: 365, cat: Audio, desc: ' |- Asian Pop' }
+    - { id: 1217, cat: Audio/Lossless, desc: ' |- Asian Rock, Metal (Lossless)' }
+    - { id: 366, cat: Audio, desc: ' |- Asian Rock, Metal' }
+    - { id: 1215, cat: Audio/Lossless, desc: ' |- Doujin Music (Lossless)' }
+    - { id: 1216, cat: Audio, desc: ' |- Doujin Music' }
+    - { id: 1213, cat: Audio/Lossless, desc: ' |- Other Asian (Lossless)' }
+    - { id: 367, cat: Audio, desc: ' |- Other Asian' }
+    - { id: 331, cat: Audio, desc: 'Other Styles' }
+    - { id: 1358, cat: Audio, desc: ' |- Instrumental (Hi-Res)' }
+    - { id: 1157, cat: Audio/Lossless, desc: ' |- Instrumental (Lossless)' }
+    - { id: 711, cat: Audio, desc: ' |- Instrumental' }
+    - { id: 1159, cat: Audio/Lossless, desc: ' |- New Age/Meditative/Relax (Lossless)' }
+    - { id: 378, cat: Audio, desc: ' |- New Age/Meditative/Relax' }
+    - { id: 1359, cat: Audio, desc: ' |- Folk (Hi-Res)' }
+    - { id: 1158, cat: Audio/Lossless, desc: ' |- Folk (Lossless)' }
+    - { id: 379, cat: Audio, desc: ' |- Folk' }
+    - { id: 380, cat: Audio/Lossless, desc: ' |- Other (Lossless)' }
+    - { id: 1178, cat: Audio, desc: ' |- Other' }
+    - { id: 1360, cat: Audio, desc: ' |- OST (Hi-Res)' }
+    - { id: 361, cat: Audio/Lossless, desc: ' |- OST (Lossless)' }
+    - { id: 360, cat: Audio, desc: ' |- OST' }
+    - { id: 327, cat: Audio, desc: 'Неофициальные сборники' }
+    - { id: 1184, cat: Audio, desc: ' |- Jazz, Blues, Soul (сборники)' }
+    - { id: 824, cat: Audio, desc: ' |- Шансон, Авторская и Военная песня (сборники)' }
+    - { id: 1182, cat: Audio, desc: ' |- Rock, Alternative, Punk, Metal (сборники)' }
+    - { id: 354, cat: Audio, desc: ' |- Pop (сборники)' }
+    - { id: 877, cat: Audio, desc: ' |- Electronic (сборники)' }
+    - { id: 1183, cat: Audio, desc: ' |- Rap, Hip-hop, RnB, Reggae (сборники)' }
+    - { id: 1190, cat: Audio, desc: ' |- Instrumental/New Age/Meditative/Relax (сборники)' }
+    - { id: 917, cat: Audio, desc: ' |- Прочее (сборники)' }
+    # Other
+    - { id: 410, cat: Other, desc: 'Win Игры' }
+    - { id: 411, cat: Other, desc: ' |- Горячие новинки Игр' }
+    - { id: 412, cat: Other, desc: ' |- Action (FPS)' }
+    - { id: 1008, cat: Other, desc: ' |- Action (TPS)' }
+    - { id: 415, cat: Other, desc: ' |- Adventure/Quest' }
+    - { id: 746, cat: Other, desc: ' |- Arcade' }
+    - { id: 428, cat: Other, desc: ' |- Online (MMO)' }
+    - { id: 1009, cat: Other, desc: ' |- Online Action (MMO)' }
+    - { id: 413, cat: Other, desc: ' |- RPG' }
+    - { id: 414, cat: Other, desc: ' |- Strategy (RTS/TBS/Grand)' }
+    - { id: 1010, cat: Other, desc: ' |- Strategy Tactical (RTS/TBS)' }
+    - { id: 1012, cat: Other, desc: ' |- Strategy (Manage/Busin)' }
+    - { id: 1014, cat: Other, desc: ' |- Racing' }
+    - { id: 416, cat: Other, desc: ' |- Simulation (Flight/Space)' }
+    - { id: 1013, cat: Other, desc: ' |- Simulation (Sport)' }
+    - { id: 1015, cat: Other, desc: ' |- Simulation (Other)' }
+    - { id: 268, cat: Other, desc: ' |- Action/Arcade/Platformer (Casual)' }
+    - { id: 1016, cat: Other, desc: ' |- Adventure/Quest (Casual)' }
+    - { id: 1041, cat: Other, desc: ' |- Classic Arcade/Zuma/3match (Casual)' }
+    - { id: 1018, cat: Other, desc: ' |- Board/Puzzle/Logic (Casual)' }
+    - { id: 1017, cat: Other, desc: ' |- Strategy/Manager/Business (Casual)' }
+    - { id: 972, cat: Other, desc: ' |- AddOn/DLC/Mod для Игр' }
+    - { id: 971, cat: Other, desc: ' |- Demo/Beta версии Игр' }
+    - { id: 970, cat: Other, desc: ' |- Языковые пакеты для Игр' }
+    - { id: 969, cat: Other, desc: ' |- Patch/Tweak/Trainer/Other для Игр' }
+    - { id: 968, cat: Other, desc: ' |- NoCD/NoDVD/Crack для Игр' }
+    - { id: 1146, cat: Other, desc: ' |- Песочница Win Игр' }
+    - { id: 418, cat: Other, desc: 'Win Старые Игры' }
+    - { id: 1061, cat: Other, desc: ' |- Action (FPS)' }
+    - { id: 1060, cat: Other, desc: ' |- Action (TPS)' }
+    - { id: 1059, cat: Other, desc: ' |- Adventure/Quest' }
+    - { id: 1058, cat: Other, desc: ' |- Arcade' }
+    - { id: 1057, cat: Other, desc: ' |- RPG' }
+    - { id: 1056, cat: Other, desc: ' |- Strategy (RTS/TBS/Grand)' }
+    - { id: 1054, cat: Other, desc: ' |- Strategy Tactical (RTS/TBS/Wargame)' }
+    - { id: 1053, cat: Other, desc: ' |- Strategy (Manage/Busin)' }
+    - { id: 1052, cat: Other, desc: ' |- Racing' }
+    - { id: 1051, cat: Other, desc: ' |- Simulation (Flight/Space)' }
+    - { id: 1050, cat: Other, desc: ' |- Simulation (Sport)' }
+    - { id: 1049, cat: Other, desc: ' |- Simulation (Other)' }
+    - { id: 1048, cat: Other, desc: ' |- AddOn/DLC/Mod для Игр' }
+    - { id: 1047, cat: Other, desc: ' |- Demo/Beta версии Игр' }
+    - { id: 1046, cat: Other, desc: ' |- Языковые пакеты для Игр' }
+    - { id: 1045, cat: Other, desc: ' |- Patch/Tweak/Trainer/Other для Игр' }
+    - { id: 1044, cat: Other, desc: ' |- NoCD/NoDVD/Crack для Игр' }
+    - { id: 382, cat: Other, desc: 'Консольные Игры' }
+    - { id: 390, cat: Other, desc: ' |- Тех. раздел Консолей' }
+    - { id: 387, cat: Other, desc: ' |- Xbox 360' }
+    - { id: 388, cat: Other, desc: ' |- Wii, GameCube' }
+    - { id: 1264, cat: Other, desc: ' |- Wii U' }
+    - { id: 1318, cat: Other, desc: ' |- Switch' }
+    - { id: 385, cat: Other, desc: ' |- PS1' }
+    - { id: 386, cat: Other, desc: ' |- PS2' }
+    - { id: 848, cat: Other, desc: ' |- PS3' }
+    - { id: 1321, cat: Other, desc: ' |- PS4' }
+    - { id: 383, cat: Other, desc: ' |- PSP' }
+    - { id: 384, cat: Other, desc: ' |- Psx to PSP' }
+    - { id: 1292, cat: Other, desc: ' |- PS Vita' }
+    - { id: 389, cat: Other, desc: ' |- Ромы' }
+    - { id: 391, cat: Other, desc: ' |- Другие приставки' }
+    # pda and mobile
+    - { id: 1240, cat: Other, desc: ' |- Всё для детей и родителей для Android' }
+    - { id: 830, cat: Other, desc: ' |- ПО для Android' }
+    - { id: 833, cat: Other, desc: ' |- Игры для Android' }
+    - { id: 839, cat: Other, desc: ' |- Навигация для Android' }
+    - { id: 1233, cat: Other, desc: ' |- Прошивки для Android устройств' }
+    - { id: 1236, cat: Other, desc: ' |- Вспомогательное ПО для Android' }
+    - { id: 832, cat: Other, desc: ' |- ПО и Игры на Java' }
+    - { id: 829, cat: Other, desc: ' |- ПО и Игры для Symbian' }
+    - { id: 828, cat: Other, desc: ' |- ПО и Игры для Windows Mobile' }
+    - { id: 1231, cat: Other, desc: ' |- Навигация для др. мобильных устройств' }
+    - { id: 840, cat: Other, desc: ' |- Прошивки для др. мобильных устройств' }
+    - { id: 1232, cat: Other, desc: ' |- Вспомогательное ПО для др. мобильных устройств' }
+    - { id: 841, cat: Other, desc: ' |- Прочее для мобильных устройств' }
+    - { id: 1238, cat: Other, desc: ' |- Карты для навигационного ПО' }
+    - { id: 844, cat: Other, desc: ' |- Мобильное Аудио' }
+    - { id: 842, cat: Other, desc: ' |- Мобильное Видео' }
+    - { id: 843, cat: Other, desc: ' |- Темы и Изображения' }
+    # apple
+    - { id: 537, cat: Other, desc: ' |- macOS (Apple)' }
+    - { id: 538, cat: Other, desc: ' |- macOS (osx86project/hackintosh)' }
+    - { id: 1151, cat: Other, desc: ' |- Разное для macOS (Apple/hackintosh)' }
+    - { id: 1083, cat: Other, desc: ' |- Графика для macOS' }
+    - { id: 1029, cat: Other, desc: ' |- CAD, 3D, ПО для специалистов для macOS' }
+    - { id: 1082, cat: Other, desc: ' |- Офис, Интернет для macOS' }
+    - { id: 1028, cat: Other, desc: ' |- Аудио и видео редакторы для macOS' }
+    - { id: 1087, cat: Other, desc: ' |- Плееры, конвертеры, кодеки для macOS' }
+    - { id: 1030, cat: Other, desc: ' |- Утилиты для macOS' }
+    - { id: 1039, cat: Other, desc: ' |- Kinder Games для macOS' }
+    - { id: 1038, cat: Other, desc: ' |- Quests, Adventure, Arcade для macOS' }
+    - { id: 1037, cat: Other, desc: ' |- Action, FPS для macOS' }
+    - { id: 1036, cat: Other, desc: ' |- Strategy, RPG для macOS' }
+    - { id: 1035, cat: Other, desc: ' |- Racing, Simulation, Sports для macOS' }
+    - { id: 1034, cat: Other, desc: ' |- Casual Games, Other для macOS' }
+    - { id: 822, cat: Other, desc: ' |- Тестовые macOS Игры' }
+    - { id: 1093, cat: Other, desc: ' |- Прошивки iOS и AppleTV' }
+    - { id: 1092, cat: Other, desc: ' |- UnLock, Jailbreak, Cydia' }
+    - { id: 1091, cat: Other, desc: ' |- ПО для iOS' }
+    - { id: 834, cat: Other, desc: ' |- Игры для iOS' }
+    - { id: 831, cat: Other, desc: ' |- ПО из App Store' }
+    - { id: 1155, cat: Other, desc: ' |- Отечественное видео для устройств Apple' }
+    - { id: 1156, cat: Other, desc: ' |- Отечественное видео HD для устройств Apple' }
+    - { id: 1099, cat: Other, desc: ' |- Зарубежное видео для устройств Apple' }
+    - { id: 1098, cat: Other, desc: ' |- Зарубежное видео HD для устройств Apple' }
+    - { id: 1096, cat: Audio, desc: ' |- Музыка (AAC)' }
+    - { id: 1097, cat: Audio/Lossless, desc: ' |- Музыка Lossless (ALAC)' }
+    - { id: 1095, cat: Audio/Audiobook, desc: ' |- Аудиокниги (AAC)' }
+    # linux
+    - { id: 536, cat: Other, desc: 'Linux, Unix и другие ОС' }
+    - { id: 563, cat: Other, desc: ' |- ОС Linux' }
+    - { id: 1032, cat: Other, desc: ' |- ОС *Nix (Alpha, Beta, RC)' }
+    - { id: 1031, cat: Other, desc: ' |- Сборки ОС Linux' }
+    - { id: 1025, cat: Other, desc: ' |- ОС *BSD' }
+    - { id: 1026, cat: Other, desc: ' |- Другие ОС' }
+    - { id: 564, cat: Other, desc: ' |- *Nix. Программы' }
+    - { id: 1137, cat: Other, desc: ' |- Специализированные ОС' }
+    - { id: 417, cat: Other, desc: '*Nix Игры' }
+    - { id: 1193, cat: Other, desc: ' |- Native *Nix Games' }
+    - { id: 1192, cat: Other, desc: ' |- Ported *Nix Games' }
+    # multimedia, designs, graphics
+    - { id: 1102, cat: Other, desc: 'Материалы для мультимедиа и дизайна' }
+    - { id: 1070, cat: Other, desc: ' |- Digital Juice' }
+    - { id: 534, cat: Other, desc: ' |- Звуковые библиотеки' }
+    - { id: 676, cat: Other, desc: ' |- Пресеты' }
+    - { id: 1077, cat: Other, desc: ' |- Дополнения' }
+    - { id: 267, cat: Other, desc: ' |- Футажи' }
+    - { id: 1071, cat: Other, desc: ' |- 3D модели и материалы' }
+    - { id: 1134, cat: Other, desc: ' |- Web-дизайн и шаблоны сайтов' }
+    - { id: 1107, cat: Other, desc: ' |- Текстуры и Фоны' }
+    - { id: 1075, cat: Other, desc: ' |- Шрифты' }
+    - { id: 1105, cat: Other, desc: ' |- Шаблоны и Рамки' }
+    - { id: 676, cat: Other, desc: ' |- Костюмы' }
+    - { id: 1072, cat: Other, desc: ' |- Растровый клипарт (фото)' }
+    - { id: 166, cat: Other, desc: ' |- Растровый клипарт (элементы)' }
+    - { id: 1078, cat: Other, desc: ' |- Растровый клипарт (иллюстрации)' }
+    - { id: 1074, cat: Other, desc: ' |- Векторный клипарт' }
+    - { id: 1076, cat: Other, desc: ' |- Сборники' }
+    - { id: 1266, cat: Other, desc: 'Проекты' }
+    - { id: 1267, cat: Other, desc: ' |- Детские (проекты)' }
+    - { id: 1268, cat: Other, desc: ' |- Свадебные и романтические (проекты)' }
+    - { id: 1269, cat: Other, desc: ' |- Праздничные (проекты)' }
+    - { id: 1270, cat: Other, desc: ' |- Презентации (проекты)' }
+    - { id: 1277, cat: Other, desc: ' |- Трейлеры (проекты)' }
+    - { id: 1271, cat: Other, desc: ' |- Спортивные (проекты)' }
+    - { id: 1272, cat: Other, desc: ' |- Логотипы (проекты)' }
+    - { id: 1273, cat: Other, desc: ' |- Слайдшоу (проекты)' }
+    - { id: 1274, cat: Other, desc: ' |- Титры (проекты)' }
+    - { id: 1275, cat: Other, desc: ' |- Элементы (проекты)' }
+    - { id: 1372, cat: Other, desc: ' |- Переходы, фоны и оверлеи (проекты)' }
+    - { id: 1276, cat: Other, desc: ' |- Разное (проекты)' }
+    - { id: 1103, cat: Other, desc: 'Графика, Арт, Разное' }
+    - { id: 1114, cat: Other, desc: ' |- Классическое искусство' }
+    - { id: 1113, cat: Other, desc: ' |- Современное изобразительное искусство' }
+    - { id: 1115, cat: Other, desc: ' |- Книжная иллюстрация' }
+    - { id: 1129, cat: Other, desc: ' |- Современная фотография' }
+    - { id: 1111, cat: Other, desc: ' |- Иконки и аватарки' }
+    - { id: 1116, cat: Other, desc: ' |- Картинки' }
+    - { id: 808, cat: Other, desc: ' |- Обои для рабочего стола' }
+    - { id: 1139, cat: Other, desc: ' |- Обои для рабочего стола (16+)' }
+    - { id: 988, cat: Other, desc: ' |- Графика (16+)' }
+    - { id: 1073, cat: Other, desc: ' |- Интернет-творчество' }
+    # temp, archive
+    - { id: 892, cat: Other, desc: ' |- Архив Мультфильмов' }
+    - { id: 91, cat: Other, desc: ' |- Архив Видео. Кино, Театра' }
+    - { id: 668, cat: Other, desc: ' |- Архив Классики кино и Старых фильмов до 90-х' }
+    - { id: 1143, cat: Other, desc: ' |- Архив Музыкального Видео' }
+    - {
+        id: 802,
+        cat: Other,
+        desc: ' |- Архив Сериалов и Архив Старого многосерийного кино до 90-х'
+      }
+    - { id: 669, cat: Other, desc: ' |- Архив Документалистики и TV' }
+    - { id: 400, cat: Other, desc: ' |- Архив Юмора' }
+    - { id: 169, cat: Other, desc: ' |- Архив Аниме' }
+    - { id: 94, cat: Other, desc: ' |- Архив Книг и обучающих материалов' }
+    - { id: 303, cat: Other, desc: ' |- Архив Авто' }
+    - { id: 92, cat: Other, desc: ' |- Архив Музыки' }
+    - { id: 93, cat: Other, desc: ' |- Архив Игр' }
+    - { id: 1333, cat: Other, desc: ' |- Архив *Nix' }
+    - { id: 95, cat: Other, desc: ' |- Архив Программ' }
+    - { id: 184, cat: Other, desc: ' |- Архив КПК и Мобильных устройств' }
+    - { id: 1080, cat: Other, desc: ' |- Архив 4Apple' }
+    - { id: 180, cat: Other, desc: ' |- Архив Медиа-Диз-Графика' }
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep]
+    movie-search: [q]
+    music-search: [q]
+    book-search: [q]
+  allowrawsearch: true
+
+settings:
+  - name: stripcyrillic
+    type: checkbox
+    label: Strip Cyrillic Letters
+    default: false
+  - name: addrussiantotitle
+    type: checkbox
+    label: Add RUS to end of all titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 1
+    options:
+      1: created
+      10: seeders
+      7: size
+      2: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: 2
+    options:
+      2: desc
+      1: asc
+
+search:
+  paths:
+    - path: forum/tracker.php
+      method: post
+  inputs:
+    $raw: '{{ if .Categories }}{{ range .Categories }}f[]={{.}}&{{end}}{{ else }}f[]=-1{{ end }}'
+    o: '{{ .Config.sort }}'
+    s: '{{ .Config.type }}'
+    tm: -1
+    shf: 1
+    sha: 1
+    ta: -1
+    sns: -1
+    sds: 4 # only freeleech available for download without account
+    nm: '{{ .Keywords }}'
+    submit: 'Поиск'
+
+  keywordsfilters:
+    - name: re_replace # S01 to сезон 1
+      args: ["(?i)\\bS0*(\\d+)\\b", 'сезон $1']
+    - name: re_replace # E02 to сери 1
+      args: ["(?i)\\bE0*(\\d+)\\b", 'сери $1']
+    - name: re_replace # S01E02 to сезон 1 сери 2
+      args: ["(?i)\\bS0*(\\d+)E0*(\\d+)\\b", 'сезон $1 сери $2']
+
+  rows:
+    selector: table.forumline.tablesorter > tbody > tr:has(a[href^="viewtopic.php?t="]):has(a[href^="download.php?id="])
+
+  fields:
+    category_id:
+      selector: a[href^="tracker.php?f="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: f
+    category:
+      # Cinephage parses HTML fields independently, so extract the tracker
+      # category directly instead of relying on Cardigann's row-field context.
+      selector: a[href^="tracker.php?f="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: f
+    title:
+      selector: a[href^="viewtopic.php?t="] > b
+      filters:
+        # normalize to SXXEYY format
+        - name: re_replace
+          args:
+            [
+              "(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?).+?(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))[\\s:]*(\\d+(?:-\\d+)?)\\s*из\\s*(\\w?)",
+              'S$1E$2 of $3'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)(\\d+(?:-\\d+)?)\\s*[CС]езоны?.+?(\\d+(?:-\\d+)?)\\s*из\\s*(\\w?)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))?",
+              'S$1E$2 of $3'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)(\\d+(?:-\\d+)?)\\s*[CС]езоны?.+?(\\d+(?:-\\d+)?)\\s*(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))\\s+из\\s*(\\w?)",
+              'S$1E$2 of $3'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?).+?(\\d+(?:-\\d+)?)\\s*из\\s*(\\w?)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))?",
+              'S$1E$2 of $3'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?).+?(\\d+(?:-\\d+)?)\\s*(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))\\s+из\\s*(\\w?)",
+              'S$1E$2 of $3'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?).+?(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))[\\s:]*(\\d+(?:-\\d+)?)",
+              'S$1E$2'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)(\\d+(?:-\\d+)?)\\s*[CС]езоны?.+?(\\d+(?:-\\d+)?)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))",
+              'S$1E$2'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?).+?(\\d+(?:-\\d+)?)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))",
+              'S$1E$2'
+            ]
+        - name: re_replace
+          args: ["(?i)[CС]езоны?[\\s:]*(\\d+(?:-\\d+)?)", 'S$1']
+        - name: re_replace
+          args: ["(?i)(\\d+(?:-\\d+)?)\\s+[CС]езоны?", 'S$1']
+        - name: re_replace
+          args:
+            [
+              "(?i)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))[\\s:]*(\\d+(?:-\\d+)?)\\s*из\\s*(\\w?)",
+              'E$1 of $2'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)(\\d+(?:-\\d+)?)\\s*из\\s*(\\w?)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))",
+              'E$1 of $2'
+            ]
+        - name: re_replace
+          args:
+            [
+              "(?i)(\\d+(?:-\\d+)?)\\s+(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))\\s+из\\s*(\\w?)",
+              'E$1 of $2'
+            ]
+        - name: re_replace
+          args: ["(?i)(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))[\\s:]*(\\d+(?:-\\d+)?)", 'E$1']
+        - name: re_replace
+          args: ["(?i)(\\d+(?:-\\d+)?)\\s+(?:\\s*(?:[CС]ери[ияй]|Эпизод|Выпуски?))", 'E$1']
+        - name: re_replace
+          args: ["(?i)\\bКураж-Бамбей\\b", 'kurazh']
+        - name: re_replace
+          args: ["(?i)\\bКубик в Кубе\\b", 'Kubik']
+        - name: re_replace
+          args: ["(?i)\\bКравец\\b", 'Kravec']
+        - name: re_replace
+          args: ["(?i)\\bПифагор\\b", 'Pifagor']
+        - name: re_replace
+          args: ["(?i)\\bНевафильм\\b", 'Nevafilm']
+        - name: re_replace
+          args: ["(?i)\\bЛицензия\\b", 'Lic']
+        - name: re_replace
+          args: ["(?i)\\bселезень\\b", 'selezen']
+        - name: re_replace
+          args: ["(?i)\\sот\\s([\\w\\p{P}\\p{S}]+)$", '-$1']
+        - name: re_replace
+          args: ["\\s\\|\\s(\\w{4,})$", '-$1']
+        - name: re_replace
+          args:
+            [
+              "(\\([\\p{IsCyrillic}\\W]+\\))|(^[\\p{IsCyrillic}\\W\\d]+\\/ )|([\\p{IsCyrillic} \\-]+,+)|([\\p{IsCyrillic}]+)",
+              '{{ if .Config.stripcyrillic }}{{ else }}$1$2$3$4{{ end }}'
+            ]
+        - name: re_replace
+          args: ["(?i)\\bHDTV[-\\s]?Rip\\b", 'HDTV']
+        - name: re_replace
+          args: ["(?i)\\bSAT[-\\s]?Rip\\b", 'HDTV']
+        - name: re_replace
+          args: ["(?i)\\bWEB[-\\s]?DL[-\\s]?Rip\\b", 'WEB-DL']
+        - name: re_replace
+          args: ["(?i)\\bWEB\\sRip\\b", 'WEBRip']
+        - name: re_replace
+          args: ["(?i)\\bWEB\\sDL\\b", 'WEB-DL']
+        - name: re_replace
+          args: ["[\\[\\(\\{<«][\\s\\W]*[\\]\\)\\}>»]", '']
+        - name: re_replace
+          args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", '']
+        - name: re_replace
+          args:
+            [
+              "^(.*?)(\\((?:(?:20|19)\\d{2}-?)+\\))(.*?)(.*?)\\((\\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+[?0-9]+)?)\\)(.*)",
+              '$1 / $5 $2$4$6'
+            ]
+        - name: append
+          # The category-specific Cardigann condition depends on row-field
+          # context that Cinephage does not expose to HTML filter templates.
+          args: '{{ if .Config.addrussiantotitle }} RUS{{ end }}'
+    details:
+      selector: a[href^="viewtopic.php?t="]
+      attribute: href
+    download:
+      selector: a[href^="download.php?id="]
+      attribute: href
+    size:
+      selector: td:nth-child(6) > u
+    grabs:
+      selector: td:nth-child(9)
+    date:
+      # unix
+      selector: td:last-child > u
+    seeders:
+      selector: td.seedmed > b
+    leechers:
+      selector: td.leechmed > b
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1
+    description:
+      selector: a[href^="viewtopic.php?t="] > b
+# engine n/a

--- a/src/lib/server/indexers/definitions/kinozal-categories.test.ts
+++ b/src/lib/server/indexers/definitions/kinozal-categories.test.ts
@@ -1,0 +1,31 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { YamlDefinitionLoader } from '../loader/YamlDefinitionLoader.js';
+
+const definitionPath = resolve('data/indexers/definitions/kinozal-magnet.yaml');
+
+async function loadDefinition() {
+	const loader = new YamlDefinitionLoader(resolve('data/indexers/definitions'));
+	const result = await loader.loadOne(definitionPath);
+	expect(result).not.toBeNull();
+	return result!.definition;
+}
+
+describe('Kinozal magnet category mappings', () => {
+	it('maps cartoon sections to both TV and movie categories', async () => {
+		const definition = await loadDefinition();
+		const mappings = new Map<string, string[]>();
+
+		for (const entry of definition.caps.categorymappings ?? []) {
+			const id = String(entry.id);
+			const categories = mappings.get(id) ?? [];
+			if (entry.cat) categories.push(entry.cat);
+			mappings.set(id, categories);
+		}
+
+		expect(mappings.get('1003')).toEqual(expect.arrayContaining(['TV', 'Movies']));
+		expect(mappings.get('21')).toEqual(expect.arrayContaining(['TV', 'Movies']));
+		expect(mappings.get('22')).toEqual(expect.arrayContaining(['TV', 'Movies']));
+		expect(mappings.get('20')).toEqual(expect.arrayContaining(['TV/Anime', 'Movies/Other']));
+	});
+});

--- a/src/lib/server/indexers/definitions/noname-club.test.ts
+++ b/src/lib/server/indexers/definitions/noname-club.test.ts
@@ -1,0 +1,116 @@
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FilterEngine } from '../engine/FilterEngine.js';
+import { SelectorEngine } from '../engine/SelectorEngine.js';
+import { TemplateEngine } from '../engine/TemplateEngine.js';
+import { RequestBuilder } from '../runtime/RequestBuilder.js';
+import { ResponseParser } from '../runtime/ResponseParser.js';
+import { YamlDefinitionLoader } from '../loader/YamlDefinitionLoader.js';
+import { Category } from '../types/category.js';
+
+const definitionPath = resolve('data/indexers/definitions/noname-club.yaml');
+
+async function loadDefinition() {
+	const loader = new YamlDefinitionLoader(dirname(definitionPath));
+	const result = await loader.loadOne(definitionPath);
+	expect(result).not.toBeNull();
+	return result!.definition;
+}
+
+describe('NoNaMe Club definition', () => {
+	it('loads the upstream identity and media category mappings', async () => {
+		const definition = await loadDefinition();
+
+		expect(definition.id).toBe('noname-club');
+		expect(definition.replaces).toEqual(['nnm-club']);
+		expect(definition.name).toBe('NoNaMe Club');
+		expect(definition.encoding).toBe('windows-1251');
+
+		const mapping = new Map(
+			definition.caps.categorymappings?.map((entry) => [String(entry.id), entry.cat])
+		);
+		expect(mapping.get('224')).toBe('Movies');
+		expect(mapping.get('768')).toBe('TV');
+		expect(mapping.get('615')).toBe('TV/Anime');
+	});
+
+	it('maps full-length cartoon sections to Movies', async () => {
+		const definition = await loadDefinition();
+		const mapping = new Map(
+			definition.caps.categorymappings?.map((entry) => [String(entry.id), entry.cat])
+		);
+
+		for (const id of [
+			'890',
+			'1329',
+			'1330',
+			'1331',
+			'1332',
+			'1336',
+			'1337',
+			'1338',
+			'1339',
+			'1340',
+			'660'
+		]) {
+			expect(mapping.get(id), `NNMClub category ${id}`).toBe('Movies');
+		}
+	});
+
+	it('builds a category-filtered POST request for movie searches', async () => {
+		const definition = await loadDefinition();
+		const templateEngine = new TemplateEngine();
+		templateEngine.setConfigWithDefaults({}, definition.settings ?? []);
+		const requestBuilder = new RequestBuilder(definition, templateEngine, new FilterEngine());
+
+		const [request] = requestBuilder.buildSearchRequests({
+			searchType: 'movie',
+			query: 'Despicable Me',
+			year: 2024,
+			categories: [Category.MOVIES]
+		});
+
+		expect(request).toBeDefined();
+		expect(request.method).toBe('POST');
+		expect(request.url).toBe('https://nnmclub.to/forum/tracker.php');
+		expect(request.body).toContain('%66%5B%5D=%32%31%36');
+		expect(request.body).toContain('%66%5B%5D=%31%33%33%39');
+		expect(request.body).toContain('%6E%6D=%44%65%73%70%69%63%61%62%6C%65%20%4D%65%20%32%30%32%34');
+	});
+
+	it('parses a movie row with its tracker category', async () => {
+		const definition = await loadDefinition();
+		const templateEngine = new TemplateEngine();
+		templateEngine.setConfigWithDefaults({}, definition.settings ?? []);
+		const filterEngine = new FilterEngine(templateEngine);
+		const parser = new ResponseParser(
+			definition,
+			templateEngine,
+			filterEngine,
+			new SelectorEngine(templateEngine, filterEngine)
+		);
+
+		const result = parser.parse(
+			`<table class="forumline tablesorter"><tbody><tr>
+				<td><a href="tracker.php?f=1339">Зарубежные Мультфильмы 21-го века (HD, FHD, UHD)</a></td>
+				<td><a href="viewtopic.php?t=42"><b>Despicable Me 4 (2024)</b></a><a href="download.php?id=42">download</a></td>
+				<td></td><td></td><td></td><td><u>1.2 GB</u></td>
+				<td class="seedmed"><b>12</b></td><td class="leechmed"><b>3</b></td>
+				<td>7</td><td><u>1720000000</u></td>
+			</tr></tbody></table>`,
+			definition.search.paths?.[0],
+			{
+				indexerId: 'noname-club',
+				indexerName: 'NoNaMe Club',
+				protocol: 'torrent',
+				baseUrl: 'https://nnmclub.to/'
+			}
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.releases).toHaveLength(1);
+		expect(result.releases[0].title).toBe('Despicable Me 4 (2024)');
+		expect(result.releases[0].categories).toContain(Category.MOVIES);
+		expect(result.releases[0].downloadUrl).toBe('https://nnmclub.to/download.php?id=42');
+	});
+});

--- a/src/lib/server/indexers/search/russian-trackers.test.ts
+++ b/src/lib/server/indexers/search/russian-trackers.test.ts
@@ -40,6 +40,7 @@ describe('russian-trackers', () => {
 			expect(RUSSIAN_TRACKER_NAMES).toContain('kinozal');
 			expect(RUSSIAN_TRACKER_NAMES).toContain('rutor');
 			expect(RUSSIAN_TRACKER_NAMES).toContain('nnmclub');
+			expect(RUSSIAN_TRACKER_NAMES).toContain('noname club');
 		});
 	});
 
@@ -118,6 +119,14 @@ describe('russian-trackers', () => {
 			const indexer = makeIndexer({
 				name: 'RuTracker',
 				baseUrl: 'https://rutracker.org'
+			});
+			expect(prefersNativeCyrillicTitles(indexer)).toBe(true);
+		});
+
+		it('should return true for NoNaMe Club by display name', () => {
+			const indexer = makeIndexer({
+				name: 'NoNaMe Club',
+				baseUrl: 'https://nnmclub.to'
 			});
 			expect(prefersNativeCyrillicTitles(indexer)).toBe(true);
 		});

--- a/src/lib/server/indexers/search/russian-trackers.ts
+++ b/src/lib/server/indexers/search/russian-trackers.ts
@@ -17,6 +17,7 @@ export const RUSSIAN_TRACKER_NAMES = [
 	'rutor',
 	'nnmclub',
 	'nnm-club',
+	'noname club',
 	'rustorka'
 ];
 


### PR DESCRIPTION
## Summary

- Add a native Cardigann-compatible NoNaMe Club indexer definition based on the official Prowlarr/Indexers and Jackett definitions.
- Map NoNaMe Club's full-length cartoon sections to Movies so movie searches request and retain animated features.
- Map Kinozal magnet cartoon sections to both TV and movie categories, matching the regular Kinozal definition.
- Preserve native Cyrillic title handling for NoNaMe Club and add focused regression coverage.

## Root cause

The upstream NoNaMe Club definition classified feature-cartoon sections as TV. Cinephage consequently omitted those tracker sections from movie requests and could reject parsed rows at the movie/TV category gate. The Kinozal magnet definition had the same category asymmetry: its cartoon IDs were TV-only even though the regular Kinozal definition maps them to both content types.

## Validation

- `npx vitest run src/lib/server/indexers/definitions/kinozal-categories.test.ts src/lib/server/indexers/definitions/kinozal.test.ts src/lib/server/indexers/definitions/noname-club.test.ts src/lib/server/indexers/search/russian-trackers.test.ts` — 45 tests passed.
- `npm run check` — 0 errors and 0 warnings.
- Targeted ESLint and Prettier checks passed.
- `git diff --check` passed.
