### PR TITLE
fix(library): honor read-only root folder validation

### DIFF
--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -41,8 +41,8 @@ export async function deleteRootFolder(id: string) {
 	return apiDelete(`/api/root-folders/${id}`);
 }
 
-export async function validateRootFolder(path: string, mediaType?: string, folderId?: string) {
-	return apiPost('/api/root-folders/validate', { path, mediaType, folderId });
+export async function validateRootFolder(path: string, readOnly?: boolean, folderId?: string) {
+	return apiPost('/api/root-folders/validate', { path, readOnly, folderId });
 }
 
 export async function getLibraries(params?: { mediaType?: string; includeSystem?: boolean }) {

--- a/src/routes/settings/library/root-folders/+page.svelte
+++ b/src/routes/settings/library/root-folders/+page.svelte
@@ -80,11 +80,11 @@
 
 	async function handleValidatePath(
 		path: string,
-		_readOnly = false,
+		readOnly = false,
 		folderId?: string
 	): Promise<PathValidationResult> {
 		try {
-			const payload = await validateRootFolder(path, undefined, folderId);
+			const payload = await validateRootFolder(path, readOnly, folderId);
 			return payload as unknown as PathValidationResult;
 		} catch (error) {
 			return {

--- a/src/routes/settings/monitoring/status/folders/+page.svelte
+++ b/src/routes/settings/monitoring/status/folders/+page.svelte
@@ -41,11 +41,11 @@
 
 	async function handleValidatePath(
 		path: string,
-		_readOnly = false,
+		readOnly = false,
 		folderId?: string
 	): Promise<PathValidationResult> {
 		try {
-			const payload = await validateRootFolder(path, undefined, folderId);
+			const payload = await validateRootFolder(path, readOnly, folderId);
 			return payload as unknown as PathValidationResult;
 		} catch (error) {
 			return {


### PR DESCRIPTION
## Summary

Fix Root Folder validation so folders explicitly configured as **read-only** are validated using read access only instead of failing because the path is not writable.

Fixes #522.

## Root cause

The backend already supports the intended behavior.

`RootFolderService.validatePath(path, readOnly, folderId)` skips the write test when `readOnly === true` and only checks that the path exists, is a directory, is readable, and does not overlap another root folder.

The issue was in the frontend/API plumbing:

- `RootFolderModal` passes the current read-only state to the page-level validation callback.
- Both Root Folder settings pages accepted that value as `_readOnly`, but intentionally discarded it.
- `validateRootFolder()` in `src/lib/api/settings.ts` did not expose a `readOnly` parameter and posted `mediaType` instead.
- As a result, `/api/root-folders/validate` received no `readOnly` flag and defaulted to `false`, causing the normal write test to run.

This produced the contradictory UI state reported in #522: **Read-only mode enabled** together with **Path validation failed: Path is not writable**.

## Changes Made

This is intentionally a minimal fix:

- Change the second argument of `validateRootFolder()` from the unused `mediaType` field to `readOnly`.
- Pass `readOnly` through to `/api/root-folders/validate`.
- Forward the modal's read-only state from:
  - `Settings -> Library -> Root Folders`
  - `Settings -> Monitoring -> Folders`

No backend validation logic is changed because the server-side read-only behavior is already implemented correctly.

## Behaviour after the fix

For normal root folders:

- path existence is checked;
- the path must be a directory;
- write access is tested;
- validation still fails if the path is not writable.

For read-only root folders:

- path existence is checked;
- the path must be a directory;
- read access is checked;
- the write test is skipped;
- validation succeeds for a readable, intentionally read-only path.

This keeps validation consistent with the existing **Read-only folder (catalog only, no imports)** setting.

## Areas Affected

- [x] UI / Frontend
- [x] Library Management
- [x] Root Folder validation
- [ ] Database / Schema
- [ ] Import logic
- [ ] Scanner behavior
- [ ] Backend validation semantics

## Testing

- [x] Change is based directly on the current upstream `dev` branch.
- [x] Diff is limited to the validation parameter plumbing.
- [x] Existing server-side read-only validation path is reused unchanged.
- [x] Normal writable-folder validation behavior remains unchanged.

## Checklist

- [x] Minimal code change
- [x] No new dependency
- [x] No schema or migration change
- [x] No change to Root Folder persistence
- [x] Fix directly addresses #522
