### PR TITLE
feat(api): local library file streaming, reconciliation fixes, and benchmark improvements

### DIFF
--- a/scripts/benchmark-scan.ts
+++ b/scripts/benchmark-scan.ts
@@ -1,10 +1,10 @@
 /**
- * Benchmark: Large Library Scan
+ * Benchmark: Large Library Scan + Reconciliation
  *
  * Purpose:
  *   Measures scan performance and event-loop responsiveness against a synthetic
- *   library of configurable size. Run this before/after changes to disk-scan.ts
- *   or db/index.ts to catch regressions on large libraries.
+ *   library of configurable size. Run this before/after changes to disk-scan.ts,
+ *   ReconciliationService.ts, or db/index.ts to catch regressions on large libraries.
  *
  *   It creates a temporary fixture directory and an isolated SQLite database so
  *   the production database is never touched. Both are deleted after the run
@@ -14,54 +14,72 @@
  *   npx tsx scripts/benchmark-scan.ts [options]
  *
  * Options:
- *   --files N    Total number of files to generate (default: 63000)
- *   --tv         TV-only mode: generate a series tree only
- *   --movie      Movie-only mode: generate a flat movie tree only
- *   --keep       Skip cleanup — leave fixture dirs and temp DB for inspection
+ *   --files N      Total number of files/items (default: 63000)
+ *   --tv           TV-only mode: generate a series tree only (scan mode)
+ *   --movie        Movie-only mode: generate a flat movie tree only (scan mode)
+ *   --reconcile    Reconcile benchmark: seed DB rows and run ReconciliationService
+ *   --keep         Skip cleanup: leave fixture dirs and temp DB for inspection
  *
- * Example runs:
+ * Example runs (scan benchmark):
  *   npx tsx scripts/benchmark-scan.ts --files 63000            # mixed (default)
  *   npx tsx scripts/benchmark-scan.ts --files 63000 --tv       # TV only
  *   npx tsx scripts/benchmark-scan.ts --files 63000 --movie    # movies only
- *   npx tsx scripts/benchmark-scan.ts --files 125000 --keep
  *
- * Output:
+ * Example runs (reconcile benchmark):
+ *   npx tsx scripts/benchmark-scan.ts --reconcile              # 63000 items (~31k movies + ~31k TV files)
+ *   npx tsx scripts/benchmark-scan.ts --reconcile --files 100000
+ *
+ * Output (scan):
  *   - Fixture generation time
  *   - Per-scan wall-clock time and file counts
  *   - Event loop lag across all scans (p50 / p99 / max)
  *   - DB size after all scans and after incremental_vacuum
  *
+ * Output (reconcile):
+ *   - Seeding time
+ *   - Three passes: insert-only, update-only, partial-insert
+ *   - Per-pass wall-clock time + event-loop lag (p50 / p99 / max)
+ *   - Item counts per pass (inserted / updated / deleted)
+ *   - DB size after all passes
+ *
  * Notes:
- *   - Generated files are empty .strm stubs; they pass the size filter because
+ *   - Generated scan files are empty .strm stubs; they pass the size filter because
  *     disk-scan.ts exempts .strm files from the minimum size check.
  *
- *   - What IS benchmarked by default:
+ *   - What IS benchmarked by the scan mode:
  *       The full filesystem walk + DB insert path. Every generated file is
  *       discovered, parsed, and written to unmatched_files. This covers the
  *       hot path in DiskScanService and the setImmediate yield points.
  *
- *   - What is NOT benchmarked by default (the reconcile phase):
+ *   - What IS benchmarked by --reconcile:
+ *       The full ReconciliationService.reconcile() path: loading all local rows,
+ *       chunked upsert transactions, stale cleanup, and event-loop yield behavior.
+ *       Three passes exercise the insert path (cold start), the update path
+ *       (steady state), and a mixed insert+update path (post-import trigger).
+ *
+ *   - What is NOT benchmarked by scan mode (DiskScanService's file-presence reconcile):
  *       After the walk, scanRootFolder calls reconcileMoviePresence /
  *       reconcileEpisodePresence to sync movies.hasFile and episodes.hasFile.
- *       It is a no-op here because no movies/series rows exist
- *       in the temp DB; reconcile only operates on matched media.
+ *       It is a no-op here because no movies/series rows exist in the temp DB;
+ *       those reconcile methods only update rows for matched media.
  *
- *   - To benchmark the reconcile phase:
- *       1. Run the benchmark once with --keep to preserve the fixture files
- *          and temp DB:
- *              npx tsx scripts/benchmark-scan.ts --files 63000 --keep
- *       2. Note the fixture dir and temp DB paths printed in the header.
- *       3. Using sqlite3 or a script, insert rows into the `movies` table
- *          (and `movie_files` for the movie root folder) or the `series` /
- *          `seasons` / `episodes` / `episode_files` tables (for the TV root
- *          folder) with paths that match the generated fixture filenames.
- *          Each movie_file.relative_path should match the .strm filename;
- *          each episode_file.series_id must reference a real series row.
- *       4. Re-run the scan against the same temp DB by temporarily hardcoding
- *          DATA_DIR to the preserved data dir and the root folder ID.
+ *       To benchmark DiskScanService's file-presence reconcile (a separate code
+ *       path from ReconciliationService), do the following manually:
+ *         1. Run the scan benchmark with --keep to preserve files and the temp DB:
+ *                npx tsx scripts/benchmark-scan.ts --files 63000 --keep
+ *         2. Note the fixture dir and temp DB paths printed in the header.
+ *         3. Using sqlite3, insert rows into the movies table (+ movie_files for
+ *            the movie root folder) or the series / seasons / episodes /
+ *            episode_files tables (for the TV root folder) whose paths match the
+ *            generated fixture filenames.
+ *         4. Re-run the scan against the same temp DB by temporarily hardcoding
+ *            DATA_DIR to the preserved data dir and the root folder ID.
+ *       DiskScanService's reconcile will then find real rows to process and
+ *       will exercise the bulk hasFile update transactions in disk-scan.ts.
  *
- * 		Reconcile will then have real rows to process and will exercise the
- * 		bulk hasFile update transactions.
+ *       Note: this is distinct from ReconciliationService.reconcile() (tested
+ *       by --reconcile), which syncs the storage_items table rather than the
+ *       hasFile flags on movies/episodes.
  */
 
 import { mkdir, rm, writeFile, stat } from 'node:fs/promises';
@@ -69,12 +87,14 @@ import { join } from 'node:path';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
 import { tmpdir } from 'node:os';
 import { parseArgs } from 'node:util';
+import { randomUUID } from 'node:crypto';
 
 const { values: argv } = parseArgs({
 	options: {
 		files: { type: 'string', default: '63000' },
 		tv: { type: 'boolean', default: false },
 		movie: { type: 'boolean', default: false },
+		reconcile: { type: 'boolean', default: false },
 		keep: { type: 'boolean', default: false }
 	}
 });
@@ -83,6 +103,7 @@ const fileCount = parseInt(argv.files as string, 10);
 const isTV = argv.tv as boolean;
 const isMovie = argv.movie as boolean;
 const isMix = !isTV && !isMovie;
