### PR TITLE
feat(indexers): add native Hungarian tracker definitions

### DIFF
--- a/data/indexers/definitions/bithumen.yaml
+++ b/data/indexers/definitions/bithumen.yaml
@@ -1,0 +1,208 @@
+---
+id: bithumen
+name: BitHUmen
+description: 'BitHUmen is a HUNGARIAN Private Torrent Tracker for MOVIES / TV / GENERAL'
+language: hu-HU
+type: private
+protocol: torrent
+encoding: ISO-8859-2
+links:
+  - https://bithumen.be/
+
+caps:
+  categorymappings:
+    - { id: 23, cat: Movies/SD, desc: 'Film/Hun/SD' }
+    - { id: 24, cat: Movies/DVD, desc: 'Film/Hun/DVD-R' }
+    - { id: 25, cat: Movies/HD, desc: 'Film/Hun/720p' }
+    - { id: 37, cat: Movies/HD, desc: 'Film/Hun/1080p' }
+    - { id: 33, cat: Movies/BluRay, desc: 'Film/Hun/Blu-ray' }
+    - { id: 30, cat: XXX, desc: 'XXX/SD' }
+    - { id: 19, cat: Movies/SD, desc: 'Film/Eng/SD' }
+    - { id: 20, cat: Movies/DVD, desc: 'Film/Eng/DVD-R' }
+    - { id: 5, cat: Movies/HD, desc: 'Film/Eng/720p' }
+    - { id: 39, cat: Movies/HD, desc: 'Film/Eng/1080p' }
+    - { id: 40, cat: Movies/BluRay, desc: 'Film/Eng/Blu-ray' }
+    - { id: 34, cat: XXX, desc: 'XXX/HD' }
+    - { id: 7, cat: TV/SD, desc: 'Sorozat/Hun/SD' }
+    - { id: 41, cat: TV/HD, desc: 'Sorozat/Hun/HD' }
+    - { id: 26, cat: TV/SD, desc: 'Sorozat/Eng/SD' }
+    - { id: 42, cat: TV/HD, desc: 'Sorozat/Eng/HD' }
+    - { id: 28, cat: Books, desc: 'eBook/Hun' }
+    - { id: 29, cat: Books, desc: 'eBook/Eng' }
+    - { id: 9, cat: Audio/MP3, desc: 'Mp3/Hun' }
+    - { id: 35, cat: Audio/Lossless, desc: 'Lossless/Hun' }
+    - { id: 1, cat: PC/0day, desc: 'Programok/ISO' }
+    - { id: 4, cat: PC/Games, desc: 'Jatekok/ISO' }
+    - { id: 31, cat: Console/PS4, desc: 'Jatekok/PS' }
+    - { id: 36, cat: Console/Wii, desc: 'Jatekok/Wii' }
+    - { id: 6, cat: Audio/MP3, desc: 'Mp3/Eng' }
+    - { id: 38, cat: Audio/Lossless, desc: 'Lossless/Eng' }
+    - { id: 22, cat: PC, desc: 'Programok/egyeb' }
+    - { id: 21, cat: PC, desc: 'Jatekok/Rip/Dox' }
+    - { id: 32, cat: 'Console/Xbox 360', desc: 'Jatekok/Xbox360' }
+    - { id: 27, cat: Other, desc: Klipek }
+    # Cinephage routes searches by the parent Newznab category. Duplicate
+    # mappings let a Movies/TV/etc. request expand to every matching tracker
+    # category while preserving the more precise parsed category.
+    - { id: 23, cat: Movies }
+    - { id: 24, cat: Movies }
+    - { id: 25, cat: Movies }
+    - { id: 37, cat: Movies }
+    - { id: 33, cat: Movies }
+    - { id: 19, cat: Movies }
+    - { id: 20, cat: Movies }
+    - { id: 5, cat: Movies }
+    - { id: 39, cat: Movies }
+    - { id: 40, cat: Movies }
+    - { id: 7, cat: TV }
+    - { id: 41, cat: TV }
+    - { id: 26, cat: TV }
+    - { id: 42, cat: TV }
+    - { id: 9, cat: Audio }
+    - { id: 35, cat: Audio }
+    - { id: 6, cat: Audio }
+    - { id: 38, cat: Audio }
+    - { id: 28, cat: Books }
+    - { id: 29, cat: Books }
+    - { id: 1, cat: PC }
+    - { id: 4, cat: PC }
+    - { id: 22, cat: PC }
+    - { id: 21, cat: PC }
+    - { id: 31, cat: Console }
+    - { id: 36, cat: Console }
+    - { id: 32, cat: Console }
+    - { id: 30, cat: XXX }
+    - { id: 34, cat: XXX }
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    music-search: [q]
+    book-search: [q]
+
+settings:
+  - name: cookie
+    type: text
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: added
+    options:
+      added: created
+      seeders: seeders
+      size: size
+      name: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: DESC
+    options:
+      DESC: desc
+      ASC: asc
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: 'If you do not visit the site for 1 year, you will be banned for inactivity. The permanent deletion of your account after the ban is 2 years.'
+
+login:
+  method: cookie
+  inputs:
+    cookie: '{{ .Config.cookie }}'
+  test:
+    path: index.php
+    selector: 'a[href^="/logout.php?"]'
+
+search:
+  paths:
+    - path: browse.php
+  inputs:
+    $raw: '{{ range .Categories }}c{{.}}=1&{{end}}'
+    search: '{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}'
+    onlytitle: '{{ if .Query.IMDBID }}{{ else }}yes{{ end }}'
+    sort: '{{ .Config.sort }}'
+    d: '{{ .Config.type }}'
+  rows:
+    selector: 'table#torrenttable > tbody > tr:has(a[href^="details.php?id="])'
+  fields:
+    category:
+      selector: 'a[href^="?cat="]'
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
+    # The link text is used directly so this definition does not depend on
+    # Cardigann's sequential .Result.title_default field expansion.
+    title:
+      selector: 'a[href^="details.php?id="]'
+    details:
+      selector: 'a[href^="details.php?id="]'
+      attribute: href
+    download:
+      selector: 'a[href^="details.php?id="]'
+      attribute: href
+      filters:
+        - name: replace
+          args: ['details.php?id=', 'download.php/']
+        - name: append
+          args: /invalid.torrent
+    poster:
+      selector: 'a[onmouseover^="bithumen.UI.images.coverShow"]'
+      attribute: onmouseover
+      optional: true
+      filters:
+        - name: regexp
+          args: '"(.*?)"'
+    imdbid:
+      selector: 'a[href*="imdb.com/title/tt"]'
+      attribute: href
+      optional: true
+    size:
+      selector: 'td:nth-child(6) > u'
+    files:
+      selector: 'td:nth-child(3)'
+      optional: true
+    grabs:
+      selector: 'td:nth-child(7)'
+    seeders:
+      selector: 'td:nth-child(8)'
+    leechers:
+      selector: 'td:nth-child(9)'
+      filters:
+        - name: regexp
+          args: '\s*([\d,]+)'
+    genre:
+      selector: 'span:has(a[href^="browse.php?genre="])'
+      optional: true
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      selector: 'td:nth-child(5) > nobr > font:contains(" x ")'
+      optional: true
+      default: 1
+    minimumseedtime:
+      text: 86400
+    description:
+      selector: 'td:nth-child(2) > div'
+      optional: true
+    # BitHUmen uses "MM. DD. HH:mm", "ma HH:mm", "tegnap HH:mm", and
+    # occasionally an ISO date. Normalize all of them with Cinephage filters.
+    # For ma/tegnap, fuzzytime preserves the correct day but uses the current
+    # clock time because Cinephage exposes only .Today.Year to YAML templates.
+    date:
+      selector: 'td:nth-child(5)'
+      remove: font
+      optional: true
+      filters:
+        - name: trim
+        - name: re_replace
+          args:
+            - '^([0-9]{1,2})\.\s*([0-9]{1,2})\.\s*([0-9]{1,2}:[0-9]{2})$'
+            - '{{ .Today.Year }}-$1-$2 $3 +01:00'
+        - name: re_replace
+          args: ['^ma(?:\s+.*)?$', 'today']
+        - name: re_replace
+          args: ['^tegnap(?:\s+.*)?$', 'yesterday']
+        - name: fuzzytime

