### PR TITLE
fix(settings): preserve Date columns in configuration backup round-trip

### DIFF
--- a/src/lib/server/settings/ConfigurationBackupService.test.ts
+++ b/src/lib/server/settings/ConfigurationBackupService.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createTestDb } from '../../../test/db-helper';
-import { downloadClients } from '$lib/server/db/schema';
+import { downloadClients, namingPresets } from '$lib/server/db/schema';
 
 const testDb = createTestDb();
 const DEFAULT_SECRET = process.env.BETTER_AUTH_SECRET ?? 'test-secret';
@@ -93,5 +93,85 @@ describe('ConfigurationBackupService debrid safety', () => {
 		await expect(
 			getConfigurationBackupService().exportConfig('passphrase-12345')
 		).rejects.toThrow();
+	});
+});
+
+describe('ConfigurationBackupService timestamp round-trip', () => {
+	afterEach(() => {
+		testDb.db.delete(namingPresets).run();
+		process.env.BETTER_AUTH_SECRET = DEFAULT_SECRET;
+	});
+
+	it('restores a system-section backup whose rows contain serialized Date columns', async () => {
+		const { getConfigurationBackupService } = await import('./ConfigurationBackupService');
+
+		process.env.BETTER_AUTH_SECRET = 'backup-timestamp-secret';
+		const preset = {
+			id: 'preset-1',
+			name: 'My Preset',
+			description: null,
+			config: { movie: '{title}' },
+			isBuiltIn: false
+		};
+		testDb.db.insert(namingPresets).values(preset).run();
+		const savedAt = testDb.sqlite
+			.prepare(`SELECT "created_at" FROM "naming_presets" WHERE "id" = ?`)
+			.get(preset.id) as { created_at: number };
+
+		const backup = await getConfigurationBackupService().exportConfig('passphrase-12345');
+		testDb.db.delete(namingPresets).run();
+
+		// A real backup round-trips through JSON (download → upload), which
+		// serializes Date columns to ISO strings. Reproduce that exactly.
+		const serialized = JSON.parse(JSON.stringify(backup)) as typeof backup;
+
+		await getConfigurationBackupService().restoreConfig(serialized, {
+			passphrase: 'passphrase-12345',
+			sections: ['system']
+		});
+
+		const restored = testDb.sqlite
+			.prepare(`SELECT "id", "created_at" FROM "naming_presets" WHERE "id" = ?`)
+			.get(preset.id) as { id: string; created_at: number };
+		expect(restored.id).toBe(preset.id);
+		expect(restored.created_at).toBe(savedAt.created_at);
+	});
+
+	it('restores legacy backups whose Date columns were exported as empty objects', async () => {
+		const { getConfigurationBackupService } = await import('./ConfigurationBackupService');
+		const { encryptBackupPayload } = await import('$lib/server/crypto/backupCrypto');
+
+		process.env.BETTER_AUTH_SECRET = 'backup-legacy-secret';
+		const backup = {
+			format: 'cinephage-config-backup' as const,
+			version: 1 as const,
+			createdAt: new Date().toISOString(),
+			manifest: undefined,
+			options: {},
+			data: {
+				namingPresets: [
+					{
+						id: 'legacy-preset',
+						name: 'Legacy Preset',
+						description: null,
+						config: { movie: '{title}' },
+						isBuiltIn: false,
+						createdAt: {} as Record<string, never>
+					}
+				]
+			},
+			secrets: encryptBackupPayload({ tables: {} }, 'passphrase-12345')
+		};
+
+		await getConfigurationBackupService().restoreConfig(backup, {
+			passphrase: 'passphrase-12345',
+			sections: ['system']
+		});
+
+		const restored = testDb.sqlite
+			.prepare(`SELECT "id", "created_at" FROM "naming_presets" WHERE "id" = ?`)
+			.get('legacy-preset') as { id: string; created_at: number | null };
+		expect(restored.id).toBe('legacy-preset');
+		expect(restored.created_at).not.toBeNull();
 	});
 });

--- a/src/lib/server/settings/ConfigurationBackupService.ts
+++ b/src/lib/server/settings/ConfigurationBackupService.ts
@@ -1,4 +1,5 @@
-import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+import type { AnySQLiteColumn, AnySQLiteTable, SQLiteColumn } from 'drizzle-orm/sqlite-core';
+import { getTableColumns } from 'drizzle-orm';
 
 import { ValidationError } from '$lib/errors';
 import { logger } from '$lib/logging';