+const isReconcile = argv.reconcile as boolean;
 const keep = argv.keep as boolean;
 
 if (isNaN(fileCount) || fileCount < 1) {
@@ -91,6 +112,10 @@ if (isNaN(fileCount) || fileCount < 1) {
 }
 if (isTV && isMovie) {
 	console.error('--tv and --movie are mutually exclusive');
+	process.exit(1);
+}
+if (isReconcile && (isTV || isMovie)) {
+	console.error('--reconcile cannot be combined with --tv or --movie');
 	process.exit(1);
 }
 
@@ -108,11 +133,14 @@ process.env.LOG_LEVEL = 'silent';
 
 const { initializeDatabase, sqlite } = await import('../src/lib/server/db/index.js');
 const { db } = await import('../src/lib/server/db/index.js');
-const { rootFolders } = await import('../src/lib/server/db/schema.js');
+const { rootFolders, movies, movieFiles, series, episodeFiles } =
+	await import('../src/lib/server/db/schema.js');
 const { diskScanService } = await import('../src/lib/server/library/disk-scan.js');
+const { getReconciliationService } =
+	await import('../src/lib/server/storage/reconciliation/ReconciliationService.js');
 
 // ---------------------------------------------------------------------------
-// Fixture generation
+// Fixture generation (scan mode)
 // ---------------------------------------------------------------------------
 
 async function generateMovieFixtures(dir: string, count: number): Promise<void> {
@@ -153,6 +181,77 @@ async function generateTvFixtures(dir: string, count: number): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// DB seeding (reconcile mode)
+// ---------------------------------------------------------------------------
+
+const SEED_BATCH = 100; // rows per transaction — stays well within SQLite's variable limit
+const FIXED_DATE = new Date().toISOString();
+const EPISODES_PER_SERIES = 50;
+
+function seedMoviesSync(count: number, startIdx: number = 0): void {
+	for (let i = startIdx; i < startIdx + count; i += SEED_BATCH) {
+		const end = Math.min(i + SEED_BATCH, startIdx + count);
+		db.transaction((tx) => {
+			for (let j = i; j < end; j++) {
+				const movieId = randomUUID();
+				tx.insert(movies)
+					.values({
+						id: movieId,
+						tmdbId: 1_000_000 + j,
+						title: `Benchmark Movie ${j}`,
+						path: `/bench/movies/movie-${j}`
+					})
+					.run();
+				tx.insert(movieFiles)
+					.values({
+						movieId,
+						relativePath: `movie-${j}.mkv`,
+						dateAdded: FIXED_DATE
+					})
+					.run();
+			}
+		});
+	}
+}
+
+function seedSeriesSync(tvFileCount: number, startFileIdx: number = 0): void {
+	const seriesNeeded = Math.ceil(tvFileCount / EPISODES_PER_SERIES);
+	let fileIdx = startFileIdx;
+
+	for (let s = 0; s < seriesNeeded && fileIdx < startFileIdx + tvFileCount; s++) {
+		const seriesId = randomUUID();
+		const globalSeriesIdx = Math.floor(startFileIdx / EPISODES_PER_SERIES) + s;
+		db.transaction((tx) => {
+			tx.insert(series)
+				.values({
+					id: seriesId,
+					tmdbId: 2_000_000 + globalSeriesIdx,
+					title: `Benchmark Series ${globalSeriesIdx}`,
+					path: `/bench/tv/series-${globalSeriesIdx}`
+				})
+				.run();
+			for (
+				let ep = 0;
+				ep < EPISODES_PER_SERIES && fileIdx < startFileIdx + tvFileCount;
+				ep++, fileIdx++
+			) {
+				tx.insert(episodeFiles)
+					.values({
+						seriesId,
+						seasonNumber: Math.floor(ep / 24) + 1,
+						// Empty episodeIds → file-granularity fallback in loadLocalRows;
+						// no episodes table rows needed, which keeps seeding fast.
+						episodeIds: [] as string[],
+						relativePath: `series-${globalSeriesIdx}-ep-${ep}.mkv`,
+						dateAdded: FIXED_DATE
+					})
+					.run();
+			}
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -182,8 +281,125 @@ async function runScan(rootFolderId: string, label: string): Promise<ScanSummary
 	};
 }
 
+interface ReconcileSummary {
+	label: string;
+	durationMs: number;
+	itemsInserted: number;
+	itemsUpdated: number;
+	itemsDeleted: number;
+	linksUpserted: number;
+	errorCount: number;
+	p50Ms: number;
+	p99Ms: number;
+	maxMs: number;
+}
+
+async function runReconcile(label: string): Promise<ReconcileSummary> {
+	process.stdout.write(`\n[${label}] Reconcile started...`);
+	const histogram = monitorEventLoopDelay({ resolution: 10 });
+	histogram.enable();
+	const result = await getReconciliationService().reconcile();
+	histogram.disable();
+	process.stdout.write(` done (${(result.durationMs / 1000).toFixed(1)}s)\n`);
+	return {
+		label,
+		durationMs: result.durationMs,
+		itemsInserted: result.itemsInserted,
+		itemsUpdated: result.itemsUpdated,
+		itemsDeleted: result.itemsDeleted,
+		linksUpserted: result.linksUpserted,
+		errorCount: result.errorCount,
+		p50Ms: Math.round(histogram.percentile(50) / 1e6),
+		p99Ms: Math.round(histogram.percentile(99) / 1e6),
+		maxMs: Math.round(histogram.max / 1e6)
+	};
+}
+
 // ---------------------------------------------------------------------------
-// Main
+// Main — reconcile benchmark
+// ---------------------------------------------------------------------------
+
+if (isReconcile) {
+	const movieCount = Math.floor(fileCount / 2);
+	const tvCount = fileCount - movieCount;
+	const extraMovies = Math.floor(movieCount * 0.1);
+	const extraTv = Math.floor(tvCount * 0.1);
+	const extraTotal = extraMovies + extraTv;
+
+	console.log('\nCinephage Reconcile Benchmark');
+	console.log('-'.repeat(56));
+	console.log(
+		`Items:       ${fileCount.toLocaleString()} (${movieCount.toLocaleString()} movies + ${tvCount.toLocaleString()} TV files)`
+	);
+	console.log(
+		`Extra (pass 3): ${extraTotal.toLocaleString()} (${extraMovies.toLocaleString()} movies + ${extraTv.toLocaleString()} TV files)`
+	);
+	console.log(`Keep files:  ${keep}`);
+	console.log(`Temp DB:     ${dataDir}/cinephage.db`);
+	console.log('-'.repeat(56));
+
+	process.stdout.write('\nInitializing temp database... ');
+	await initializeDatabase();
+	console.log('done');
+
+	process.stdout.write(
+		`Seeding ${movieCount.toLocaleString()} movies + ${tvCount.toLocaleString()} TV episode files... `
+	);
+	const seedStart = Date.now();
+	seedMoviesSync(movieCount);
+	seedSeriesSync(tvCount);
+	console.log(`done (${((Date.now() - seedStart) / 1000).toFixed(1)}s)`);
+
+	// Pass 1: all inserts (cold start — storageItems is empty)
+	const pass1 = await runReconcile('Pass 1 - insert');
+
+	// Pass 2: all updates (steady state — every key already exists)
+	const pass2 = await runReconcile('Pass 2 - update');
+
+	// Pass 3: seed 10% more items, then reconcile (mix of inserts + updates)
+	process.stdout.write(`\nSeeding ${extraTotal.toLocaleString()} additional items (10%)... `);
+	const extra2Start = Date.now();
+	seedMoviesSync(extraMovies, movieCount);
+	seedSeriesSync(extraTv, tvCount);
+	console.log(`done (${((Date.now() - extra2Start) / 1000).toFixed(1)}s)`);
+
+	const pass3 = await runReconcile('Pass 3 - partial insert');
+
+	// Results
+	const dbPath = join(dataDir, 'cinephage.db');
+	const sizeBefore = (await stat(dbPath)).size;
+	sqlite.pragma('incremental_vacuum');
+	const sizeAfter = (await stat(dbPath)).size;
+
+	console.log('\nResults');
+	console.log('-'.repeat(56));
+	for (const s of [pass1, pass2, pass3]) {
+		console.log(`\n[${s.label}]`);
+		console.log(`  Duration:       ${(s.durationMs / 1000).toFixed(2)}s`);
+		console.log(`  Event loop lag: p50 ${s.p50Ms}ms  p99 ${s.p99Ms}ms  max ${s.maxMs}ms`);
+		console.log(
+			`  Items:          ${s.itemsInserted} inserted  ${s.itemsUpdated} updated  ${s.itemsDeleted} deleted  ${s.linksUpserted} links`
+		);
+		if (s.errorCount > 0) console.log(`  [WARN] ${s.errorCount} item errors`);
+	}
+	console.log(`\nDB size after reconcile:  ${fmtSize(sizeBefore)}`);
+	console.log(`DB size after vacuum:     ${fmtSize(sizeAfter)}`);
+	console.log('-'.repeat(56));
+
+	if (!keep) {
+		process.stdout.write('\nCleaning up temp DB... ');
+		await rm(dataDir, { recursive: true, force: true });
+		console.log('done');
+	} else {
+		console.log('\n--keep passed: temp DB left for inspection.');
+	}
+
+	console.log();
+	process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Main — scan benchmark
 // ---------------------------------------------------------------------------
 
 const mode = isMix ? 'Mix (movies + TV)' : isTV ? 'TV only' : 'Movies only';
@@ -191,7 +407,7 @@ const movieCount = isMix ? Math.floor(fileCount / 2) : isMovie ? fileCount : 0;
 const tvCount = isMix ? fileCount - movieCount : isTV ? fileCount : 0;
 
 console.log('\nCinephage Scan Benchmark');
-console.log('─'.repeat(48));
+console.log('-'.repeat(48));
 console.log(`Files:       ${fileCount.toLocaleString()} (${mode})`);
 if (isMix) {
 	console.log(`  Movies:    ${movieCount.toLocaleString()}`);
@@ -199,7 +415,7 @@ if (isMix) {
 }
 console.log(`Keep files:  ${keep}`);
 console.log(`Temp DB:     ${dataDir}/cinephage.db`);
-console.log('─'.repeat(48));
+console.log('-'.repeat(48));
 
 // 1. Generate fixtures
 process.stdout.write(`\nGenerating ${fileCount.toLocaleString()} fixture files... `);
@@ -276,7 +492,7 @@ console.log(`\nEvent loop lag (across all scans):`);
 console.log(`  p50: ${p50}ms   p99: ${p99}ms   max: ${maxLag}ms`);
 console.log(`\nDB size after scan:    ${fmtSize(sizeBefore)}`);
 console.log(`DB size after vacuum:  ${fmtSize(sizeAfter)}`);
-console.log('─'.repeat(48));
+console.log('-'.repeat(48));
 
 // 8. Cleanup
 const dirsToRemove = isMix ? [movieFixtureDir, tvFixtureDir] : [fixtureDir];

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -256,12 +256,13 @@ const customHandler: Handle = async ({ event, resolve }) => {
 					});
 
 					if (!verifyResult.valid) {
-						// Fall back to full-access key check (main API key)
+						// Fall back to main API key check. Main keys are created with
+						// { default: ['*'] }.
 						verifyResult = await auth.api.verifyApiKey({
 							body: {
 								key: apiKey,
 								permissions: {
-									'*': ['*']
+									default: ['*']
 								}
 							}
 						});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -135,6 +135,9 @@ const customHandler: Handle = async ({ event, resolve }) => {
 				if (path.startsWith('/api/streaming/usenet/')) {
 					return true;
 				}
+				if (path.startsWith('/api/streaming/library/')) {
+					return true;
+				}
 				return false;
 			}
 
@@ -242,7 +245,8 @@ const customHandler: Handle = async ({ event, resolve }) => {
 				}
 
 				try {
-					const verifyResult = await auth.api.verifyApiKey({
+					// Accept either a streaming-scoped key or a full-access (main) key
+					let verifyResult = await auth.api.verifyApiKey({
 						body: {
 							key: apiKey,
 							permissions: {
@@ -252,13 +256,25 @@ const customHandler: Handle = async ({ event, resolve }) => {
 					});
 
 					if (!verifyResult.valid) {
+						// Fall back to full-access key check (main API key)
+						verifyResult = await auth.api.verifyApiKey({
+							body: {
+								key: apiKey,
+								permissions: {
+									'*': ['*']
+								}
+							}
+						});
+					}
+
+					if (!verifyResult.valid) {
 						requestLogger.warn(
 							{
 								logDomain: 'auth',
 								endpoint: pathname,
 								error: verifyResult.error?.message || 'Invalid permissions'
 							},
-							'[Auth] Main API key attempted to access streaming endpoint'
+							'[Auth] API key does not have streaming or full-access permissions'
 						);
 
 						return json(

--- a/src/lib/server/blocklist/BlocklistService.ts
+++ b/src/lib/server/blocklist/BlocklistService.ts
@@ -258,7 +258,9 @@ class BlocklistService {
 
 	async removeFromBlocklistByIds(ids: string[]): Promise<void> {
 		if (ids.length === 0) return;
-		await db.delete(blocklist).where(inArray(blocklist.id, ids));
+		for (let i = 0; i < ids.length; i += 500) {
+			await db.delete(blocklist).where(inArray(blocklist.id, ids.slice(i, i + 500)));
+		}
 	}
 
 	async updateExpiry(id: string, expiresInHours: number | null): Promise<void> {

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -25,6 +25,9 @@ try {
 	sqlite.pragma('wal_autocheckpoint = 4000');
 	sqlite.pragma('temp_store = MEMORY');
 	sqlite.pragma('foreign_keys = ON');
+	// 32MB page cache: reduces re-reads of hot tables (episodes, storage_items, episode_files)
+	// during reconcile and scan passes on large libraries.
+	sqlite.pragma('cache_size = -32000');
 } catch (error) {
 	logger.warn(
 		{

--- a/src/lib/server/storage/reconciliation/ReconciliationService.ts
+++ b/src/lib/server/storage/reconciliation/ReconciliationService.ts
@@ -34,11 +34,19 @@ type SourceRow = {
 	libraryId: string | null;
 };
 
+const CHUNK_SIZE = 500;
+
+function yield_(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
 class ReconciliationService extends EventEmitter implements BackgroundService {
 	readonly name = 'ReconciliationService';
 	private _status: ServiceStatus = 'pending';
 	private _error?: Error;
 	private reconcileLock = false;
+	private pendingTrigger = false;
+	private debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private listenersAttached = false;
 	private attachPromise: Promise<void> | null = null;
 
@@ -104,8 +112,8 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 					logger.error('[ReconciliationService] failed to subscribe to syncComplete', e);
 				}),
 			// Subscribe to library data mutations (movie/series/episode/season CRUD,
-			// root-folder and library changes). The reconcileLock coalesces concurrent
-			// triggers, so a 50-item batch delete produces one reconcile run, not 50.
+			// root-folder and library changes). Triggers are debounced so a burst of
+			// imports (e.g. 6 episodes) coalesces into one reconcile run.
 			import('$lib/server/library/LibraryMediaEvents.js')
 				.then(({ libraryMediaEvents }) => {
 					libraryMediaEvents.onLibraryDataChanged(this.handleTrigger);
@@ -142,20 +150,38 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 			});
 	}
 
+	// Debounce triggers so a burst of library mutations (e.g. importing 6 episodes
+	// back-to-back) coalesces into a single reconcile run. If a reconcile is already
+	// running when the timer fires, set pendingTrigger so we re-run immediately after.
 	private handleTrigger = (): void => {
-		this.reconcile().catch((err) => {
-			logger.error('[ReconciliationService] reconcile failed after trigger', err);
-		});
+		if (this.debounceTimer) clearTimeout(this.debounceTimer);
+		this.debounceTimer = setTimeout(() => {
+			this.debounceTimer = null;
+			if (this.reconcileLock) {
+				this.pendingTrigger = true;
+				return;
+			}
+			this.reconcile().catch((err) => {
+				logger.error('[ReconciliationService] reconcile failed after trigger', err);
+			});
+		}, 1500);
 	};
 
 	/**
 	 * Run a full reconciliation pass. Idempotent; safe to call repeatedly.
-	 * Acquires a lock so concurrent triggers coalesce into one run.
+	 *
+	 * The reconcile loop runs in chunks of 500 items, yielding the event loop
+	 * between chunks via setImmediate. This keeps import processing and HTTP
+	 * requests responsive even on libraries with tens of thousands of items.
+	 * If a new trigger arrives while a reconcile is in-flight, pendingTrigger
+	 * is set and a follow-up run starts immediately after the current one
+	 * finishes, ensuring no library mutations are silently dropped.
 	 */
 	async reconcile(): Promise<ReconcileResult> {
 		const start = Date.now();
 		if (this.reconcileLock) {
-			logger.debug('[ReconciliationService] reconcile already in progress; skipping');
+			this.pendingTrigger = true;
+			logger.debug('[ReconciliationService] reconcile already in progress; deferring');
 			return {
 				itemsUpserted: 0,
 				itemsInserted: 0,
@@ -168,289 +194,304 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 			};
 		}
 		this.reconcileLock = true;
+		this.pendingTrigger = false;
 		try {
+			// Select only the columns needed for reconcile logic to reduce memory
+			// pressure when storage_items grows to tens of thousands of rows.
 			const [localRows, serverItemRows, existingItems, existingLinks] = await Promise.all([
 				this.loadLocalRows(),
 				this.loadServerItems(),
-				db.select().from(storageItems),
-				db.select().from(storageItemServerLinks)
+				db
+					.select({
+						id: storageItems.id,
+						itemType: storageItems.itemType,
+						tmdbId: storageItems.tmdbId,
+						seasonNumber: storageItems.seasonNumber,
+						episodeNumber: storageItems.episodeNumber
+					})
+					.from(storageItems),
+				db
+					.select({
+						storageItemId: storageItemServerLinks.storageItemId,
+						serverId: storageItemServerLinks.serverId
+					})
+					.from(storageItemServerLinks)
 			]);
 
-			// All writes run inside a single transaction so a 10k-item library
-			// commits once instead of issuing 20k+ autocommit round-trips, and a
-			// crash mid-reconcile cannot leave partial state. Note: better-sqlite3
-			// transactions are synchronous, so the callback must not be async —
-			// we use the sync query methods (.run()/.all()) on `tx`.
-			//
-			// SCALING NOTE: The entire transaction runs synchronously and blocks
-			// the Node event loop for its duration. For typical libraries (<1k items)
-			// this is <100ms — unnoticeable. For large libraries (10k+ items) the
-			// blocking window grows to ~500ms-2s, which delays request handling.
-			// If this becomes a problem: refactor to chunked transactions (batches
-			// of ~500 items, each in its own short transaction, yield via setImmediate
-			// between batches). See docs/superpowers/plans/2026-07-01-storage-overhaul-phase-2-reconciliation.md.
-			const result = db.transaction((tx) => {
-				// Desired state from local sources: Map<logicalKey, SourceRow>
-				const desired = new Map<string, SourceRow>();
-				for (const row of localRows) {
-					if (row.tmdbId === null) continue;
-					const key = logicalKey(row.itemType, row.tmdbId, row.seasonNumber, row.episodeNumber);
-					if (!desired.has(key)) desired.set(key, row); // first row wins (matches existing dedup)
-				}
+			// ---- Build all read-only maps before touching the DB ----
 
-				// Server items: Map<logicalKey, serverItem[]>
-				const serverByKey = new Map<string, Array<typeof mediaServerSyncedItems.$inferSelect>>();
-				for (const s of serverItemRows) {
-					const key = logicalKey(
-						s.itemType as 'movie' | 'episode',
-						s.tmdbId,
-						s.seasonNumber,
-						s.episodeNumber
-					);
-					if (!serverByKey.has(key)) serverByKey.set(key, []);
-					serverByKey.get(key)!.push(s);
-				}
+			const desired = new Map<string, SourceRow>();
+			for (const row of localRows) {
+				if (row.tmdbId === null) continue;
+				const key = logicalKey(row.itemType, row.tmdbId, row.seasonNumber, row.episodeNumber);
+				if (!desired.has(key)) desired.set(key, row); // first row wins (matches existing dedup)
+			}
 
-				// File-granularity server coverage: media servers report one item
-				// per physical file, so a combined file (e.g. S02E12-E13) appears
-				// under a single episode number. Without this, every episode after
-				// the first in the range would have no 1:1 server counterpart and
-				// be flagged as "missing from your media server". A server episode
-				// item (series tmdbId + season + episode number) covers a local file
-				// whose episodeIds include that number.
-				const filesByTmdbSeason = new Map<
-					string,
-					Array<{ fileId: string; episodeNumbers: Set<number> }>
-				>();
-				for (const row of localRows) {
-					if (
-						row.itemType !== 'episode' ||
-						!row.episodeFileId ||
-						row.tmdbId === null ||
-						row.seasonNumber === null ||
-						row.episodeNumber === null
-					) {
-						continue;
-					}
-					const seasonKey = `${row.tmdbId}:${row.seasonNumber}`;
-					let files = filesByTmdbSeason.get(seasonKey);
-					if (!files) {
-						files = [];
-						filesByTmdbSeason.set(seasonKey, files);
-					}
-					let fileEntry = files.find((f) => f.fileId === row.episodeFileId);
-					if (!fileEntry) {
-						fileEntry = { fileId: row.episodeFileId, episodeNumbers: new Set() };
-						files.push(fileEntry);
-					}
-					fileEntry.episodeNumbers.add(row.episodeNumber);
-				}
-				const serverItemsByFile = new Map<
-					string,
-					Array<typeof mediaServerSyncedItems.$inferSelect>
-				>();
-				for (const s of serverItemRows) {
-					if (
-						s.itemType !== 'episode' ||
-						s.tmdbId === null ||
-						s.seasonNumber === null ||
-						s.episodeNumber === null
-					) {
-						continue;
-					}
-					const files = filesByTmdbSeason.get(`${s.tmdbId}:${s.seasonNumber}`);
-					if (!files) {
-						continue;
-					}
-					for (const file of files) {
-						if (!file.episodeNumbers.has(s.episodeNumber)) {
-							continue;
-						}
-						const arr = serverItemsByFile.get(file.fileId);
-						if (arr) {
-							arr.push(s);
-						} else {
-							serverItemsByFile.set(file.fileId, [s]);
-						}
-					}
-				}
-
-				// Existing rows indexed by logical key
-				const existingByKey = new Map<string, typeof storageItems.$inferSelect>();
-				for (const item of existingItems) {
-					const key = logicalKey(
-						item.itemType as 'movie' | 'episode',
-						item.tmdbId,
-						item.seasonNumber,
-						item.episodeNumber
-					);
-					existingByKey.set(key, item);
-				}
-				const existingLinkIds = new Set(
-					existingLinks.map((l) => `${l.storageItemId}:${l.serverId}`)
+			const serverByKey = new Map<string, Array<typeof mediaServerSyncedItems.$inferSelect>>();
+			for (const s of serverItemRows) {
+				const key = logicalKey(
+					s.itemType as 'movie' | 'episode',
+					s.tmdbId,
+					s.seasonNumber,
+					s.episodeNumber
 				);
+				if (!serverByKey.has(key)) serverByKey.set(key, []);
+				serverByKey.get(key)!.push(s);
+			}
 
-				const keepItemIds = new Set<string>();
-				let itemsInserted = 0;
-				let itemsUpdated = 0;
-				let linksUpserted = 0;
-				let errorCount = 0;
-				const now = new Date().toISOString();
-
-				const allKeys = new Set<string>([...desired.keys(), ...serverByKey.keys()]);
-
-				for (const key of allKeys) {
-					try {
-						const localRow = desired.get(key) ?? null;
-						let serverItems = serverByKey.get(key) ?? [];
-						// Fall back to file-granularity coverage for episodes of a
-						// multi-episode file: the file exists on the server under a
-						// sibling episode number, so this episode is satisfied too.
-						if (serverItems.length === 0 && localRow?.episodeFileId) {
-							serverItems = serverItemsByFile.get(localRow.episodeFileId) ?? [];
-						}
-						const existing = existingByKey.get(key);
-
-						// Preserve any pre-existing row even if this iteration later
-						// throws, so a transient update failure doesn't cause a
-						// stale-cleanup deletion.
-						if (existing) keepItemIds.add(existing.id);
-
-						const hasLocal = localRow !== null;
-						const hasServer = serverItems.length > 0;
-						const sourceSystem = hasLocal && hasServer ? 'both' : hasLocal ? 'local' : 'server';
-						const matchConfidence = hasLocal ? 'exact' : 'id';
-
-						const title = localRow?.title ?? serverItems[0]?.title ?? 'Unknown';
-						const year = localRow?.year ?? serverItems[0]?.year ?? null;
-						const seriesName = serverItems[0]?.seriesName ?? null;
-						const itemType = (localRow?.itemType ?? serverItems[0]?.itemType ?? 'movie') as
-							'movie' | 'episode' | 'series' | 'season';
-						const tmdbId = localRow?.tmdbId ?? serverItems[0]?.tmdbId ?? null;
-						const tvdbId = serverItems[0]?.tvdbId ?? null;
-						const imdbId = serverItems[0]?.imdbId ?? null;
-						// Movies must never carry season/episode values: the unique index and
-						// logicalKey match movies on tmdbId alone, and stray server-side
-						// metadata (e.g. Jellyfin reporting IndexNumber=1 on a movie) would
-						// otherwise create a second storage_items row for the same film.
-						const isMovie = itemType === 'movie';
-						const seasonNumber = isMovie
-							? null
-							: (localRow?.seasonNumber ?? serverItems[0]?.seasonNumber ?? null);
-						const episodeNumber = isMovie
-							? null
-							: (localRow?.episodeNumber ?? serverItems[0]?.episodeNumber ?? null);
-
-						let itemId: string;
-						if (existing) {
-							itemId = existing.id;
-							tx.update(storageItems)
-								.set({
-									title,
-									year,
-									seriesName,
-									itemType,
-									tmdbId,
-									tvdbId,
-									imdbId,
-									seasonNumber,
-									episodeNumber,
-									movieFileId: localRow?.movieFileId ?? null,
-									episodeFileId: localRow?.episodeFileId ?? null,
-									rootFolderId: localRow?.rootFolderId ?? null,
-									libraryId: localRow?.libraryId ?? null,
-									sourceSystem,
-									matchConfidence,
-									lastReconciledAt: now
-								})
-								.where(eq(storageItems.id, existing.id))
-								.run();
-							itemsUpdated++;
-						} else {
-							const [inserted] = tx
-								.insert(storageItems)
-								.values({
-									itemType,
-									tmdbId,
-									tvdbId,
-									imdbId,
-									title,
-									year,
-									seriesName,
-									seasonNumber,
-									episodeNumber,
-									movieFileId: localRow?.movieFileId ?? null,
-									episodeFileId: localRow?.episodeFileId ?? null,
-									rootFolderId: localRow?.rootFolderId ?? null,
-									libraryId: localRow?.libraryId ?? null,
-									sourceSystem,
-									matchConfidence,
-									firstSeenAt: now,
-									lastReconciledAt: now
-								})
-								.returning({ id: storageItems.id })
-								.all();
-							itemId = inserted.id;
-							itemsInserted++;
-						}
-						keepItemIds.add(itemId);
-
-						// Upsert server links
-						for (const s of serverItems) {
-							const linkKey = `${itemId}:${s.serverId}`;
-							if (!existingLinkIds.has(linkKey)) {
-								tx.insert(storageItemServerLinks)
-									.values({
-										storageItemId: itemId,
-										serverId: s.serverId,
-										syncedItemId: s.id,
-										lastSeenAt: now
-									})
-									.onConflictDoNothing()
-									.run();
-							} else {
-								tx.update(storageItemServerLinks)
-									.set({ lastSeenAt: now, syncedItemId: s.id })
-									.where(
-										and(
-											eq(storageItemServerLinks.storageItemId, itemId),
-											eq(storageItemServerLinks.serverId, s.serverId)
-										)
-									)
-									.run();
-							}
-							linksUpserted++;
-						}
-					} catch (itemError) {
-						// Isolate per-item failures so one bad row can't abort the
-						// whole run (and re-abort on every subsequent run).
-						errorCount++;
-						logger.warn(`[ReconciliationService] failed to reconcile key ${key}`, {
-							error: itemError instanceof Error ? itemError : new Error(String(itemError))
-						});
+			// File-granularity server coverage: media servers report one item
+			// per physical file, so a combined file (e.g. S02E12-E13) appears
+			// under a single episode number. Without this, every episode after
+			// the first in the range would have no 1:1 server counterpart and
+			// be flagged as "missing from your media server". A server episode
+			// item (series tmdbId + season + episode number) covers a local file
+			// whose episodeIds include that number.
+			const filesByTmdbSeason = new Map<
+				string,
+				Array<{ fileId: string; episodeNumbers: Set<number> }>
+			>();
+			for (const row of localRows) {
+				if (
+					row.itemType !== 'episode' ||
+					!row.episodeFileId ||
+					row.tmdbId === null ||
+					row.seasonNumber === null ||
+					row.episodeNumber === null
+				) {
+					continue;
+				}
+				const seasonKey = `${row.tmdbId}:${row.seasonNumber}`;
+				let files = filesByTmdbSeason.get(seasonKey);
+				if (!files) {
+					files = [];
+					filesByTmdbSeason.set(seasonKey, files);
+				}
+				let fileEntry = files.find((f) => f.fileId === row.episodeFileId);
+				if (!fileEntry) {
+					fileEntry = { fileId: row.episodeFileId, episodeNumbers: new Set() };
+					files.push(fileEntry);
+				}
+				fileEntry.episodeNumbers.add(row.episodeNumber);
+			}
+			const serverItemsByFile = new Map<
+				string,
+				Array<typeof mediaServerSyncedItems.$inferSelect>
+			>();
+			for (const s of serverItemRows) {
+				if (
+					s.itemType !== 'episode' ||
+					s.tmdbId === null ||
+					s.seasonNumber === null ||
+					s.episodeNumber === null
+				) {
+					continue;
+				}
+				const files = filesByTmdbSeason.get(`${s.tmdbId}:${s.seasonNumber}`);
+				if (!files) {
+					continue;
+				}
+				for (const file of files) {
+					if (!file.episodeNumbers.has(s.episodeNumber)) {
 						continue;
 					}
+					const arr = serverItemsByFile.get(file.fileId);
+					if (arr) {
+						arr.push(s);
+					} else {
+						serverItemsByFile.set(file.fileId, [s]);
+					}
 				}
+			}
 
-				// Stale cleanup: remove rows no longer present in any source
-				let itemsDeleted = 0;
-				const staleIds = existingItems.filter((i) => !keepItemIds.has(i.id)).map((i) => i.id);
-				if (staleIds.length > 0) {
-					tx.delete(storageItems).where(inArray(storageItems.id, staleIds)).run();
-					itemsDeleted = staleIds.length;
+			// Existing rows indexed by logical key
+			const existingByKey = new Map<string, { id: string }>();
+			for (const item of existingItems) {
+				const key = logicalKey(
+					item.itemType as 'movie' | 'episode',
+					item.tmdbId,
+					item.seasonNumber,
+					item.episodeNumber
+				);
+				existingByKey.set(key, item);
+			}
+			const existingLinkIds = new Set(existingLinks.map((l) => `${l.storageItemId}:${l.serverId}`));
+
+			const keepItemIds = new Set<string>();
+			let itemsInserted = 0;
+			let itemsUpdated = 0;
+			let linksUpserted = 0;
+			let errorCount = 0;
+			const now = new Date().toISOString();
+
+			const allKeys = [...new Set<string>([...desired.keys(), ...serverByKey.keys()])];
+
+			// Process in chunks, yielding between each to keep the event loop
+			// responsive during large library reconciles.
+			for (let chunkStart = 0; chunkStart < allKeys.length; chunkStart += CHUNK_SIZE) {
+				const chunk = allKeys.slice(chunkStart, chunkStart + CHUNK_SIZE);
+				db.transaction((tx) => {
+					for (const key of chunk) {
+						try {
+							const localRow = desired.get(key) ?? null;
+							let serverItems = serverByKey.get(key) ?? [];
+							// Fall back to file-granularity coverage for episodes of a
+							// multi-episode file: the file exists on the server under a
+							// sibling episode number, so this episode is satisfied too.
+							if (serverItems.length === 0 && localRow?.episodeFileId) {
+								serverItems = serverItemsByFile.get(localRow.episodeFileId) ?? [];
+							}
+							const existing = existingByKey.get(key);
+
+							// Preserve any pre-existing row even if this iteration later
+							// throws, so a transient update failure doesn't cause a
+							// stale-cleanup deletion.
+							if (existing) keepItemIds.add(existing.id);
+
+							const hasLocal = localRow !== null;
+							const hasServer = serverItems.length > 0;
+							const sourceSystem = hasLocal && hasServer ? 'both' : hasLocal ? 'local' : 'server';
+							const matchConfidence = hasLocal ? 'exact' : 'id';
+
+							const title = localRow?.title ?? serverItems[0]?.title ?? 'Unknown';
+							const year = localRow?.year ?? serverItems[0]?.year ?? null;
+							const seriesName = serverItems[0]?.seriesName ?? null;
+							const itemType = (localRow?.itemType ?? serverItems[0]?.itemType ?? 'movie') as
+								'movie' | 'episode' | 'series' | 'season';
+							const tmdbId = localRow?.tmdbId ?? serverItems[0]?.tmdbId ?? null;
+							const tvdbId = serverItems[0]?.tvdbId ?? null;
+							const imdbId = serverItems[0]?.imdbId ?? null;
+							// Movies must never carry season/episode values: the unique index and
+							// logicalKey match movies on tmdbId alone, and stray server-side
+							// metadata (e.g. Jellyfin reporting IndexNumber=1 on a movie) would
+							// otherwise create a second storage_items row for the same film.
+							const isMovie = itemType === 'movie';
+							const seasonNumber = isMovie
+								? null
+								: (localRow?.seasonNumber ?? serverItems[0]?.seasonNumber ?? null);
+							const episodeNumber = isMovie
+								? null
+								: (localRow?.episodeNumber ?? serverItems[0]?.episodeNumber ?? null);
+
+							let itemId: string;
+							if (existing) {
+								itemId = existing.id;
+								tx.update(storageItems)
+									.set({
+										title,
+										year,
+										seriesName,
+										itemType,
+										tmdbId,
+										tvdbId,
+										imdbId,
+										seasonNumber,
+										episodeNumber,
+										movieFileId: localRow?.movieFileId ?? null,
+										episodeFileId: localRow?.episodeFileId ?? null,
+										rootFolderId: localRow?.rootFolderId ?? null,
+										libraryId: localRow?.libraryId ?? null,
+										sourceSystem,
+										matchConfidence,
+										lastReconciledAt: now
+									})
+									.where(eq(storageItems.id, existing.id))
+									.run();
+								itemsUpdated++;
+							} else {
+								const [inserted] = tx
+									.insert(storageItems)
+									.values({
+										itemType,
+										tmdbId,
+										tvdbId,
+										imdbId,
+										title,
+										year,
+										seriesName,
+										seasonNumber,
+										episodeNumber,
+										movieFileId: localRow?.movieFileId ?? null,
+										episodeFileId: localRow?.episodeFileId ?? null,
+										rootFolderId: localRow?.rootFolderId ?? null,
+										libraryId: localRow?.libraryId ?? null,
+										sourceSystem,
+										matchConfidence,
+										firstSeenAt: now,
+										lastReconciledAt: now
+									})
+									.returning({ id: storageItems.id })
+									.all();
+								itemId = inserted.id;
+								itemsInserted++;
+							}
+							keepItemIds.add(itemId);
+
+							// Upsert server links
+							for (const s of serverItems) {
+								const linkKey = `${itemId}:${s.serverId}`;
+								if (!existingLinkIds.has(linkKey)) {
+									tx.insert(storageItemServerLinks)
+										.values({
+											storageItemId: itemId,
+											serverId: s.serverId,
+											syncedItemId: s.id,
+											lastSeenAt: now
+										})
+										.onConflictDoNothing()
+										.run();
+								} else {
+									tx.update(storageItemServerLinks)
+										.set({ lastSeenAt: now, syncedItemId: s.id })
+										.where(
+											and(
+												eq(storageItemServerLinks.storageItemId, itemId),
+												eq(storageItemServerLinks.serverId, s.serverId)
+											)
+										)
+										.run();
+								}
+								linksUpserted++;
+							}
+						} catch (itemError) {
+							// Isolate per-item failures so one bad row can't abort the
+							// whole run (and re-abort on every subsequent run).
+							errorCount++;
+							logger.warn(`[ReconciliationService] failed to reconcile key ${key}`, {
+								error: itemError instanceof Error ? itemError : new Error(String(itemError))
+							});
+						}
+					}
+				});
+				if (chunkStart + CHUNK_SIZE < allKeys.length) {
+					await yield_();
 				}
+			}
 
-				return {
-					itemsUpserted: itemsInserted + itemsUpdated,
-					itemsInserted,
-					itemsUpdated,
-					itemsDeleted,
-					linksUpserted,
-					errorCount,
-					durationMs: Date.now() - start,
-					skipped: false as const
-				};
-			});
+			// Stale cleanup: remove rows no longer present in any source.
+			// Chunked to stay within SQLite's ~999 host-parameter limit.
+			let itemsDeleted = 0;
+			const staleIds = existingItems.filter((i) => !keepItemIds.has(i.id)).map((i) => i.id);
+			for (let i = 0; i < staleIds.length; i += CHUNK_SIZE) {
+				const batch = staleIds.slice(i, i + CHUNK_SIZE);
+				db.transaction((tx) => {
+					tx.delete(storageItems).where(inArray(storageItems.id, batch)).run();
+				});
+				itemsDeleted += batch.length;
+				if (i + CHUNK_SIZE < staleIds.length) {
+					await yield_();
+				}
+			}
+
+			const result: ReconcileResult = {
+				itemsUpserted: itemsInserted + itemsUpdated,
+				itemsInserted,
+				itemsUpdated,
+				itemsDeleted,
+				linksUpserted,
+				errorCount,
+				durationMs: Date.now() - start,
+				skipped: false as const
+			};
 
 			logger.info(
 				`[ReconciliationService] reconcile complete: ${result.itemsInserted} new, ${result.itemsUpdated} updated, ${result.itemsDeleted} removed, ${result.linksUpserted} links, ${result.errorCount} errors in ${result.durationMs}ms`
@@ -463,11 +504,21 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 			throw e;
 		} finally {
 			this.reconcileLock = false;
+			// A trigger that arrived while we were running sets pendingTrigger.
+			// Start a follow-up pass immediately so those mutations aren't missed.
+			if (this.pendingTrigger) {
+				this.pendingTrigger = false;
+				setImmediate(() => {
+					this.reconcile().catch((err) => {
+						logger.error('[ReconciliationService] reconcile failed on deferred trigger', err);
+					});
+				});
+			}
 		}
 	}
 
 	private async loadLocalRows(): Promise<SourceRow[]> {
-		const [movieFileRows, episodeFileRows, episodeRows] = await Promise.all([
+		const [movieFileRows, episodeFileRows] = await Promise.all([
 			db
 				.select({
 					movieId: movies.id,
@@ -493,16 +544,41 @@ class ReconciliationService extends EventEmitter implements BackgroundService {
 					episodeIds: episodeFiles.episodeIds
 				})
 				.from(series)
-				.innerJoin(episodeFiles, eq(episodeFiles.seriesId, series.id)),
-			db
-				.select({
-					id: episodes.id,
-					episodeNumber: episodes.episodeNumber,
-					seasonNumber: episodes.seasonNumber,
-					seriesId: episodes.seriesId
-				})
-				.from(episodes)
+				.innerJoin(episodeFiles, eq(episodeFiles.seriesId, series.id))
 		]);
+
+		// Collect only the episode IDs referenced by episode files — avoids
+		// loading the entire episodes table for large libraries.
+		const referencedEpisodeIds = new Set<string>();
+		for (const r of episodeFileRows) {
+			for (const id of r.episodeIds ?? []) {
+				referencedEpisodeIds.add(id);
+			}
+		}
+
+		// Load referenced episodes in chunks to stay within SQLite's variable limit.
+		const episodeRows: Array<{
+			id: string;
+			episodeNumber: number;
+			seasonNumber: number;
+			seriesId: string;
+		}> = [];
+		if (referencedEpisodeIds.size > 0) {
+			const ids = [...referencedEpisodeIds];
+			for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+				const batch = ids.slice(i, i + CHUNK_SIZE);
+				const rows = await db
+					.select({
+						id: episodes.id,
+						episodeNumber: episodes.episodeNumber,
+						seasonNumber: episodes.seasonNumber,
+						seriesId: episodes.seriesId
+					})
+					.from(episodes)
+					.where(inArray(episodes.id, batch));
+				episodeRows.push(...rows);
+			}
+		}
 
 		// Map<episodeId, { episodeNumber, seasonNumber }> for per-episode expansion.
 		// An episode file can cover multiple episodes (e.g. double episodes); we emit

--- a/src/routes/api/streaming/library/episode/[fileId]/+server.ts
+++ b/src/routes/api/streaming/library/episode/[fileId]/+server.ts
@@ -52,16 +52,21 @@ async function resolveEpisodeFile(
 		return null;
 	}
 
-	let size = row.size ?? 0;
-	if (size === 0) {
-		try {
-			size = statSync(absolutePath).size;
-		} catch {
-			return null;
-		}
+	// Always stat: verify the file exists, is a regular file, and get its current size.
+	// The DB size field can be stale if the file was replaced or deleted after import.
+	let stats: ReturnType<typeof statSync>;
+	try {
+		stats = statSync(absolutePath);
+	} catch {
+		logger.warn({ fileId, absolutePath }, '[LocalEpisodeStream] File not found on disk');
+		return null;
+	}
+	if (!stats.isFile()) {
+		logger.warn({ fileId, absolutePath }, '[LocalEpisodeStream] Path is not a regular file');
+		return null;
 	}
 
-	return { absolutePath, size, contentType: getContentType(row.relativePath) };
+	return { absolutePath, size: stats.size, contentType: getContentType(row.relativePath) };
 }
 
 export const GET: RequestHandler = async (event) => {

--- a/src/routes/api/streaming/library/episode/[fileId]/+server.ts
+++ b/src/routes/api/streaming/library/episode/[fileId]/+server.ts
@@ -1,0 +1,143 @@
+/**
+ * GET/HEAD /api/streaming/library/episode/[fileId]
+ *
+ * Stream a local episode file directly from disk with HTTP Range support.
+ * Resolves the file by database ID, never by raw path and validates the
+ * resolved absolute path is within a configured root folder before opening it.
+ *
+ * Auth: API key (x-api-key header or ?api_key= query param).
+ */
+
+import { createReadStream, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { episodeFiles, series, rootFolders } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
+import { isPathInsideManagedRoot } from '$lib/server/filesystem/path-guard.js';
+import { getContentType, parseRangeHeader } from '$lib/server/streaming/usenet/types.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({
+	logDomain: 'streams' as const,
+	component: 'LocalEpisodeStream'
+});
+
+async function resolveEpisodeFile(
+	fileId: string
+): Promise<{ absolutePath: string; size: number; contentType: string } | null> {
+	const row = await db
+		.select({
+			relativePath: episodeFiles.relativePath,
+			size: episodeFiles.size,
+			seriesPath: series.path,
+			rootFolderPath: rootFolders.path
+		})
+		.from(episodeFiles)
+		.innerJoin(series, eq(episodeFiles.seriesId, series.id))
+		.innerJoin(rootFolders, eq(series.rootFolderId, rootFolders.id))
+		.where(eq(episodeFiles.id, fileId))
+		.get();
+
+	if (!row) return null;
+
+	const absolutePath = join(row.rootFolderPath, row.seriesPath, row.relativePath);
+
+	if (!(await isPathInsideManagedRoot(absolutePath))) {
+		logger.warn(
+			{ fileId, absolutePath },
+			'[LocalEpisodeStream] Path outside managed root — rejecting'
+		);
+		return null;
+	}
+
+	let size = row.size ?? 0;
+	if (size === 0) {
+		try {
+			size = statSync(absolutePath).size;
+		} catch {
+			return null;
+		}
+	}
+
+	return { absolutePath, size, contentType: getContentType(row.relativePath) };
+}
+
+export const GET: RequestHandler = async (event) => {
+	// Accept either a streaming API key (validated by hooks) or an admin session
+	if (!event.locals.apiKey && event.locals.user?.role !== 'admin') {
+		return new Response('Unauthorized', { status: 401 });
+	}
+
+	const { params, request } = event;
+	const { fileId } = params;
+
+	const file = await resolveEpisodeFile(fileId);
+	if (!file) {
+		return new Response('Not found', { status: 404 });
+	}
+
+	const rangeHeader = request.headers.get('range');
+	const range = parseRangeHeader(rangeHeader, file.size);
+
+	const headers: Record<string, string> = {
+		'Content-Type': file.contentType,
+		'Accept-Ranges': 'bytes',
+		'Cache-Control': 'no-cache',
+		Connection: 'keep-alive'
+	};
+
+	if (rangeHeader && !range) {
+		// Malformed / unsatisfiable range
+		headers['Content-Range'] = `bytes */${file.size}`;
+		return new Response('Range Not Satisfiable', { status: 416, headers });
+	}
+
+	if (range) {
+		const startByte = range.start;
+		const endByte = range.end === -1 ? file.size - 1 : range.end;
+		const contentLength = endByte - startByte + 1;
+
+		headers['Content-Range'] = `bytes ${startByte}-${endByte}/${file.size}`;
+		headers['Content-Length'] = String(contentLength);
+
+		logger.debug(
+			{ fileId, startByte, endByte, totalSize: file.size },
+			'[LocalEpisodeStream] Serving partial content'
+		);
+
+		const nodeStream = createReadStream(file.absolutePath, { start: startByte, end: endByte });
+		return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 206, headers });
+	}
+
+	headers['Content-Length'] = String(file.size);
+
+	logger.debug({ fileId, totalSize: file.size }, '[LocalEpisodeStream] Serving full content');
+
+	const nodeStream = createReadStream(file.absolutePath);
+	return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 200, headers });
+};
+
+export const HEAD: RequestHandler = async (event) => {
+	if (!event.locals.apiKey && event.locals.user?.role !== 'admin') {
+		return new Response(null, { status: 401 });
+	}
+
+	const { params } = event;
+	const { fileId } = params;
+
+	const file = await resolveEpisodeFile(fileId);
+	if (!file) {
+		return new Response(null, { status: 404 });
+	}
+
+	return new Response(null, {
+		status: 200,
+		headers: {
+			'Content-Type': file.contentType,
+			'Content-Length': String(file.size),
+			'Accept-Ranges': 'bytes'
+		}
+	});
+};

--- a/src/routes/api/streaming/library/episode/[fileId]/server.test.ts
+++ b/src/routes/api/streaming/library/episode/[fileId]/server.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+	createTestDb,
+	destroyTestDb,
+	clearTestDb,
+	type TestDatabase
+} from '../../../../../../test/db-helper';
+import { createRequestEvent } from '../../../../../../test/api-helper';
+import { rootFolders, series, episodeFiles } from '$lib/server/db/schema';
+
+const testDb: TestDatabase = createTestDb();
+
+vi.mock('$lib/server/db/index.js', () => ({
+	get db() {
+		return testDb.db;
+	}
+}));
+
+const mockLogger = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	child: vi.fn().mockReturnThis()
+}));
+
+vi.mock('$lib/logging', () => ({
+	logger: mockLogger,
+	createChildLogger: vi.fn(() => mockLogger)
+}));
+
+const { isPathInsideManagedRootMock } = vi.hoisted(() => ({
+	isPathInsideManagedRootMock: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock('$lib/server/filesystem/path-guard.js', () => ({
+	isPathInsideManagedRoot: isPathInsideManagedRootMock
+}));
+
+const { GET, HEAD } = await import('./+server');
+
+const TEST_DIR = join(tmpdir(), `cinephage-stream-episode-test-${process.pid}`);
+const TEST_FILE = 'episode.mkv';
+const TEST_FILE_CONTENT = Buffer.from('fake mkv episode bytes for testing 0987654321');
+const ROOT_FOLDER_ID = 'rf-ep-test-1';
+const SERIES_ID = 'series-test-1';
+const FILE_ID = 'ef-test-1';
+const MISSING_FILE_ID = 'ef-does-not-exist';
+
+function makeRequest(method: string, headers: Record<string, string> = {}): Request {
+	return new Request('http://localhost/api/streaming/library/episode/' + FILE_ID, {
+		method,
+		headers
+	});
+}
+
+async function callGet(fileId: string, headers: Record<string, string> = {}): Promise<Response> {
+	const request = makeRequest('GET', headers);
+	return GET(createRequestEvent(request, { fileId }, { auth: 'admin' }) as any);
+}
+
+async function callHead(fileId: string): Promise<Response> {
+	const request = makeRequest('HEAD');
+	return HEAD(createRequestEvent(request, { fileId }, { auth: 'admin' }) as any);
+}
+
+beforeAll(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+	writeFileSync(join(TEST_DIR, TEST_FILE), TEST_FILE_CONTENT);
+});
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+	destroyTestDb(testDb);
+});
+
+beforeEach(async () => {
+	clearTestDb(testDb);
+	isPathInsideManagedRootMock.mockResolvedValue(true);
+
+	// Seed: rootFolder -> series -> episodeFile
+	await testDb.db.insert(rootFolders).values({
+		id: ROOT_FOLDER_ID,
+		name: 'TV Shows',
+		path: TEST_DIR,
+		mediaType: 'tv'
+	});
+
+	await testDb.db.insert(series).values({
+		id: SERIES_ID,
+		tmdbId: 67890,
+		title: 'Test Series',
+		path: '',
+		rootFolderId: ROOT_FOLDER_ID
+	});
+
+	await testDb.db.insert(episodeFiles).values({
+		id: FILE_ID,
+		seriesId: SERIES_ID,
+		seasonNumber: 1,
+		relativePath: TEST_FILE,
+		size: TEST_FILE_CONTENT.length
+	});
+});
+
+describe('GET /api/streaming/library/episode/[fileId]', () => {
+	it('returns 404 for unknown fileId', async () => {
+		const res = await callGet(MISSING_FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 404 when resolved path is outside managed root', async () => {
+		isPathInsideManagedRootMock.mockResolvedValue(false);
+		const res = await callGet(FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 200 with full content and correct headers', async () => {
+		const res = await callGet(FILE_ID);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+		expect(res.headers.get('Content-Length')).toBe(String(TEST_FILE_CONTENT.length));
+		expect(res.headers.get('Content-Type')).toMatch(/video/);
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT);
+	});
+
+	it('returns 206 for a valid Range request', async () => {
+		const start = 5;
+		const end = 14;
+		const res = await callGet(FILE_ID, { Range: `bytes=${start}-${end}` });
+
+		expect(res.status).toBe(206);
+		expect(res.headers.get('Content-Range')).toBe(
+			`bytes ${start}-${end}/${TEST_FILE_CONTENT.length}`
+		);
+		expect(res.headers.get('Content-Length')).toBe(String(end - start + 1));
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT.subarray(start, end + 1));
+	});
+
+	it('returns 206 for an open-ended Range request (bytes=N-)', async () => {
+		const start = 10;
+		const end = TEST_FILE_CONTENT.length - 1;
+		const res = await callGet(FILE_ID, { Range: `bytes=${start}-` });
+
+		expect(res.status).toBe(206);
+		expect(res.headers.get('Content-Range')).toBe(
+			`bytes ${start}-${end}/${TEST_FILE_CONTENT.length}`
+		);
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT.subarray(start));
+	});
+
+	it('returns 416 for an unsatisfiable Range request', async () => {
+		const res = await callGet(FILE_ID, { Range: `bytes=9999-99999` });
+		expect(res.status).toBe(416);
+		expect(res.headers.get('Content-Range')).toBe(`bytes */${TEST_FILE_CONTENT.length}`);
+	});
+});
+
+describe('HEAD /api/streaming/library/episode/[fileId]', () => {
+	it('returns 404 for unknown fileId', async () => {
+		const res = await callHead(MISSING_FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 200 with correct headers and no body', async () => {
+		const res = await callHead(FILE_ID);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Length')).toBe(String(TEST_FILE_CONTENT.length));
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+		expect(res.headers.get('Content-Type')).toBe('video/x-matroska');
+
+		const body = await res.text();
+		expect(body).toBe('');
+	});
+});

--- a/src/routes/api/streaming/library/movie/[fileId]/+server.ts
+++ b/src/routes/api/streaming/library/movie/[fileId]/+server.ts
@@ -1,0 +1,140 @@
+/**
+ * GET/HEAD /api/streaming/library/movie/[fileId]
+ *
+ * Stream a local movie file directly from disk with HTTP Range support.
+ * Resolves the file by database ID, never by raw path and validates the
+ * resolved absolute path is within a configured root folder before opening it.
+ *
+ * Auth: API key (x-api-key header or ?api_key= query param).
+ */
+
+import { createReadStream, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { movieFiles, movies, rootFolders } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
+import { isPathInsideManagedRoot } from '$lib/server/filesystem/path-guard.js';
+import { getContentType, parseRangeHeader } from '$lib/server/streaming/usenet/types.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ logDomain: 'streams' as const, component: 'LocalMovieStream' });
+
+async function resolveMovieFile(
+	fileId: string
+): Promise<{ absolutePath: string; size: number; contentType: string } | null> {
+	const row = await db
+		.select({
+			relativePath: movieFiles.relativePath,
+			size: movieFiles.size,
+			moviePath: movies.path,
+			rootFolderPath: rootFolders.path
+		})
+		.from(movieFiles)
+		.innerJoin(movies, eq(movieFiles.movieId, movies.id))
+		.innerJoin(rootFolders, eq(movies.rootFolderId, rootFolders.id))
+		.where(eq(movieFiles.id, fileId))
+		.get();
+
+	if (!row) return null;
+
+	const absolutePath = join(row.rootFolderPath, row.moviePath, row.relativePath);
+
+	if (!(await isPathInsideManagedRoot(absolutePath))) {
+		logger.warn(
+			{ fileId, absolutePath },
+			'[LocalMovieStream] Path outside managed root — rejecting'
+		);
+		return null;
+	}
+
+	let size = row.size ?? 0;
+	if (size === 0) {
+		try {
+			size = statSync(absolutePath).size;
+		} catch {
+			return null;
+		}
+	}
+
+	return { absolutePath, size, contentType: getContentType(row.relativePath) };
+}
+
+export const GET: RequestHandler = async (event) => {
+	// Accept either a streaming API key (validated by hooks) or an admin session
+	if (!event.locals.apiKey && event.locals.user?.role !== 'admin') {
+		return new Response('Unauthorized', { status: 401 });
+	}
+
+	const { params, request } = event;
+	const { fileId } = params;
+
+	const file = await resolveMovieFile(fileId);
+	if (!file) {
+		return new Response('Not found', { status: 404 });
+	}
+
+	const rangeHeader = request.headers.get('range');
+	const range = parseRangeHeader(rangeHeader, file.size);
+
+	const headers: Record<string, string> = {
+		'Content-Type': file.contentType,
+		'Accept-Ranges': 'bytes',
+		'Cache-Control': 'no-cache',
+		Connection: 'keep-alive'
+	};
+
+	if (rangeHeader && !range) {
+		// Malformed / unsatisfiable range
+		headers['Content-Range'] = `bytes */${file.size}`;
+		return new Response('Range Not Satisfiable', { status: 416, headers });
+	}
+
+	if (range) {
+		const startByte = range.start;
+		const endByte = range.end === -1 ? file.size - 1 : range.end;
+		const contentLength = endByte - startByte + 1;
+
+		headers['Content-Range'] = `bytes ${startByte}-${endByte}/${file.size}`;
+		headers['Content-Length'] = String(contentLength);
+
+		logger.debug(
+			{ fileId, startByte, endByte, totalSize: file.size },
+			'[LocalMovieStream] Serving partial content'
+		);
+
+		const nodeStream = createReadStream(file.absolutePath, { start: startByte, end: endByte });
+		return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 206, headers });
+	}
+
+	headers['Content-Length'] = String(file.size);
+
+	logger.debug({ fileId, totalSize: file.size }, '[LocalMovieStream] Serving full content');
+
+	const nodeStream = createReadStream(file.absolutePath);
+	return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 200, headers });
+};
+
+export const HEAD: RequestHandler = async (event) => {
+	if (!event.locals.apiKey && event.locals.user?.role !== 'admin') {
+		return new Response(null, { status: 401 });
+	}
+
+	const { params } = event;
+	const { fileId } = params;
+
+	const file = await resolveMovieFile(fileId);
+	if (!file) {
+		return new Response(null, { status: 404 });
+	}
+
+	return new Response(null, {
+		status: 200,
+		headers: {
+			'Content-Type': file.contentType,
+			'Content-Length': String(file.size),
+			'Accept-Ranges': 'bytes'
+		}
+	});
+};

--- a/src/routes/api/streaming/library/movie/[fileId]/+server.ts
+++ b/src/routes/api/streaming/library/movie/[fileId]/+server.ts
@@ -49,16 +49,21 @@ async function resolveMovieFile(
 		return null;
 	}
 
-	let size = row.size ?? 0;
-	if (size === 0) {
-		try {
-			size = statSync(absolutePath).size;
-		} catch {
-			return null;
-		}
+	// Always stat: verify the file exists, is a regular file, and get its current size.
+	// The DB size field can be stale if the file was replaced or deleted after import.
+	let stats: ReturnType<typeof statSync>;
+	try {
+		stats = statSync(absolutePath);
+	} catch {
+		logger.warn({ fileId, absolutePath }, '[LocalMovieStream] File not found on disk');
+		return null;
+	}
+	if (!stats.isFile()) {
+		logger.warn({ fileId, absolutePath }, '[LocalMovieStream] Path is not a regular file');
+		return null;
 	}
 
-	return { absolutePath, size, contentType: getContentType(row.relativePath) };
+	return { absolutePath, size: stats.size, contentType: getContentType(row.relativePath) };
 }
 
 export const GET: RequestHandler = async (event) => {

--- a/src/routes/api/streaming/library/movie/[fileId]/server.test.ts
+++ b/src/routes/api/streaming/library/movie/[fileId]/server.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+	createTestDb,
+	destroyTestDb,
+	clearTestDb,
+	type TestDatabase
+} from '../../../../../../test/db-helper';
+import { createRequestEvent } from '../../../../../../test/api-helper';
+import { rootFolders, movies, movieFiles } from '$lib/server/db/schema';
+
+const testDb: TestDatabase = createTestDb();
+
+vi.mock('$lib/server/db/index.js', () => ({
+	get db() {
+		return testDb.db;
+	}
+}));
+
+const mockLogger = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	child: vi.fn().mockReturnThis()
+}));
+
+vi.mock('$lib/logging', () => ({
+	logger: mockLogger,
+	createChildLogger: vi.fn(() => mockLogger)
+}));
+
+const { isPathInsideManagedRootMock } = vi.hoisted(() => ({
+	isPathInsideManagedRootMock: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock('$lib/server/filesystem/path-guard.js', () => ({
+	isPathInsideManagedRoot: isPathInsideManagedRootMock
+}));
+
+const { GET, HEAD } = await import('./+server');
+
+const TEST_DIR = join(tmpdir(), `cinephage-stream-movie-test-${process.pid}`);
+const TEST_FILE = 'movie.mkv';
+const TEST_FILE_CONTENT = Buffer.from('fake mkv video bytes for testing 1234567890');
+const ROOT_FOLDER_ID = 'rf-test-1';
+const MOVIE_ID = 'movie-test-1';
+const FILE_ID = 'mf-test-1';
+const MISSING_FILE_ID = 'mf-does-not-exist';
+
+function makeRequest(method: string, headers: Record<string, string> = {}): Request {
+	return new Request('http://localhost/api/streaming/library/movie/' + FILE_ID, {
+		method,
+		headers
+	});
+}
+
+async function callGet(fileId: string, headers: Record<string, string> = {}): Promise<Response> {
+	const request = makeRequest('GET', headers);
+	return GET(createRequestEvent(request, { fileId }, { auth: 'admin' }) as any);
+}
+
+async function callHead(fileId: string): Promise<Response> {
+	const request = makeRequest('HEAD');
+	return HEAD(createRequestEvent(request, { fileId }, { auth: 'admin' }) as any);
+}
+
+beforeAll(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+	writeFileSync(join(TEST_DIR, TEST_FILE), TEST_FILE_CONTENT);
+});
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+	destroyTestDb(testDb);
+});
+
+beforeEach(async () => {
+	clearTestDb(testDb);
+	isPathInsideManagedRootMock.mockResolvedValue(true);
+
+	// Seed: rootFolder -> movie -> movieFile
+	await testDb.db.insert(rootFolders).values({
+		id: ROOT_FOLDER_ID,
+		name: 'Movies',
+		path: TEST_DIR,
+		mediaType: 'movie'
+	});
+
+	await testDb.db.insert(movies).values({
+		id: MOVIE_ID,
+		tmdbId: 12345,
+		title: 'Test Movie',
+		path: '',
+		rootFolderId: ROOT_FOLDER_ID
+	});
+
+	await testDb.db.insert(movieFiles).values({
+		id: FILE_ID,
+		movieId: MOVIE_ID,
+		relativePath: TEST_FILE,
+		size: TEST_FILE_CONTENT.length
+	});
+});
+
+describe('GET /api/streaming/library/movie/[fileId]', () => {
+	it('returns 404 for unknown fileId', async () => {
+		const res = await callGet(MISSING_FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 404 when resolved path is outside managed root', async () => {
+		isPathInsideManagedRootMock.mockResolvedValue(false);
+		const res = await callGet(FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 200 with full content and correct headers', async () => {
+		const res = await callGet(FILE_ID);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+		expect(res.headers.get('Content-Length')).toBe(String(TEST_FILE_CONTENT.length));
+		expect(res.headers.get('Content-Type')).toMatch(/video/);
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT);
+	});
+
+	it('returns 206 for a valid Range request', async () => {
+		const start = 5;
+		const end = 14;
+		const res = await callGet(FILE_ID, { Range: `bytes=${start}-${end}` });
+
+		expect(res.status).toBe(206);
+		expect(res.headers.get('Content-Range')).toBe(
+			`bytes ${start}-${end}/${TEST_FILE_CONTENT.length}`
+		);
+		expect(res.headers.get('Content-Length')).toBe(String(end - start + 1));
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT.subarray(start, end + 1));
+	});
+
+	it('returns 206 for an open-ended Range request (bytes=N-)', async () => {
+		const start = 10;
+		const end = TEST_FILE_CONTENT.length - 1;
+		const res = await callGet(FILE_ID, { Range: `bytes=${start}-` });
+
+		expect(res.status).toBe(206);
+		expect(res.headers.get('Content-Range')).toBe(
+			`bytes ${start}-${end}/${TEST_FILE_CONTENT.length}`
+		);
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT.subarray(start));
+	});
+
+	it('returns 206 for a suffix Range request (bytes=-N)', async () => {
+		const suffixLength = 8;
+		const start = TEST_FILE_CONTENT.length - suffixLength;
+		const end = TEST_FILE_CONTENT.length - 1;
+		const res = await callGet(FILE_ID, { Range: `bytes=-${suffixLength}` });
+
+		expect(res.status).toBe(206);
+		expect(res.headers.get('Content-Range')).toBe(
+			`bytes ${start}-${end}/${TEST_FILE_CONTENT.length}`
+		);
+
+		const body = Buffer.from(await res.arrayBuffer());
+		expect(body).toEqual(TEST_FILE_CONTENT.subarray(start));
+	});
+
+	it('returns 416 for an unsatisfiable Range request', async () => {
+		const res = await callGet(FILE_ID, { Range: `bytes=9999-99999` });
+		expect(res.status).toBe(416);
+		expect(res.headers.get('Content-Range')).toBe(`bytes */${TEST_FILE_CONTENT.length}`);
+	});
+
+	it('uses Content-Type video/x-matroska for .mkv files', async () => {
+		const res = await callGet(FILE_ID);
+		expect(res.headers.get('Content-Type')).toBe('video/x-matroska');
+	});
+});
+
+describe('HEAD /api/streaming/library/movie/[fileId]', () => {
+	it('returns 404 for unknown fileId', async () => {
+		const res = await callHead(MISSING_FILE_ID);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 200 with correct headers and no body', async () => {
+		const res = await callHead(FILE_ID);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Length')).toBe(String(TEST_FILE_CONTENT.length));
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+		expect(res.headers.get('Content-Type')).toBe('video/x-matroska');
+
+		// HEAD must have no body
+		const body = await res.text();
+		expect(body).toBe('');
+	});
+});

--- a/src/routes/api/streaming/library/streaming-auth.test.ts
+++ b/src/routes/api/streaming/library/streaming-auth.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Auth integration tests for /api/streaming/library/* endpoints.
+ *
+ * These tests exercise the full authentication path:
+ *   hooks.server.ts (API-key validation -> locals population) -> route handler
+ *
+ * They complement the isolated route tests (server.test.ts) which bypass auth
+ * by injecting admin locals directly. Here we verify that:
+ *   - A valid Media Streaming key (streaming: ['*']) is accepted
+ *   - A valid Main API key (default: ['*']) is accepted via the fallback check
+ *   - A missing key returns 401
+ *   - An invalid / wrong-permission key returns 401
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+	createTestDb,
+	destroyTestDb,
+	clearTestDb,
+	type TestDatabase
+} from '../../../../test/db-helper';
+import { rootFolders, movies, movieFiles } from '$lib/server/db/schema';
+
+const testDb: TestDatabase = createTestDb();
+
+vi.mock('$lib/server/db/index.js', () => ({
+	get db() {
+		return testDb.db;
+	}
+}));
+
+const mockLogger = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	child: vi.fn().mockReturnThis(),
+	fatal: vi.fn(),
+	trace: vi.fn()
+}));
+
+vi.mock('$lib/logging', () => ({
+	logger: mockLogger,
+	createChildLogger: vi.fn(() => mockLogger),
+	createRequestLogger: vi.fn(() => mockLogger),
+	runWithLogContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn())
+}));
+
+vi.mock('$lib/server/filesystem/path-guard.js', () => ({
+	isPathInsideManagedRoot: vi.fn().mockResolvedValue(true)
+}));
+
+const STREAMING_KEY = 'cinephage_streaming_key';
+const MAIN_KEY = 'cinephage_main_key';
+const BAD_KEY = 'cinephage_bad_key';
+
+const verifyApiKeyMock = vi.fn();
+
+vi.mock('$lib/server/auth/index.js', () => ({
+	auth: {
+		api: {
+			verifyApiKey: verifyApiKeyMock
+		}
+	},
+	isSetupComplete: vi.fn().mockResolvedValue(true),
+	repairCurrentUserAdminRole: vi.fn()
+}));
+
+vi.mock('$lib/server/auth/session-helpers.js', () => ({
+	createSupportId: vi.fn(() => 'test-support-id'),
+	setAuthenticatedLocals: vi.fn(),
+	clearAuthenticatedLocals: vi.fn()
+}));
+
+vi.mock('$lib/server/services/initializer.js', () => ({
+	ensureServicesInitialized: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('$lib/server/services/shutdown.js', () => ({}));
+
+vi.mock('$lib/server/rate-limit.js', () => ({
+	// Must return null/undefined to signal "not rate limited"; a truthy value
+	// is treated as a rate-limit Response and returned early.
+	checkApiRateLimit: vi.fn().mockReturnValue(null),
+	applyRateLimitHeaders: vi.fn((_, response) => response)
+}));
+
+vi.mock('$lib/server/security/headers.js', () => ({
+	SECURITY_HEADERS: {},
+	BASE_SECURITY_HEADERS: {}
+}));
+
+vi.mock('$lib/server/utils/origin.js', () => ({
+	isTrustedOrigin: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('$lib/server/hooks/error-handler.js', () => ({
+	handleError: vi.fn()
+}));
+
+vi.mock('$lib/paraglide/server.js', () => ({
+	paraglideMiddleware: vi.fn(
+		(request: Request, resolve: (args: { request: Request; locale: string }) => unknown) =>
+			resolve({ request, locale: 'en' })
+	)
+}));
+
+vi.mock('$app/environment', () => ({ building: false }));
+
+vi.mock('$lib/auth/config.js', () => ({ AUTH_BASE_PATH: '/api/auth' }));
+
+// sequence() normally requires the SvelteKit server async-local request store.
+// Replace it with a simple sequential compose so handle() works outside the
+// SvelteKit runtime.
+
+type HandleFn = (input: {
+	event: any;
+	resolve: (e: any) => Promise<Response>;
+}) => Promise<Response>;
+vi.mock('@sveltejs/kit/hooks', () => ({
+	sequence:
+		(...handlers: HandleFn[]) =>
+		(input: { event: any; resolve: (e: any) => Promise<Response> }) => {
+			const run = (i: number, event: any): Promise<Response> => {
+				if (i >= handlers.length) return input.resolve(event);
+				return handlers[i]({ event, resolve: (e) => run(i + 1, e) });
+			};
+			return run(0, input.event);
+		}
+}));
+
+const { handle } = await import('../../../../hooks.server');
+const { GET, HEAD } = await import('./movie/[fileId]/+server');
+
+const TEST_DIR = join(tmpdir(), `cinephage-auth-integration-test-${process.pid}`);
+const TEST_FILE = 'auth-test.mkv';
+const TEST_CONTENT = Buffer.from('auth integration test file content');
+const FILE_ID = 'auth-mf-test-1';
+
+beforeAll(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+	writeFileSync(join(TEST_DIR, TEST_FILE), TEST_CONTENT);
+});
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+	destroyTestDb(testDb);
+});
+
+beforeEach(async () => {
+	clearTestDb(testDb);
+	vi.clearAllMocks();
+
+	// Default: streaming key valid, main key valid, bad key invalid
+	verifyApiKeyMock.mockImplementation(
+		({ body }: { body: { key: string; permissions: object } }) => {
+			const { key, permissions } = body;
+			const wantsStreaming = 'streaming' in permissions;
+			const wantsFull = 'default' in permissions;
+
+			if (key === STREAMING_KEY && wantsStreaming) {
+				return Promise.resolve({
+					valid: true,
+					key: { permissions: { streaming: ['*'] } }
+				});
+			}
+			if (key === MAIN_KEY && wantsFull) {
+				return Promise.resolve({
+					valid: true,
+					key: { permissions: { default: ['*'] } }
+				});
+			}
+			// Main key fails streaming check: it uses { default: ['*'] }, not { streaming: ['*'] }
+			if (key === MAIN_KEY && wantsStreaming) {
+				return Promise.resolve({ valid: false, error: { message: 'KEY_NOT_FOUND' } });
+			}
+			return Promise.resolve({ valid: false, error: { message: 'invalid key' } });
+		}
+	);
+
+	await testDb.db.insert(rootFolders).values({
+		id: 'auth-rf-1',
+		name: 'Movies',
+		path: TEST_DIR,
+		mediaType: 'movie'
+	});
+	await testDb.db.insert(movies).values({
+		id: 'auth-movie-1',
+		tmdbId: 99999,
+		title: 'Auth Test Movie',
+		path: '',
+		rootFolderId: 'auth-rf-1'
+	});
+	await testDb.db.insert(movieFiles).values({
+		id: FILE_ID,
+		movieId: 'auth-movie-1',
+		relativePath: TEST_FILE,
+		size: TEST_CONTENT.length
+	});
+});
+
+function makeEvent(method: string, apiKey: string | null): Parameters<typeof handle>[0]['event'] {
+	const headers = new Headers();
+	if (apiKey) headers.set('x-api-key', apiKey);
+
+	const request = new Request(`http://localhost/api/streaming/library/movie/${FILE_ID}`, {
+		method,
+		headers
+	});
+
+	return {
+		request,
+		url: new URL(request.url),
+		params: { fileId: FILE_ID },
+		locals: {} as App.Locals,
+		platform: undefined,
+		cookies: {
+			get: () => undefined,
+			getAll: () => [],
+			set: () => {},
+			delete: () => {},
+			serialize: () => ''
+		},
+		fetch: globalThis.fetch,
+		getClientAddress: () => '127.0.0.1',
+		setHeaders: () => {},
+		isDataRequest: false,
+		isSubRequest: false,
+		route: { id: '/api/streaming/library/movie/[fileId]' }
+	} as any;
+}
+
+async function callViaHooks(method: string, apiKey: string | null): Promise<Response> {
+	const event = makeEvent(method, apiKey);
+	const handler = method === 'HEAD' ? HEAD : GET;
+
+	return handle({
+		event,
+		resolve: (evt) => handler(evt as any)
+	});
+}
+
+describe('streaming library auth — Media Streaming API Key', () => {
+	it('GET: accepts a valid streaming key and returns 200', async () => {
+		const res = await callViaHooks('GET', STREAMING_KEY);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+	});
+
+	it('HEAD: accepts a valid streaming key and returns 200', async () => {
+		const res = await callViaHooks('HEAD', STREAMING_KEY);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Length')).toBe(String(TEST_CONTENT.length));
+	});
+});
+
+describe('streaming library auth — Main API Key', () => {
+	it('GET: accepts the main key (full-access fallback) and returns 200', async () => {
+		const res = await callViaHooks('GET', MAIN_KEY);
+		expect(res.status).toBe(200);
+	});
+
+	it('HEAD: accepts the main key (full-access fallback) and returns 200', async () => {
+		const res = await callViaHooks('HEAD', MAIN_KEY);
+		expect(res.status).toBe(200);
+	});
+
+	it('verifyApiKey is called twice for the main key — streaming check then full-access fallback', async () => {
+		await callViaHooks('GET', MAIN_KEY);
+		expect(verifyApiKeyMock).toHaveBeenCalledTimes(2);
+		const [first, second] = verifyApiKeyMock.mock.calls;
+		expect(first[0].body.permissions).toHaveProperty('streaming');
+		expect(second[0].body.permissions).toHaveProperty('default');
+	});
+});
+
+describe('streaming library auth — rejected requests', () => {
+	it('GET: returns 401 when no API key is provided', async () => {
+		const res = await callViaHooks('GET', null);
+		expect(res.status).toBe(401);
+	});
+
+	it('HEAD: returns 401 when no API key is provided', async () => {
+		const res = await callViaHooks('HEAD', null);
+		expect(res.status).toBe(401);
+	});
+
+	it('GET: returns 401 for an invalid key', async () => {
+		const res = await callViaHooks('GET', BAD_KEY);
+		expect(res.status).toBe(401);
+	});
+});


### PR DESCRIPTION
## Summary

Implements HTTP streaming endpoints for local library files (issue #527) so gateways can stream content without mounting Cinephage directories. Also fixes three classes of bugs in ReconciliationService and extends the benchmark script with a reconciliation mode.

## Related Issues

Closes #527

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

- Add `GET/HEAD /api/streaming/library/movie/[fileId]` and `GET/HEAD /api/streaming/library/episode/[fileId]` endpoints; files are resolved by DB ID only, path is validated via `isPathInsideManagedRoot`, `statSync` on every request catches stale DB sizes, full Range (206/416) support
- Fix streaming auth to accept both the Media Streaming key (`streaming: ['*']`) and the Main API key (`default: ['*']`); the previous fallback checked `{ '*': ['*'] }` which does not match how main keys are issued, causing Better Auth to return `KEY_NOT_FOUND`
- Add `/api/streaming/library/` to `requiresStreamingApiKey()` in `hooks.server.ts`
- Chunk all `inArray` DB operations in `ReconciliationService` to 500 items to fix the "too many SQL variables" crash on large libraries
- Replace one monolithic reconcile transaction with chunked 500-item transactions separated by `setImmediate` yields to end multi-minute import delays and CPU spikes
- Add `pendingTrigger` flag so triggers arriving during an in-flight reconcile queue a follow-up pass instead of being silently dropped
- Debounce `handleTrigger` at 1500 ms to coalesce burst imports into a single reconcile run
- Apply the same 500-item `inArray` chunk fix to `BlocklistService.removeFromBlocklistByIds`
- Add `--reconcile` flag to `benchmark-scan.ts` for testing `ReconciliationService` directly with three passes (cold insert, steady-state update, partial insert) and per-pass event-loop lag histograms

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

N/A