--- a/data/indexers/definitions/majomparade.yaml
+++ b/data/indexers/definitions/majomparade.yaml
@@ -1,0 +1,296 @@
+---
+id: majomparade
+name: Majomparádé
+description: 'Majomparádé (TurkDepo) is a HUNGARIAN Private Torrent Tracker for MOVIES / TV / GENERAL'
+language: hu-HU
+type: private
+protocol: torrent
+encoding: UTF-8
+requestdelay: 2
+links:
+  - https://majomparade.eu/
+  - https://majomparade.net/
+
+caps:
+  categorymappings:
+    - { id: 2, cat: Movies/3D, desc: '3D/Kulfoldi', default: true }
+    - { id: 1, cat: Movies/3D, desc: '3D/Magyar', default: true }
+    - { id: 3, cat: Movies/HD, desc: 'Film/BR-BDRIP/Kulfoldi', default: true }
+    - { id: 4, cat: Movies/HD, desc: 'Film/BR-BDRIP/Magyar', default: true }
+    - { id: 5, cat: Movies/SD, desc: 'Film/Cam/Kulfoldi', default: true }
+    - { id: 6, cat: Movies/SD, desc: 'Film/Cam/Magyar', default: true }
+    - { id: 7, cat: Movies/DVD, desc: 'Film/DVD/Kulfoldi', default: true }
+    - { id: 8, cat: Movies/DVD, desc: 'Film/DVD/Magyar', default: true }
+    - { id: 9, cat: Movies/DVD, desc: 'Film/DVD9/Kulfold', default: true }
+    - { id: 10, cat: Movies/DVD, desc: 'Film/DVD9/Magyar', default: true }
+    - { id: 11, cat: Movies/HD, desc: 'Film/HD/Kulfoldi', default: true }
+    - { id: 12, cat: Movies/HD, desc: 'Film/HD/Magyar', default: true }
+    - { id: 13, cat: Movies/SD, desc: 'Film/XviD/Kulfoldi', default: true }
+    - { id: 14, cat: Movies/SD, desc: 'Film/XviD/Magyar', default: true }
+    - { id: 21, cat: Audio/Audiobook, desc: Hangoskonyv, default: true }
+    - { id: 24, cat: PC/Games, desc: 'Jatek/ISO', default: true }
+    - { id: 25, cat: Console, desc: 'Jatek/Konzol', default: true }
+    - { id: 26, cat: PC/Games, desc: 'Jatek/RIP', default: true }
+    - { id: 22, cat: Books, desc: 'Konyv/Kulfoldi', default: true }
+    - { id: 23, cat: Books, desc: 'Konyv/Magyar', default: true }
+    - { id: 27, cat: Audio/Lossless, desc: 'Lossless/Kulfoldi', default: true }
+    - { id: 28, cat: Audio/Lossless, desc: 'Lossless/Magyar', default: true }
+    - { id: 31, cat: PC/Mobile-Other, desc: Mobil, default: true }
+    - { id: 32, cat: PC/ISO, desc: 'Programok/ISO', default: true }
+    - { id: 33, cat: PC/0day, desc: 'Programok/RIP', default: true }
+    - { id: 20, cat: TV/HD, desc: 'Sorozat/HD/Magyar', default: true }
+    - { id: 19, cat: TV/HD, desc: 'Sorozat/HD/Kulfoldi', default: true }
+    - { id: 17, cat: TV/SD, desc: 'Sorozat/Kulfoldi', default: true }
+    - { id: 18, cat: TV/SD, desc: 'Sorozat/Magyar', default: true }
+    - { id: 15, cat: TV/Sport, desc: 'Sport/Kulfoldi', default: true }
+    - { id: 16, cat: TV/Sport, desc: 'Sport/Magyar', default: true }
+    - { id: 29, cat: Audio/Other, desc: 'Zene/Kulfoldi', default: true }
+    - { id: 30, cat: Audio/Other, desc: 'Zene/Magyar', default: true }
+    - { id: 34, cat: XXX/DVD, desc: 'XXX/DVD', default: false }
+    - { id: 36, cat: XXX/x264, desc: 'XXX/HD', default: false }
+    - { id: 35, cat: XXX/XviD, desc: 'XXX/XviD', default: false }
+    # Parent mappings are required by Cinephage's typed search routing.
+    - { id: 2, cat: Movies }
+    - { id: 1, cat: Movies }
+    - { id: 3, cat: Movies }
+    - { id: 4, cat: Movies }
+    - { id: 5, cat: Movies }
+    - { id: 6, cat: Movies }
+    - { id: 7, cat: Movies }
+    - { id: 8, cat: Movies }
+    - { id: 9, cat: Movies }
+    - { id: 10, cat: Movies }
+    - { id: 11, cat: Movies }
+    - { id: 12, cat: Movies }
+    - { id: 13, cat: Movies }
+    - { id: 14, cat: Movies }
+    - { id: 20, cat: TV }
+    - { id: 19, cat: TV }
+    - { id: 17, cat: TV }
+    - { id: 18, cat: TV }
+    - { id: 15, cat: TV }
+    - { id: 16, cat: TV }
+    - { id: 21, cat: Audio }
+    - { id: 27, cat: Audio }
+    - { id: 28, cat: Audio }
+    - { id: 29, cat: Audio }
+    - { id: 30, cat: Audio }
+    - { id: 22, cat: Books }
+    - { id: 23, cat: Books }
+    - { id: 24, cat: PC }
+    - { id: 26, cat: PC }
+    - { id: 31, cat: PC }
+    - { id: 32, cat: PC }
+    - { id: 33, cat: PC }
+    - { id: 25, cat: Console }
+    - { id: 34, cat: XXX }
+    - { id: 36, cat: XXX }
+    - { id: 35, cat: XXX }
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    music-search: [q]
+    book-search: [q]
+
+settings:
+  - name: cookie
+    type: text
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
+  - name: useragent
+    type: text
+    label: User-Agent
+  - name: info_useragent
+    type: info_useragent
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 0
+    # Cinephage stores select values as indices. Omitting the site's numeric
+    # size key keeps all exposed keys index-stable without a runtime change.
+    options:
+      0: created
+      1: title
+      5: seeders
+  - name: type
+    type: select
+    label: Order requested from site
+    default: 0
+    options:
+      0: desc
+      1: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: 'For best results, change the Torrentek oldalankent setting to 100 on your account profile.'
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: 'Users who have been inactive for more than 25 weeks are automatically deleted.'
+
+login:
+  method: cookie
+  inputs:
+    cookie: '{{ .Config.cookie }}'
+  test:
+    path: index
+    selector: 'a[href^="/logout/"]'
+
+search:
+  paths:
+    # Embedding search_text in the path is intentional: Cinephage recognizes
+    # .Keywords in paths as a meaningful query without requiring a source-code
+    # whitelist entry for the tracker's custom search_text parameter.
+    - path: 'torrents/?search_text={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}'
+      categories:
+        [
+          '2',
+          '1',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '8',
+          '9',
+          '10',
+          '11',
+          '12',
+          '13',
+          '14',
+          '21',
+          '24',
+          '25',
+          '26',
+          '27',
+          '28',
+          '31',
+          '32',
+          '33',
+          '20',
+          '19',
+          '17',
+          '18',
+          '15',
+          '16',
+          '29',
+          '30'
+        ]
+    - path: 'torrents/turkalo/?search_text={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}'
+      categories:
+        [
+          '2',
+          '1',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '8',
+          '9',
+          '10',
+          '11',
+          '12',
+          '13',
+          '14',
+          '21',
+          '24',
+          '25',
+          '26',
+          '27',
+          '28',
+          '31',
+          '32',
+          '33',
+          '20',
+          '19',
+          '17',
+          '18',
+          '15',
+          '16',
+          '29',
+          '30'
+        ]
+    - path: 'torrents/xxx/?search_text={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}'
+      categories: ['34', '36', '35']
+  inputs:
+    action: search
+    incldead: 1
+    $raw: '{{ range .Categories }}&categories[]={{.}}{{end}}'
+    sort: '{{ .Config.sort }}'
+    order_by: '{{ .Config.type }}'
+  headers:
+    User-Agent: ['{{ .Config.useragent }}']
+  rows:
+    selector: article.torrent-card
+  fields:
+    category:
+      selector: 'a[href*="&categories[]="]'
+      attribute: href
+      filters:
+        - name: querystring
+          args: 'categories[]'
+    title:
+      selector: a.torrent-title
+      attribute: data-name
+    details:
+      selector: a.torrent-title
+      attribute: href
+    download:
+      selector: a.torrent-title
+      attribute: data-dl
+    imdbid:
+      selector: 'a[href*="imdb.com/title/tt"]'
+      attribute: href
+      optional: true
+    poster:
+      selector: a.torrent-title
+      attribute: data-cover
+      optional: true
+    size:
+      selector: 'div.torrent-card__meta-short span:nth-child(3)'
+      # The tracker uses Hungarian decimal commas (for example 10,03 GB).
+      # Cinephage otherwise strips the comma and interprets that as 1003 GB.
+      filters:
+        - name: replace
+          args: [',', '.']
+    grabs:
+      selector: 'a[href^="/torrent/snatches/"]'
+    seeders:
+      selector: 'a[href^="/torrent/peers/"]'
+    leechers:
+      selector: 'a[href$="leechers"]'
+    date:
+      selector: 'div.torrent-card__meta-short span:nth-child(1)'
+      filters:
+        - name: append
+          args: ' +01:00'
+        - name: dateparse
+          args: 'YYYY-MM-DD HH:mm:ss Z'
+    downloadvolumefactor:
+      text: 1
+    uploadvolumefactor:
+      case:
+        'span.torrent-chip--boost:contains("0.5x")': '0.5'
+        'span.torrent-chip--boost:contains("2x")': '2'
+        'span.torrent-chip--boost:contains("3x")': '3'
+        'span.torrent-chip--boost:contains("4x")': '4'
+        '*': '1'
+    # Resolve verification directly from the row instead of relying on a
+    # previously extracted .Result._verification variable.
+    description:
+      case:
+        span.torrent-chip--mod-ok: Verified
+        span.torrent-chip--mod-unknown: Unverified
+        span.torrent-chip--mod-bad: Blocked
+        '*': Unverified
+    genre:
+      selector: div.torrent-card__actions-row
+      remove: 'a, span.torrent-chip--boost, span.torrent-chip--mod-ok, span.torrent-chip--mod-unknown'
+      optional: true
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      text: 172800

