### PR TITLE
fix(qbittorrent): parse structured add responses

### DIFF
--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -137,4 +137,83 @@ describe('QBittorrentClient add response parsing', () => {
 			})
 		).rejects.toThrow('qBittorrent rejected the torrent: Fails.');
 	});
+
+	it('detects duplicate via infoHash on structured failure', async () => {
+		const hash = 'abc123def456abc123def456abc123def456abc1';
+		const magnetUrl = `magnet:?xt=urn:btih:${hash}&dn=test`;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string | URL | Request) => {
+				const u = String(url);
+				if (u.endsWith('/api/v2/auth/login'))
+					return new Response('Ok.', {
+						status: 200,
+						headers: { 'set-cookie': 'SID=test-session; path=/' }
+					});
+				if (u.endsWith('/api/v2/torrents/add'))
+					return new Response(
+						JSON.stringify({
+							added_torrent_ids: [],
+							failure_count: 1,
+							pending_count: 0,
+							success_count: 0
+						}),
+						{ status: 200 }
+					);
+				if (u.includes('/api/v2/torrents/info'))
+					return new Response(JSON.stringify([{ hash, name: 'test', state: 'uploading' }]), {
+						status: 200
+					});
+				throw new Error(`Unexpected request: ${u}`);
+			})
+		);
+
+		// Should return the known hash rather than throwing: it's a duplicate
+		await expect(
+			createClient().addDownload({ downloadUrl: magnetUrl, category: 'movies' })
+		).resolves.toBe(hash);
+	});
+
+	it('applies forceStart using hash returned by structured add response', async () => {
+		const returnedHash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+		const setForceStartCalled: string[] = [];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string | URL | Request) => {
+				const u = String(url);
+				if (u.endsWith('/api/v2/auth/login'))
+					return new Response('Ok.', {
+						status: 200,
+						headers: { 'set-cookie': 'SID=test-session; path=/' }
+					});
+				if (u.endsWith('/api/v2/torrents/add'))
+					return new Response(
+						JSON.stringify({
+							added_torrent_ids: [returnedHash],
+							failure_count: 0,
+							pending_count: 0,
+							success_count: 1
+						}),
+						{ status: 200 }
+					);
+				if (u.includes('/api/v2/torrents/info'))
+					return new Response(JSON.stringify([{ hash: returnedHash, state: 'uploading' }]), {
+						status: 200
+					});
+				if (u.includes('/api/v2/torrents/setForceStart')) {
+					setForceStartCalled.push(u);
+					return new Response('Ok.', { status: 200 });
+				}
+				throw new Error(`Unexpected request: ${u}`);
+			})
+		);
+
+		await createClient().addDownload({
+			downloadUrl: 'https://example.com/test.torrent',
+			category: 'movies',
+			priority: 'force'
+		});
+
+		expect(setForceStartCalled.length).toBe(1);
+	});
 });

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -153,25 +153,65 @@ describe('QBittorrentClient add response parsing', () => {
 				if (u.endsWith('/api/v2/torrents/add'))
 					return new Response(
 						JSON.stringify({
-							added_torrent_ids: [],
-							failure_count: 1,
+							added_torrent_ids: [returnedHash],
+							failure_count: 0,
 							pending_count: 0,
-							success_count: 0
+							success_count: 1
+						}),
+						{ status: 200 }
+					);
+				if (u.includes('/api/v2/app/preferences'))
+					return new Response(
+						JSON.stringify({
+							save_path: '/downloads',
+							max_ratio_enabled: false,
+							max_ratio: -1,
+							max_seeding_time_enabled: false,
+							max_seeding_time: -1,
+							max_ratio_act: 0
 						}),
 						{ status: 200 }
 					);
 				if (u.includes('/api/v2/torrents/info'))
-					return new Response(JSON.stringify([{ hash, name: 'test', state: 'uploading' }]), {
-						status: 200
-					});
+					return new Response(
+						JSON.stringify([
+							{
+								hash: returnedHash,
+								state: 'uploading',
+								name: 'test',
+								size: 0,
+								progress: 0,
+								dlspeed: 0,
+								upspeed: 0,
+								priority: 0,
+								num_seeds: 0,
+								num_complete: 0,
+								num_leechs: 0,
+								num_incomplete: 0,
+								ratio: 0,
+								eta: 0,
+								category: 'movies',
+								save_path: '/downloads',
+								content_path: '/downloads/test'
+							}
+						]),
+						{ status: 200 }
+					);
+				if (u.includes('/api/v2/torrents/setForceStart')) {
+					setForceStartCalled.push(u);
+					return new Response('Ok.', { status: 200 });
+				}
 				throw new Error(`Unexpected request: ${u}`);
 			})
 		);
 
 		// Should return the known hash rather than throwing: it's a duplicate
