### PR TITLE
fix(discover): prevent TMDB request loop in SectionRow

### DIFF
--- a/src/lib/components/discover/SectionRow.svelte
+++ b/src/lib/components/discover/SectionRow.svelte
@@ -28,6 +28,8 @@
 	let displayedItems = $state<T[]>([]);
 	let page = $state(1);
 	let loading = $state(false);
+	let hasMore = $state(true);
+	let retryAfter = $state(0);
 	let container: HTMLElement;
 	let showLeftArrow = $state(false);
 	let showRightArrow = $state(true);
@@ -36,30 +38,47 @@
 	$effect(() => {
 		displayedItems = items;
 		page = 1;
+		hasMore = true;
+		retryAfter = 0;
 	});
 
 	async function loadMore() {
-		if (loading || !endpoint) return;
+		if (loading || !endpoint || !hasMore || Date.now() < retryAfter) return;
 		loading = true;
 		try {
 			const next = page + 1;
-			const data = (await getTmdb(endpoint, { page: String(next) })) as { results?: T[] };
-			if (data.results && data.results.length > 0) {
-				// Filter out duplicates
-				const existingIds = new Set(displayedItems.map((i: T) => i.id));
-				let newResults = data.results.filter((i: T) => !existingIds.has(i.id));
+			const data = (await getTmdb(endpoint, { page: String(next) })) as {
+				results?: T[];
+				total_pages?: number;
+			};
 
-				// Filter out items in library if excludeInLibrary is true
-				if (excludeInLibrary) {
-					newResults = newResults.filter((i: T & { inLibrary?: boolean }) => !i.inLibrary);
-				}
+			if (!data.results || data.results.length === 0) {
+				hasMore = false;
+				return;
+			}
 
-				if (newResults.length > 0) {
-					displayedItems = [...displayedItems, ...newResults];
-					page = next;
-				}
+			// Advance the source page even if every result is a duplicate or filtered out.
+			// Otherwise the same page is fetched repeatedly and can trigger the TMDB proxy rate limit.
+			page = next;
+			if (typeof data.total_pages === 'number' && next >= data.total_pages) {
+				hasMore = false;
+			}
+
+			// Filter out duplicates
+			const existingIds = new Set(displayedItems.map((i: T) => i.id));
+			let newResults = data.results.filter((i: T) => !existingIds.has(i.id));
+
+			// Filter out items in library if excludeInLibrary is true
+			if (excludeInLibrary) {
+				newResults = newResults.filter((i: T & { inLibrary?: boolean }) => !i.inLibrary);
+			}
+
+			if (newResults.length > 0) {
+				displayedItems = [...displayedItems, ...newResults];
 			}
 		} catch (e) {
+			// Prevent reactive effects from immediately retrying a failed request in a tight loop.
+			retryAfter = Date.now() + 30_000;
 			toasts.error(m.discover_failedToLoadMore(), {
 				description: e instanceof Error ? e.message : m.discover_failedToLoadMore()
 			});
@@ -76,7 +95,12 @@
 		showRightArrow = scrollLeft < scrollWidth - clientWidth - 10;
 
 		// Load more when we're close to the end (within 200px)
-		if (endpoint && scrollWidth - (scrollLeft + clientWidth) < 200) {
+		if (
+			endpoint &&
+			hasMore &&
+			Date.now() >= retryAfter &&
+			scrollWidth - (scrollLeft + clientWidth) < 200
+		) {
 			loadMore();
 		}
 	}

--- a/src/lib/server/tmdb-client-language.test.ts
+++ b/src/lib/server/tmdb-client-language.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, afterAll, beforeEach, vi } from 'vitest';
 
 import { createTestDb, destroyTestDb, type TestDatabase } from '../../test/db-helper.js';
-import { eq } from 'drizzle-orm';
 
 const testDb: TestDatabase = createTestDb();
 


### PR DESCRIPTION
## Summary

Fixes a Discover-page request loop that could repeatedly call the internal TMDB proxy until Cinephage's per-client rate limiter started returning `429 Rate limit exceeded` responses.

The problem occurs in `SectionRow.svelte` when infinite horizontal pagination reaches a TMDB page that contains no usable new items. This can happen when the response is empty, when every result is already displayed, or when `excludeInLibrary` filters every result out.

## Root cause

`SectionRow` tracks the current TMDB page in `page` and calls `loadMore()` whenever the carousel is within 200 px of the end.

Before this change, `page = next` was only executed when `newResults.length > 0`.

That creates a retry loop in the following case:

1. The row reaches the end and `handleScroll()` calls `loadMore()`.
2. `loadMore()` requests `page + 1` from `/api/tmdb/...`.
3. TMDB returns a page, but all items are duplicates or are removed by `excludeInLibrary` (or the response has no results).
4. Because no item is appended, `page` is not advanced.
5. `loading` is set back to `false` in `finally`.
6. The Svelte `$effect` / scroll state still sees the carousel within the 200 px threshold and calls `loadMore()` again.
7. The exact same TMDB page is requested again.

Once this repeats, multiple Discover rows can consume the shared proxy rate-limit bucket for the same client IP very quickly. The server-side TMDB proxy currently allows 1000 requests per 60 seconds per client IP, so the loop eventually produces a rapid stream of:

```text
service=tmdb-proxy clientIp=<client-ip> msg="Rate limit exceeded"
```

After the first `429`, the old client behavior also had no backoff, so the reactive loop could continue retrying immediately instead of recovering.

## Changes Made

- **Always advance successful source pagination**: the requested TMDB page is now recorded even when every returned item is a duplicate or is filtered from the local row. This prevents the same remote page from being fetched indefinitely.
- **Track whether more pages are available** with `hasMore`.
- **Stop pagination on an empty TMDB result page** instead of continuing to request beyond the available data.
- **Honor TMDB `total_pages`** when present and stop once the last page has been reached.
- **Add a retry cooldown after request failures** so reactive scroll/effect updates cannot immediately hammer a failing endpoint. The current cooldown is 30 seconds.
- **Guard `handleScroll()` with pagination/retry state** so it only calls `loadMore()` when more data may exist and the retry cooldown has expired.
- **Reset pagination state when row items change** so a refreshed/reused section starts again from page 1 with `hasMore` and retry state cleared.
- Remove a pre-existing unused `eq` import from `tmdb-client-language.test.ts`; the current `dev` branch otherwise fails ESLint on that unrelated line before the PR changes can be validated.

## Behaviour after the fix

A successful TMDB response now progresses through remote pages independently of whether those items are ultimately displayed locally.

For example, if page 2 contains 20 entries but all 20 are already present or excluded by the user's library filter, the row advances to page 2 instead of repeatedly requesting page 2. A later scroll can then request page 3 normally.

If TMDB returns no results, or `page >= total_pages`, the row marks itself exhausted and stops issuing pagination requests.

If a request fails (including a proxy rate-limit response), the row temporarily suppresses automatic retries instead of entering a tight reactive request loop.

## Areas Affected

- [x] UI/Frontend
- [x] TMDB / Discover pagination
- [ ] API/Backend behavior
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

The backend rate-limit implementation itself is unchanged; this fixes the client-side request storm that was exhausting it.

## Testing

- [x] Reproduced the issue on the Discover page with repeated `tmdb-proxy` rate-limit warnings occurring tens of milliseconds apart.
- [x] Built and ran a Docker image containing the `SectionRow` fix.
- [x] Verified in the affected environment that opening/using Discover no longer produces the request storm or repeated `Rate limit exceeded` messages.
- [x] Prettier formatting passes for the changed implementation.
- [x] Removed the pre-existing unused `drizzle-orm` import that caused `npm run lint` to fail on the current `dev` base.

## Checklist

- [x] Code follows the existing Svelte 5 rune/state pattern used by `SectionRow`.
- [x] Commit message follows conventional commits.
- [x] No backend rate limit was raised or bypassed.
- [x] No new dependency or schema change is introduced.
- [x] The fix is based on the current `dev` branch.

The key behavior change is deliberately on the pagination side rather than increasing the 1000/minute proxy limit: normal Discover usage should not need to generate enough requests to hit that limit in the first place.