--- a/data/indexers/definitions/ztracker.yaml
+++ b/data/indexers/definitions/ztracker.yaml
@@ -1,0 +1,233 @@
+---
+id: ztracker
+name: Ztracker
+description: 'Ztracker is a HUNGARIAN Semi-Private Torrent Tracker for 0DAY / GENERAL'
+language: hu-HU
+type: semi-private
+protocol: torrent
+encoding: ISO-8859-2
+links:
+  - https://ztracker.cc/
+legacylinks:
+  - http://ztracker.org/
+  - http://ztracker.cc/
+
+caps:
+  categorymappings:
+    - { id: 29, cat: Movies/SD, desc: 'CAM/EN' }
+    - { id: 30, cat: Movies/SD, desc: 'CAM/HUN' }
+    - { id: 49, cat: Books, desc: 'EBOOK/EN' }
+    - { id: 3, cat: Books, desc: 'EBOOK/HU' }
+    - { id: 37, cat: Movies/UHD, desc: 'FILM/4K/EN' }
+    - { id: 32, cat: Movies/UHD, desc: 'FILM/4K/HU' }
+    - { id: 36, cat: Movies/DVD, desc: 'FILM/DVD/EN' }
+    - { id: 34, cat: Movies/DVD, desc: 'FILM/DVD/HU' }
+    - { id: 35, cat: Movies/HD, desc: 'FILM/HD/EN' }
+    - { id: 31, cat: Movies/HD, desc: 'FILM/HD/HU' }
+    - { id: 8, cat: Movies/SD, desc: 'FILM/SD/EN' }
+    - { id: 28, cat: Movies/SD, desc: 'Mese/Kulfoldi' }
+    - { id: 26, cat: TV/SD, desc: 'SOROZAT/SD/EN' }
+    - { id: 7, cat: Movies/SD, desc: 'FILM/SD/HU' }
+    - { id: 27, cat: Movies/SD, desc: 'Mese/HUN' }
+    - { id: 25, cat: TV/SD, desc: 'SOROZAT/SD/HU' }
+    - { id: 45, cat: Console, desc: 'JATEK/KONZOL' }
+    - { id: 4, cat: PC/Games, desc: 'JATEK/PC/ISO' }
+    - { id: 18, cat: Other, desc: Kepek }
+    - { id: 17, cat: XXX, desc: 'XXX/IMAGESET' }
+    - { id: 24, cat: PC/Mobile-Other, desc: 'PROG/MOBIL' }
+    - { id: 1, cat: PC/0day, desc: 'PROG/PC/ISO' }
+    - { id: 47, cat: TV/UHD, desc: 'SOROZAT/4K/EN' }
+    - { id: 48, cat: TV/UHD, desc: 'SOROZAT/4K/HU' }
+    - { id: 51, cat: TV/SD, desc: 'SOROZAT/DVD/EN' }
+    - { id: 50, cat: TV/SD, desc: 'SOROZAT/DVD/HU' }
+    - { id: 46, cat: TV/HD, desc: 'SOROZAT/HD/EN' }
+    - { id: 44, cat: TV/HD, desc: 'SOROZAT/HD/HU' }
+    - { id: 41, cat: XXX, desc: 'XXX/4K' }
+    - { id: 40, cat: XXX, desc: 'XXX/DVD' }
+    - { id: 16, cat: XXX, desc: 'XXX/HD' }
+    - { id: 15, cat: XXX, desc: 'XXX/SD' }
+    - { id: 12, cat: Audio/MP3, desc: 'ZENE/MP3/EN' }
+    - { id: 11, cat: Audio/MP3, desc: 'ZENE/MP3/HU' }
+    # Cinephage routes typed searches through parent Newznab categories.
+    - { id: 29, cat: Movies }
+    - { id: 30, cat: Movies }
+    - { id: 37, cat: Movies }
+    - { id: 32, cat: Movies }
+    - { id: 36, cat: Movies }
+    - { id: 34, cat: Movies }
+    - { id: 35, cat: Movies }
+    - { id: 31, cat: Movies }
+    - { id: 8, cat: Movies }
+    - { id: 28, cat: Movies }
+    - { id: 7, cat: Movies }
+    - { id: 27, cat: Movies }
+    - { id: 26, cat: TV }
+    - { id: 25, cat: TV }
+    - { id: 47, cat: TV }
+    - { id: 48, cat: TV }
+    - { id: 51, cat: TV }
+    - { id: 50, cat: TV }
+    - { id: 46, cat: TV }
+    - { id: 44, cat: TV }
+    - { id: 12, cat: Audio }
+    - { id: 11, cat: Audio }
+    - { id: 4, cat: PC }
+    - { id: 24, cat: PC }
+    - { id: 1, cat: PC }
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    music-search: [q]
+    book-search: [q]
+
+settings:
+  - name: username
+    type: text
+    label: Username
+  - name: password
+    type: password
+    label: Password
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    # Cinephage stores selections as sorted option indices. Index 1 resolves
+    # to site key 4 (created), preserving Prowlarr's default without code changes.
+    default: 1
+    options:
+      '1': title
+      '4': created
+      '5': size
+      '7': seeders
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+
+login:
+  path: login.php
+  method: form
+  form: 'form[action="takelogin.php"]'
+  inputs:
+    username: '{{ .Config.username }}'
+    password: '{{ .Config.password }}'
+    logintype: yes
+  error:
+    - selector: div.error
+    - selector: 'table:has(img[src="/pic/ts_error/error.jpg"])'
+      message:
+        selector: 'table:has(img[src="/pic/ts_error/error.jpg"])'
+        remove: style
+  test:
+    path: index.php
+    selector: 'a[href*="/logout.php?logouthash="]'
+
+search:
+  paths:
+    # Ztracker calls its query parameter "keywords", which is not in
+    # Cinephage's meaningful-input whitelist. Embedding it in the path keeps
+    # keyword and IMDb searches active without a source-code change.
+    # Prefer IMDb because Ztracker indexes the ID stored on torrent detail
+    # pages in its description search. Fall back to the release title only
+    # when the request has no IMDb ID.
+    - path: 'browse_old.php?keywords={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}'
+  keywordsfilters:
+    - name: re_replace
+      args: ['[^a-zA-Z0-9]+', '%']
+  inputs:
+    $raw: '{{ range .Categories }}c{{.}}=1&{{end}}'
+    search_type: '{{ if .Query.IMDBID }}t_description{{ else }}t_name{{ end }}'
+    ts_type: '{{ if .Config.freeleech }}3{{ else }}1{{ end }}'
+    sort: '{{ .Config.sort }}'
+    type: '{{ .Config.type }}'
+  rows:
+    # Cinephage's selector engine does not reliably evaluate :has() on this
+    # legacy XHTML response. The results table has one header row, followed by
+    # torrent rows, and one final legend row.
+    selector: 'table[border="1"] > tbody > tr:nth-child(n+2):not(:last-child)'
+  fields:
+    category:
+      selector: 'a[href^="/browse_old.php?cat="]'
+      attribute: href
+      optional: true
+      default: 18
+      filters:
+        - name: querystring
+          args: cat
+    title:
+      selector: 'a[href*="details.php?id="][onmouseover]'
+      attribute: onmouseover
+      filters:
+        - name: regexp
+          # The hover HTML contains backslash-escaped quotes.
+          args: 'smalltext[^>]*>(.*?)</font>'
+    details:
+      selector: 'a[href*="details.php?id="][onmouseover]'
+      attribute: href
+    download:
+      selector: 'a[href*="details.php?id="]'
+      attribute: href
+      filters:
+        - name: replace
+          args: ['details.php', 'download.php']
+    poster:
+      selector: 'a[href*="details.php?id="][onmouseover]'
+      attribute: onmouseover
+      optional: true
+      filters:
+        - name: regexp
+          args: 'img src=[^A-Za-z0-9]*(https?://[^\\''"]+)'
+    imdbid:
+      selector: 'a[href*="imdb.com/title/tt"]'
+      attribute: href
+      optional: true
+    files:
+      selector: 'td:nth-child(5)'
+      optional: true
+    size:
+      selector: 'td:nth-child(11)'
+      optional: true
+      default: '0 B'
+      remove: b
+      # Hungarian decimal commas must be normalized before Cinephage parses bytes.
+      filters:
+        - name: replace
+          args: [',', '.']
+    seeders:
+      selector: 'td:nth-child(7)'
+    leechers:
+      selector: 'td:nth-child(8)'
+    downloadvolumefactor:
+      case:
+        'img[src="./pic/freedownload.gif"]': '0'
+        'img[src="./pic/silverdownload.gif"]': '0.5'
+        '*': '1'
+    uploadvolumefactor:
+      case:
+        'img[src="./pic/x2.gif"]': '2'
+        '*': '1'
+    minimumratio:
+      text: 0.8
+    minimumseedtime:
+      text: 259200
+    date:
+      selector: 'td:nth-child(2)'
+      remove: 'a, img'
+      filters:
+        - name: replace
+          args: ["\u00a0", ' ']
+        - name: trim
+        # Cinephage's fuzzy parser recognizes whole-word today/yesterday.
+        # The tracker appends a clock value, so normalize the complete value.
+        - name: re_replace
+          args: ['^Ma(?:\s+.*)?$', 'today']
+        - name: re_replace
+          args: ['^Tegnap(?:\s+.*)?$', 'yesterday']
+        - name: fuzzytime