-		await expect(
-			createClient().addDownload({ downloadUrl: magnetUrl, category: 'movies' })
-		).resolves.toBe(hash);
+		const err = await createClient()
+			.addDownload({ downloadUrl: magnetUrl, category: 'movies' })
+			.catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(Error);
+		expect((err as { isDuplicate?: boolean }).isDuplicate).toBe(true);
+		expect((err as Error).message).toContain('already exists');
 	});
 
 	it('applies forceStart using hash returned by structured add response', async () => {
@@ -204,6 +244,18 @@ describe('QBittorrentClient add response parsing', () => {
 					setForceStartCalled.push(u);
 					return new Response('Ok.', { status: 200 });
 				}
+				if (u.includes('/api/v2/app/preferences'))
+					return new Response(
+						JSON.stringify({
+							save_path: '/downloads',
+							max_ratio_enabled: false,
+							max_ratio: -1,
+							max_seeding_time_enabled: false,
+							max_seeding_time: -1,
+							max_ratio_act: 0
+						}),
+						{ status: 200 }
+					);
 				throw new Error(`Unexpected request: ${u}`);
 			})
 		);

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -141,6 +141,8 @@ describe('QBittorrentClient add response parsing', () => {
 	it('detects duplicate via infoHash on structured failure', async () => {
 		const hash = 'abc123def456abc123def456abc123def456abc1';
 		const magnetUrl = `magnet:?xt=urn:btih:${hash}&dn=test`;
+		const returnedHash = hash;
+		const setForceStartCalled: string[] = [];
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async (url: string | URL | Request) => {
@@ -212,6 +214,8 @@ describe('QBittorrentClient add response parsing', () => {
 		expect(err).toBeInstanceOf(Error);
 		expect((err as { isDuplicate?: boolean }).isDuplicate).toBe(true);
 		expect((err as Error).message).toContain('already exists');
+		// Duplicate detection should short-circuit before any force-start attempt
+		expect(setForceStartCalled.length).toBe(0);
 	});
 
 	it('applies forceStart using hash returned by structured add response', async () => {

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -44,3 +44,85 @@ describe('QBittorrentClient sequential download', () => {
 		expect(addBody?.get('sequentialDownload')).toBe(expected);
 	});
 });
+
+describe('QBittorrentClient add response parsing', () => {
+	function stubAddResponse(body: string, status = 200): void {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string | URL | Request) => {
+				if (String(url).endsWith('/api/v2/auth/login')) {
+					return new Response('Ok.', {
+						status: 200,
+						headers: { 'set-cookie': 'SID=test-session; path=/' }
+					});
+				}
+				if (String(url).endsWith('/api/v2/torrents/add')) {
+					return new Response(body, { status });
+				}
+				throw new Error(`Unexpected qBittorrent request: ${String(url)}`);
+			})
+		);
+	}
+
+	function createClient(): QBittorrentClient {
+		return new QBittorrentClient({
+			host: 'localhost',
+			port: 8080,
+			useSsl: false
+		});
+	}
+
+	it('accepts a successful WebAPI v2.14 response containing failure_count', async () => {
+		stubAddResponse(
+			JSON.stringify({
+				added_torrent_ids: ['3e0e520f8ac598a94539458192f71cbd01857c1e'],
+				failure_count: 0,
+				pending_count: 0,
+				success_count: 1
+			})
+		);
+
+		await expect(
+			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+		).resolves.toBe('3e0e520f8ac598a94539458192f71cbd01857c1e');
+	});
+
+	it('accepts a pending WebAPI v2.14 response', async () => {
+		stubAddResponse(
+			JSON.stringify({
+				added_torrent_ids: [],
+				failure_count: 0,
+				pending_count: 1,
+				success_count: 0
+			}),
+			202
+		);
+
+		await expect(
+			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+		).resolves.toBe('');
+	});
+
+	it('rejects a failed WebAPI v2.14 response', async () => {
+		stubAddResponse(
+			JSON.stringify({
+				added_torrent_ids: [],
+				failure_count: 1,
+				pending_count: 0,
+				success_count: 0
+			})
+		);
+
+		await expect(
+			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+		).rejects.toThrow('qBittorrent rejected the torrent');
+	});
+
+	it('continues to reject the legacy Fails. response', async () => {
+		stubAddResponse('Fails.');
+
+		await expect(
+			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+		).rejects.toThrow('qBittorrent rejected the torrent: Fails.');
+	});
+});

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -83,7 +83,10 @@ describe('QBittorrentClient add response parsing', () => {
 		);
 
 		await expect(
-			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+			createClient().addDownload({
+				downloadUrl: 'https://example.com/test.torrent',
+				category: 'movies'
+			})
 		).resolves.toBe('3e0e520f8ac598a94539458192f71cbd01857c1e');
 	});
 
@@ -99,7 +102,10 @@ describe('QBittorrentClient add response parsing', () => {
 		);
 
 		await expect(
-			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+			createClient().addDownload({
+				downloadUrl: 'https://example.com/test.torrent',
+				category: 'movies'
+			})
 		).resolves.toBe('');
 	});
 