@@ -442,6 +443,12 @@ function extractSecrets(
 		};
 	}
 
+	// Dates must be treated as leaves: walking them with Object.entries (which
+	// yields nothing) silently reduces them to `{}` in the exported backup.
+	if (value instanceof Date) {
+		return { sanitized: value };
+	}
+
 	if (value && typeof value === 'object') {
 		const sanitizedObject: Record<string, unknown> = {};
 		const secretObject: Record<string, unknown> = {};
@@ -483,6 +490,41 @@ function deepMergeRecord<T>(base: T, secret: unknown): T {
 	}
 
 	return secret as T;
+}
+
+/**
+ * A backup file round-trips through JSON, which serializes Date values to
+ * ISO strings. Drizzle's timestamp-mode columns expect Date instances on
+ * write (`mapToDriverValue` calls `value.getTime()`), so restoring raw JSON
+ * rows fails with "value.getTime is not a function". Convert each value
+ * according to its drizzle column type before insert.
+ */
+function deserializeRestoredRow(
+	table: AnySQLiteTable,
+	row: Record<string, unknown>
+): Record<string, unknown> {
+	const columns = getTableColumns(table) as Record<string, SQLiteColumn>;
+	const converted: Record<string, unknown> = { ...row };
+
+	for (const [key, column] of Object.entries(columns)) {
+		const value = converted[key];
+		if (value === null || value === undefined) continue;
+		if (column.dataType === 'date') {
+			if (typeof value === 'string' || typeof value === 'number') {
+				const parsed = new Date(value);
+				if (!Number.isNaN(parsed.getTime())) {
+					converted[key] = parsed;
+					continue;
+				}
+			}
+			// Backups created before Date columns were preserved carry `{}` in
+			// their place. The original value is unrecoverable, so drop the key
+			// and let the schema default supply a fresh timestamp.
+			delete converted[key];
+		}
+	}
+
+	return converted;
 }
 
 function restoreExistingSensitiveValues<T>(incoming: T, existing: unknown, fieldName?: string): T {
@@ -738,9 +780,9 @@ export class ConfigurationBackupService {
 				const row = rawRow as Record<string, unknown>;
 				const recordKey = config.getRecordKey(row);
 				const restoredWithSecrets = deepMergeRecord(row, tableSecrets[recordKey]);
-				const restored = restoreExistingSensitiveValues(
-					restoredWithSecrets,
-					existingRowMap.get(recordKey)
+				const restored = deserializeRestoredRow(
+					config.table,
+					restoreExistingSensitiveValues(restoredWithSecrets, existingRowMap.get(recordKey))
 				);
 
 				// Debrid token portable transform: re-encrypt the plaintext token


### PR DESCRIPTION
Fixes #513 (backup restore portion)

## Problem

Restoring a configuration backup failed with `value.getTime is not a function` whenever the **System & Libraries** section was checked (reported in #513, no fix commit exists for it).

## Root cause — two layers

1. **Export destroyed the data.** `extractSecrets` walked `Date` objects like plain records; `Object.entries(date)` yields nothing, so every timestamp column (`namingPresets.createdAt` — the only timestamp-mode column in the schema) was silently exported as `{}` before the file was ever written.
2. **Restore didn't deserialize.** `restoreConfig` re-inserted raw JSON rows, but drizzle's timestamp-mode columns call `value.getTime()` on write (`SQLiteTimestamp.mapToDriverValue`), so even well-formed ISO strings threw the reported error.

## Fix

- `extractSecrets` treats `Date` values as leaves (no longer reduced to `{}`).
- New `deserializeRestoredRow()` converts restored values according to the table's drizzle column types via `getTableColumns()`: ISO strings / epoch numbers → `Date` for timestamp-mode columns. Schema-driven, so any future timestamp column is covered automatically.
- Backups created by the previous exporter carry unrecoverable `{}` in date columns; restore drops those keys and lets schema defaults supply a fresh timestamp instead of failing the whole restore.

## Tests

- Round-trip test (`exportConfig` → JSON serialize → delete row → `restoreConfig`) fails with the exact production error before the fix and passes after.
- Legacy `{}`-backup test covers already-corrupted files.
- Full suite: 2815 passed, 0 failed. Prettier/eslint/svelte-check clean.