### PR TITLE
fix(library): make poster grid breakpoints responsive

### DIFF
--- a/src/routes/library/movies/+page.svelte
+++ b/src/routes/library/movies/+page.svelte
@@ -897,7 +897,9 @@
 								</div>
 								{#if !collapsedGroups.has(group.name ?? '__none__')}
 									{#if viewPreferences.viewMode === 'grid'}
-										<div class="grid grid-cols-3 gap-3 pt-2 sm:gap-4 lg:grid-cols-9">
+										<div
+											class="grid grid-cols-3 gap-3 pt-2 sm:grid-cols-4 sm:gap-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-9"
+										>
 											{#each group.movies as movie (movie.id)}
 												<LibraryMediaCard
 													item={movie}
@@ -930,7 +932,9 @@
 						{/each}
 					{:else}
 						{#if viewPreferences.viewMode === 'grid'}
-							<div class="grid grid-cols-3 gap-3 sm:gap-4 lg:grid-cols-9">
+							<div
+								class="grid grid-cols-3 gap-3 sm:grid-cols-4 sm:gap-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-9"
+							>
 								{#each renderer.visible as movie (movie.id)}
 									<LibraryMediaCard
 										item={movie}

--- a/src/routes/library/tv/+page.svelte
+++ b/src/routes/library/tv/+page.svelte
@@ -740,7 +740,9 @@
 			{:else}
 				<div class="animate-in fade-in slide-in-from-bottom-4 duration-500">
 					{#if viewPreferences.viewMode === 'grid'}
-						<div class="grid grid-cols-3 gap-3 sm:gap-4 lg:grid-cols-9">
+						<div
+							class="grid grid-cols-3 gap-3 sm:grid-cols-4 sm:gap-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-9"
+						>
 							{#each renderer.visible as show (show.id)}
 								<LibraryMediaCard
 									item={show}


### PR DESCRIPTION
## Summary

Improve the Library poster grid so Movies and TV Shows scale progressively across viewport widths instead of jumping directly from 3 columns to 9 columns.

The current Library grid uses `grid-cols-3` by default and `lg:grid-cols-9` from the Tailwind `lg` breakpoint onward. On medium and moderately wide desktop layouts this can make poster cards unnecessarily narrow, especially when the main content area is constrained by browser width, sidebars, or windowed desktop use.

This change keeps the existing card component and grid behavior, but introduces intermediate responsive column counts so the layout grows gradually with the available width.

## Problem

Before this change, the main Library poster grids effectively had only two layout states:

```text
< 1024 px    3 columns
>= 1024 px   9 columns
```

That is a very large jump at the `lg` breakpoint.

As soon as the viewport crosses 1024 px, the same content area that previously displayed three reasonably sized posters is asked to fit nine posters in one row. On narrower desktop windows this produces cards that are much smaller than necessary and makes titles, badges, and artwork harder to scan.

The issue is especially visible in normal desktop use where Cinephage is not maximized to a very wide monitor. The page technically has enough width to be considered `lg`, but not enough useful content width for nine comfortable poster columns.

## Root cause

The Movies and TV Library grids currently rely on this responsive pattern:

```text
grid-cols-3 ... lg:grid-cols-9
```

There are no intermediate breakpoints between the base 3-column layout and the 9-column desktop layout.

Because Tailwind's `lg` breakpoint starts at 1024 px, the layout changes from 3 to 9 columns in a single step. The grid therefore reacts to the breakpoint itself rather than progressively adapting to the space available.

This affects:

- the normal Movies poster grid,
- Movies displayed inside collection groups,
- the TV Shows poster grid.

## Changes Made

Replace the two-state `3 -> 9` layout with progressive responsive breakpoints:

```text
< 640 px        3 columns
640–767 px      4 columns
768–1023 px     5 columns
1024–1279 px    6 columns
1280–1535 px    7 columns
>= 1536 px      9 columns
```

The corresponding Tailwind classes are:

```text
grid-cols-3
sm:grid-cols-4
md:grid-cols-5
lg:grid-cols-6
xl:grid-cols-7
2xl:grid-cols-9
```

The same progression is applied consistently to all affected Library poster grids.

No card sizing logic, data loading, filtering, sorting, progressive rendering, or Library behavior is changed. This is intentionally a small presentation-only adjustment.

## Behaviour after the fix

The poster grid now grows gradually as more horizontal space becomes available:

```text
3 -> 4 -> 5 -> 6 -> 7 -> 9 columns
```

This keeps poster cards noticeably larger on common desktop window sizes while still allowing the existing dense 9-column layout on very wide screens.

For example, a viewport around the `lg` range now displays 6 columns instead of immediately forcing 9. At `xl`, it increases to 7, and the original 9-column density is preserved at `2xl`.

The result is a smoother responsive transition and more readable poster artwork without changing the overall visual style of the Library.

## Areas Affected

- [x] UI / Frontend
- [x] Library Movies grid
- [x] Library movie collection groups
- [x] Library TV Shows grid
- [ ] API / Backend
- [ ] Database / Schema
- [ ] Indexers
- [ ] Download Clients
- [ ] Playback
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Built the branch as a Docker image for both `linux/amd64` and `linux/arm64`.
- [x] Docker health check passed successfully.
- [x] Multi-architecture image manifest was created successfully.
- [x] Manually tested the resulting image in the affected environment.
- [x] Confirmed the Library layout is substantially more usable at intermediate desktop widths.
- [x] Confirmed the grid now transitions progressively through 3, 4, 5, 6, 7, and 9 columns as the viewport grows.

## Checklist

- [x] Based on the current `dev` branch.
- [x] No new dependencies.
- [x] No backend or schema changes.
- [x] Existing 9-column wide-screen layout is preserved at `2xl`.
- [x] The same responsive behavior is applied consistently to Movies, grouped Movies, and TV Shows.

The change is deliberately limited to responsive grid breakpoints; the Library card component and all existing Library functionality remain unchanged.