### PR TITLE
fix(cinephage): preserve release version prefix

### DIFF
--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -9,4 +9,12 @@ describe('ensureVersionPrefix', () => {
 	it('does not duplicate an existing v prefix', () => {
 		expect(ensureVersionPrefix('v0.16.0')).toBe('v0.16.0');
 	});
+
+	it('leaves dev builds unchanged', () => {
+		expect(ensureVersionPrefix('dev-20260901-492')).toBe('dev-20260901-492');
+	});
+
+	it('leaves sha builds unchanged', () => {
+		expect(ensureVersionPrefix('sha-abc1234')).toBe('sha-abc1234');
+	});
 });

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { ensureVersionPrefix } from './version.js';
+
+describe('ensureVersionPrefix', () => {
+	it('adds the v prefix to a bare version', () => {
+		expect(ensureVersionPrefix('0.16.0')).toBe('v0.16.0');
+	});
+
+	it('does not duplicate an existing v prefix', () => {
+		expect(ensureVersionPrefix('v0.16.0')).toBe('v0.16.0');
+	});
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,5 +1,6 @@
 export const PLACEHOLDER_PACKAGE_VERSION = '0.1.0';
 
 export function ensureVersionPrefix(version: string): string {
+	if (version.startsWith('dev-') || version.startsWith('sha-')) return version;
 	return version.startsWith('v') ? version : `v${version}`;
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,5 @@
 export const PLACEHOLDER_PACKAGE_VERSION = '0.1.0';
+
+export function ensureVersionPrefix(version: string): string {
+	return version.startsWith('v') ? version : `v${version}`;
+}

--- a/src/routes/api/system/github-release/+server.ts
+++ b/src/routes/api/system/github-release/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { createChildLogger } from '$lib/logging';
+import { ensureVersionPrefix } from '$lib/version.js';
 
 const logger = createChildLogger({ logDomain: 'system' as const });
 
@@ -43,7 +44,7 @@ async function fetchLatestRelease(): Promise<CachedRelease> {
 
 	const release = (await releaseRes.json()) as { tag_name: string };
 	const tagName = release.tag_name;
-	const version = tagName.replace(/^v/, '');
+	const version = ensureVersionPrefix(tagName);
 
 	const refRes = await fetch(`${GITHUB_API_BASE}/repos/${GITHUB_REPO}/git/ref/tags/${tagName}`, {
 		headers

--- a/src/routes/settings/system/cinephage/+page.svelte
+++ b/src/routes/settings/system/cinephage/+page.svelte
@@ -5,6 +5,7 @@
 	import { Sparkles, Loader2 } from 'lucide-svelte';
 	import { SettingsPage } from '$lib/components/ui/settings';
 	import * as m from '$lib/paraglide/messages.js';
+	import { ensureVersionPrefix } from '$lib/version.js';
 	import {
 		updateCinephageConfig,
 		updateCinephageModule,
@@ -164,7 +165,7 @@
 					<span class="text-sm text-base-content/60">
 						{m.settings_cinephage_detectedIdentity()}:
 						<span class="font-mono text-base-content/80">
-							v{identity.version}
+							{ensureVersionPrefix(identity.version)}
 							{#if identity.commit}
 								({identity.commit})
 							{:else}
@@ -191,7 +192,7 @@
 						{m.settings_cinephage_latestRelease()}:
 						{#if config.latestVersion}
 							<span class="font-mono text-base-content/80">
-								v{config.latestVersion}
+								{ensureVersionPrefix(config.latestVersion)}
 								{#if config.latestCommit}({config.latestCommit}){/if}
 							</span>
 						{:else}


### PR DESCRIPTION
## Summary

Preserve the `v` prefix required by Cinephage release identities while displaying exactly one prefix in the Cinephage Network settings UI.

## Related Issues

Closes #537

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Changes Made

- Add a small shared helper that ensures a version has exactly one leading `v`.
- Keep the `v` prefix when **Fetch latest release** fills and saves the version override.
- Use the same helper for detected and latest release labels, preventing `vv0.16.0`.
- Add regression tests for both bare and already-prefixed versions.

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] Targeted tests pass (38/38)
- [x] Modified files pass Prettier
- [ ] Full `npm run check` (the local checkout's ignored Paraglide output contains empty placeholder locale modules; CI can regenerate these artifacts)

## Checklist

- [x] Code follows project conventions
- [x] Ran formatting checks on all modified files
- [x] Commit messages follow conventional commits
- [x] Svelte 5 runes used correctly
- [x] No new warnings in console or test output
- [x] Documentation updated (not applicable)