@@ -114,7 +120,10 @@ describe('QBittorrentClient add response parsing', () => {
 		);
 
 		await expect(
-			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+			createClient().addDownload({
+				downloadUrl: 'https://example.com/test.torrent',
+				category: 'movies'
+			})
 		).rejects.toThrow('qBittorrent rejected the torrent');
 	});
 
@@ -122,7 +131,10 @@ describe('QBittorrentClient add response parsing', () => {
 		stubAddResponse('Fails.');
 
 		await expect(
-			createClient().addDownload({ downloadUrl: 'https://example.com/test.torrent' })
+			createClient().addDownload({
+				downloadUrl: 'https://example.com/test.torrent',
+				category: 'movies'
+			})
 		).rejects.toThrow('qBittorrent rejected the torrent: Fails.');
 	});
 });

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.test.ts
@@ -72,6 +72,42 @@ describe('QBittorrentClient add response parsing', () => {
 		});
 	}
 
+	function stubTorrent(hash: string) {
+		return {
+			hash,
+			name: 'test',
+			state: 'uploading',
+			size: 0,
+			progress: 0,
+			dlspeed: 0,
+			upspeed: 0,
+			priority: 0,
+			num_seeds: 0,
+			num_complete: 0,
+			num_leechs: 0,
+			num_incomplete: 0,
+			ratio: 0,
+			eta: 0,
+			category: 'movies',
+			save_path: '/downloads',
+			content_path: '/downloads/test',
+			downloaded: 0,
+			uploaded: 0,
+			tags: ''
+		};
+	}
+
+	function stubPreferences() {
+		return {
+			save_path: '/downloads',
+			max_ratio_enabled: false,
+			max_ratio: -1,
+			max_seeding_time_enabled: false,
+			max_seeding_time: -1,
+			max_ratio_act: 0
+		};
+	}
+
 	it('accepts a successful WebAPI v2.14 response containing failure_count', async () => {
 		stubAddResponse(
 			JSON.stringify({
@@ -141,8 +177,6 @@ describe('QBittorrentClient add response parsing', () => {
 	it('detects duplicate via infoHash on structured failure', async () => {
 		const hash = 'abc123def456abc123def456abc123def456abc1';
 		const magnetUrl = `magnet:?xt=urn:btih:${hash}&dn=test`;
-		const returnedHash = hash;
-		const setForceStartCalled: string[] = [];
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async (url: string | URL | Request) => {
@@ -155,67 +189,26 @@ describe('QBittorrentClient add response parsing', () => {
 				if (u.endsWith('/api/v2/torrents/add'))
 					return new Response(
 						JSON.stringify({
-							added_torrent_ids: [returnedHash],
-							failure_count: 0,
+							added_torrent_ids: [],
+							failure_count: 1,
 							pending_count: 0,
-							success_count: 1
+							success_count: 0
 						}),
 						{ status: 200 }
 					);
 				if (u.includes('/api/v2/app/preferences'))
-					return new Response(
-						JSON.stringify({
-							save_path: '/downloads',
-							max_ratio_enabled: false,
-							max_ratio: -1,
-							max_seeding_time_enabled: false,
-							max_seeding_time: -1,
-							max_ratio_act: 0
-						}),
-						{ status: 200 }
-					);
+					return new Response(JSON.stringify(stubPreferences()), { status: 200 });
 				if (u.includes('/api/v2/torrents/info'))
-					return new Response(
-						JSON.stringify([
-							{
-								hash: returnedHash,
-								state: 'uploading',
-								name: 'test',
-								size: 0,
-								progress: 0,
-								dlspeed: 0,
-								upspeed: 0,
-								priority: 0,
-								num_seeds: 0,
-								num_complete: 0,
-								num_leechs: 0,
-								num_incomplete: 0,
-								ratio: 0,
-								eta: 0,
-								category: 'movies',
-								save_path: '/downloads',
-								content_path: '/downloads/test'
-							}
-						]),
-						{ status: 200 }
-					);
-				if (u.includes('/api/v2/torrents/setForceStart')) {
-					setForceStartCalled.push(u);
-					return new Response('Ok.', { status: 200 });
-				}
+					return new Response(JSON.stringify([stubTorrent(hash)]), { status: 200 });
 				throw new Error(`Unexpected request: ${u}`);
 			})
 		);
 
-		// Should return the known hash rather than throwing: it's a duplicate
 		const err = await createClient()
-			.addDownload({ downloadUrl: magnetUrl, category: 'movies' })
+			.addDownload({ magnetUri: magnetUrl, category: 'movies' })
 			.catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(Error);
 		expect((err as { isDuplicate?: boolean }).isDuplicate).toBe(true);
-		expect((err as Error).message).toContain('already exists');
-		// Duplicate detection should short-circuit before any force-start attempt
-		expect(setForceStartCalled.length).toBe(0);
 	});
 
 	it('applies forceStart using hash returned by structured add response', async () => {
@@ -240,26 +233,14 @@ describe('QBittorrentClient add response parsing', () => {
 						}),
 						{ status: 200 }
 					);
+				if (u.includes('/api/v2/app/preferences'))
+					return new Response(JSON.stringify(stubPreferences()), { status: 200 });
 				if (u.includes('/api/v2/torrents/info'))
-					return new Response(JSON.stringify([{ hash: returnedHash, state: 'uploading' }]), {
-						status: 200
-					});
+					return new Response(JSON.stringify([stubTorrent(returnedHash)]), { status: 200 });
 				if (u.includes('/api/v2/torrents/setForceStart')) {
 					setForceStartCalled.push(u);
 					return new Response('Ok.', { status: 200 });
 				}
-				if (u.includes('/api/v2/app/preferences'))
-					return new Response(
-						JSON.stringify({
-							save_path: '/downloads',
-							max_ratio_enabled: false,
-							max_ratio: -1,
-							max_seeding_time_enabled: false,
-							max_seeding_time: -1,
-							max_ratio_act: 0
-						}),
-						{ status: 200 }
-					);
 				throw new Error(`Unexpected request: ${u}`);
 			})
 		);

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.ts
@@ -39,6 +39,43 @@ interface QBittorrentCategory {
 }
 
 /**
+ * Response from /api/v2/torrents/add in qBittorrent WebAPI v2.14.0+.
+ */
+interface QBittorrentAddResponse {
+	added_torrent_ids: string[];
+	failure_count: number;
+	pending_count: number;
+	success_count: number;
+}
+
+function parseAddResponse(response: string): QBittorrentAddResponse | null {
+	try {
+		const parsed: unknown = JSON.parse(response);
+		if (!parsed || typeof parsed !== 'object') return null;
+
+		const candidate = parsed as Record<string, unknown>;
+		if (
+			!Array.isArray(candidate.added_torrent_ids) ||
+			!candidate.added_torrent_ids.every((id) => typeof id === 'string') ||
+			typeof candidate.failure_count !== 'number' ||
+			typeof candidate.pending_count !== 'number' ||
+			typeof candidate.success_count !== 'number'
+		) {
+			return null;
+		}
+
+		return {
+			added_torrent_ids: candidate.added_torrent_ids as string[],
+			failure_count: candidate.failure_count,
+			pending_count: candidate.pending_count,
+			success_count: candidate.success_count
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
  * QBittorrent torrent info from /api/v2/torrents/info
  */
 interface QBittorrentTorrent {
@@ -659,9 +696,17 @@ export class QBittorrentClient implements IDownloadClient {
 			'[QBittorrent] Add torrent response'
 		);
 
-		// qBittorrent returns "Ok." on success, "Fails." on failure
-		// An empty response also indicates success in some versions
-		if (response && response.toLowerCase().includes('fail')) {
+		// WebAPI v2.14.0+ returns structured counters and torrent IDs. Older
+		// versions return "Ok." on success, "Fails." on failure, or an empty
+		// response on success.
+		const addResponse = parseAddResponse(response);
+		const responseIndicatesFailure = addResponse
+			? addResponse.failure_count > 0 &&
+				addResponse.success_count === 0 &&
+				addResponse.pending_count === 0
+			: response.trim().toLowerCase() === 'fails.';
+
+		if (responseIndicatesFailure) {
 			// Check if it's actually a duplicate that wasn't caught before
 			// (can happen with torrent files where we don't know hash beforehand)
 			if (infoHash) {
@@ -695,8 +740,9 @@ export class QBittorrentClient implements IDownloadClient {
 			throw new Error(`qBittorrent rejected the torrent: ${response}`);
 		}
 
-		// Get the hash to return
-		const returnHash = infoHash || '';
+		// WebAPI v2.14.0+ returns the added hash, which is useful when the source
+		// was a URL and Cinephage could not determine the hash before adding it.
+		const returnHash = infoHash || addResponse?.added_torrent_ids[0] || '';
 
 		// Apply file selection for episode pointers before force-starting.
 		if (returnHash && options.fileSelection && options.fileSelection.fileIndices.length > 0) {

--- a/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.ts
+++ b/src/lib/server/downloadClients/qbittorrent/QBittorrentClient.ts
@@ -737,7 +737,10 @@ export class QBittorrentClient implements IDownloadClient {
 				},
 				'[QBittorrent] Torrent add failed'
 			);
-			throw new Error(`qBittorrent rejected the torrent: ${response}`);
+			const failDetail = addResponse
+				? `${addResponse.failure_count} failed, ${addResponse.success_count} succeeded`
+				: response.trim();
+			throw new Error(`qBittorrent rejected the torrent: ${failDetail}`);
 		}
 
 		// WebAPI v2.14.0+ returns the added hash, which is useful when the source


### PR DESCRIPTION
## Summary

Parse qBittorrent WebAPI 2.14.0+ structured torrent-add responses instead of searching the raw response text for the substring `fail`.

This prevents successful responses containing `failure_count: 0` from being routed through failure and timing-dependent duplicate recovery. Legacy `Ok.` / `Fails.` / empty response behavior remains supported.

## Related Issues

Fixes #535

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Add a validated parser for the WebAPI 2.14.0+ `success_count`, `pending_count`, `failure_count`, and `added_torrent_ids` response.
- Treat a structured response as failed only when it reports failures with no successful or pending additions; retain an exact legacy `Fails.` check.
- Return the first `added_torrent_ids` hash when Cinephage could not determine a URL-based torrent hash before adding it.
- Add regression tests for successful, pending (HTTP 202), failed, and legacy failure responses.

## Areas Affected

- [ ] UI/Frontend
- [ ] API/Backend
- [ ] Indexers
- [x] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

Validation completed:

- `QBittorrentClient.test.ts`: 6/6 passed
- GitHub Actions Test: passed
- GitHub Actions Type Check: passed
- GitHub Actions Build: passed
- Targeted ESLint: passed
- Prettier and `git diff --check`: passed

## Checklist

- [x] Code follows project conventions
- [x] Changed files are formatted with the repository's Prettier configuration
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No new warnings from the changed code
- [ ] Documentation updated — not applicable

## Screenshots

Not applicable; download-client backend change only.