### PR DESCRIPTION
## Summary

- Add native Cardigann-compatible definitions for the Hungarian BitHUmen, Majomparádé, and Ztracker trackers.
- Port and adapt the definitions from the official Prowlarr indexer collection to Cinephage's native YAML runtime.
- Keep the implementation definition-only: no application or indexer runtime source code is changed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Changes Made

- Add BitHUmen with native authentication, category mappings, search modes, freeleech metadata, and result parsing.
- Add Majomparádé with native authentication and result parsing, including Hungarian decimal-comma size normalization.
- Add Ztracker with native authentication, category mappings, legacy XHTML result parsing, and IMDb-first description search with title fallback.
- Adapt tracker-specific dates and secondary metadata using YAML filters only.

## Areas Affected

- [ ] UI/Frontend
- [ ] API/Backend
- [x] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Validation

- Live-tested authentication and search result parsing against all three trackers.
- Verified live title, size, seed/leech, category, date, and download URL extraction.
- Verified Ztracker IMDb lookup against a real torrent: its description search returned the matching releases for the IMDb ID, with title search retained as fallback.
- Loaded all three YAML documents successfully with js-yaml.
- All three definitions pass the repository's Prettier check.
- git diff --check passes.

## Checklist

- [x] Definitions follow existing native indexer conventions.
- [x] Ran formatting checks on all modified files.
- [x] Commit message follows Conventional Commits.
- [x] No source-code or runtime changes are included.
- [x] No new warnings were observed during live testing.
- [x] Documentation update is not required.