### PR TITLE
feat(subtitles): add Super Subtitles provider

### DIFF
--- a/src/lib/server/subtitles/providers.live.test.ts
+++ b/src/lib/server/subtitles/providers.live.test.ts
@@ -72,7 +72,12 @@ const ERROR_TIMEOUT_MS = 90000;
 // ============================================================================
 
 /** Providers to test (no API key required) */
-const NO_AUTH_PROVIDERS: ProviderImplementation[] = ['yifysubtitles', 'subf2m', 'gestdown'];
+const NO_AUTH_PROVIDERS: ProviderImplementation[] = [
+	'yifysubtitles',
+	'subf2m',
+	'gestdown',
+	'supersubtitles'
+];
 
 /** Providers to test only when explicitly enabled */
 const OPTIONAL_NO_AUTH_PROVIDERS: ProviderImplementation[] = ['addic7ed'];
@@ -81,12 +86,12 @@ const OPTIONAL_NO_AUTH_PROVIDERS: ProviderImplementation[] = ['addic7ed'];
 const INCLUDE_OPTIONAL_PROVIDERS = process.env.SUBTITLE_LIVE_TESTS_INCLUDE_OPTIONAL === 'true';
 
 /** Providers that support movies */
-const MOVIE_PROVIDERS: ProviderImplementation[] = ['yifysubtitles', 'subf2m'];
+const MOVIE_PROVIDERS: ProviderImplementation[] = ['yifysubtitles', 'subf2m', 'supersubtitles'];
 
 /** Providers that support TV shows */
 const TV_PROVIDERS: ProviderImplementation[] = INCLUDE_OPTIONAL_PROVIDERS
-	? ['addic7ed', 'gestdown', 'subf2m']
-	: ['gestdown', 'subf2m'];
+	? ['addic7ed', 'gestdown', 'subf2m', 'supersubtitles']
+	: ['gestdown', 'subf2m', 'supersubtitles'];
 
 // ============================================================================
 // Helper Functions

--- a/src/lib/server/subtitles/providers/index.ts
+++ b/src/lib/server/subtitles/providers/index.ts
@@ -22,6 +22,7 @@ export * from './mixins';
 // Provider implementations
 
 // Regional providers
+export { SuperSubtitlesProvider } from './supersubtitles/SuperSubtitlesProvider';
 export { NapiprojektProvider } from './napiprojekt/NapiprojektProvider';
 export { LegendasdivxProvider } from './legendasdivx/LegendasdivxProvider';
 export { BetaseriesProvider } from './betaseries/BetaseriesProvider';

--- a/src/lib/server/subtitles/providers/registry.ts
+++ b/src/lib/server/subtitles/providers/registry.ts
@@ -210,6 +210,16 @@ export async function registerBuiltinProviders(): Promise<void> {
 	}
 
 	try {
+		// Import and register Super Subtitles (feliratok.eu)
+		const supersubtitles = await import('./supersubtitles');
+		if (supersubtitles.PROVIDER_INFO) {
+			providerRegistry.register(supersubtitles.PROVIDER_INFO);
+		}
+	} catch (error) {
+		logger.warn({ error }, 'Failed to register supersubtitles provider');
+	}
+
+	try {
 		// Import and register Podnapisi (Slovenian)
 		const podnapisi = await import('./podnapisi');
 		if (podnapisi.PROVIDER_INFO) {

--- a/src/lib/server/subtitles/providers/supersubtitles/SuperSubtitlesProvider.test.ts
+++ b/src/lib/server/subtitles/providers/supersubtitles/SuperSubtitlesProvider.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import { strToU8, zipSync } from 'fflate';
+import type { SubtitleSearchResult } from '../../types';
+import {
+	decodeDownloadContext,
+	extractSuperSubtitlesArchive,
+	parseAutocomplete,
+	parseEpisodeRows,
+	parseMovieRows,
+	selectBestRelease,
+	selectSeriesId,
+	SuperSubtitlesProvider
+} from './SuperSubtitlesProvider';
+
+const BASE_RESULT: SubtitleSearchResult = {
+	providerId: 'provider-id',
+	providerName: 'Super Subtitles',
+	providerSubtitleId: '123|1|2|1',
+	language: 'en',
+	title: 'Example S01E02',
+	releaseName: '1080p.WEB-DL-NTb',
+	fileName: 'Example.S01.1080p.WEB-DL-NTb.ENG.zip',
+	isForced: false,
+	isHearingImpaired: false,
+	format: 'srt',
+	isHashMatch: false,
+	matchScore: 0
+};
+
+describe('SuperSubtitlesProvider parsers', () => {
+	it('parses current movie rows and keeps the direct download metadata', () => {
+		const html = `
+			<table class="result"><tr id="vilagit">
+				<td>Film</td><td class="lang"><small>Magyar</small></td>
+				<td><div class="magyar">Dűne: Második rész (SubRip)</div>
+				<div class="eredeti">Dune: Part Two (2024) (NF.WEBRip)</div></td>
+				<td>Anonymus</td><td>2025-05-21</td>
+				<td><a href="/index.php?action=letolt&amp;fnev=Dune.Part.Two.2024.hu.srt&amp;felirat=1747826315">Download</a></td>
+			</tr></table>`;
+
+		const rows = parseMovieRows(html);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			id: '1747826315',
+			language: 'hu',
+			title: 'Dune: Part Two',
+			year: 2024,
+			releases: ['NF.WEBRip'],
+			uploader: 'Anonymus',
+			fileName: 'Dune.Part.Two.2024.hu.srt'
+		});
+		expect(rows[0].downloadUrl).toContain('felirat=1747826315');
+	});
+
+	it('accepts array-shaped episode JSON and groups compatible releases', () => {
+		const payload = [
+			{
+				language: 'Angol',
+				nev: 'The Last of Us (Season 1) (1080p-PEDRO)',
+				fnev: 'The.Last.Of.Us.S01.1080p-PEDRO.ENG.zip',
+				felirat: '1690360356',
+				evad: '1',
+				ep: '-1',
+				feltolto: 'J1GG4',
+				evadpakk: '1'
+			},
+			{
+				language: 'Angol',
+				nev: 'The Last of Us (Season 1) (2160p-JUNGLiST)',
+				fnev: 'The.Last.Of.Us.S01.1080p-PEDRO.ENG.zip',
+				felirat: '1690360356',
+				evad: '1',
+				ep: '-1',
+				feltolto: 'J1GG4',
+				evadpakk: '1'
+			}
+		];
+
+		const rows = parseEpisodeRows(payload, {
+			title: 'Episode title',
+			seriesTitle: 'The Last of Us',
+			season: 1,
+			episode: 2
+		});
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ season: 1, episode: 2, isPack: true, language: 'en' });
+		expect(rows[0].releases).toEqual(['1080p-PEDRO', '2160p-JUNGLiST']);
+	});
+
+	it('also accepts the legacy object-shaped episode JSON', () => {
+		const rows = parseEpisodeRows(
+			{
+				'10': {
+					language: 'Magyar',
+					nev: 'Example - 1x02 (WEB-DL-NTb)',
+					fnev: 'Example.S01E02.HUN.zip',
+					felirat: '42',
+					evad: '1',
+					ep: '2',
+					evadpakk: '0'
+				}
+			},
+			{ title: 'Episode', seriesTitle: 'Example', season: 1, episode: 2 }
+		);
+		expect(rows[0]).toMatchObject({
+			id: '42',
+			language: 'hu',
+			season: 1,
+			episode: 2,
+			isPack: false
+		});
+	});
+
+	it('selects the exact series title and year from autocomplete', () => {
+		const entries = parseAutocomplete([
+			{ name: 'Example (1999)', ID: '1' },
+			{ name: 'Example (2024)', ID: '2' }
+		]);
+		expect(selectSeriesId(entries, 'Example', 2024)).toBe('2');
+		expect(selectSeriesId(entries, 'Example', 2001)).toBeUndefined();
+	});
+
+	it('selects the release closest to the local video file', () => {
+		expect(
+			selectBestRelease(
+				['720p.WEB-DL-OTHER', '1080p.WEB-DL-NTb'],
+				'/media/Example.S01E02.1080p.WEB-DL.DDP5.1-NTb.mkv'
+			)
+		).toBe('1080p.WEB-DL-NTb');
+	});
+});
+
+describe('SuperSubtitlesProvider archive extraction', () => {
+	it('ignores non-subtitle files and extracts the requested pack episode', () => {
+		const archive = Buffer.from(
+			zipSync({
+				'README.txt': strToU8('not a subtitle'),
+				'Example.S01E01.1080p.WEB-DL-NTb.srt': strToU8('episode one'),
+				'Example.S01E02.1080p.WEB-DL-NTb.srt': strToU8('episode two')
+			})
+		);
+		const content = extractSuperSubtitlesArchive(
+			archive,
+			BASE_RESULT,
+			decodeDownloadContext('123|1|2|1')
+		);
+		expect(content.toString()).toBe('episode two');
+	});
+
+	it('uses the matched release when a pack has multiple files for one episode', () => {
+		const archive = Buffer.from(
+			zipSync({
+				'Example.S01E02.720p.WEB-DL-OTHER.srt': strToU8('other release'),
+				'Example.S01E02.1080p.WEB-DL-NTb.srt': strToU8('matching release')
+			})
+		);
+		const content = extractSuperSubtitlesArchive(
+			archive,
+			BASE_RESULT,
+			decodeDownloadContext('123|1|2|1')
+		);
+		expect(content.toString()).toBe('matching release');
+	});
+
+	it('supports single-season packs that use bare E02 tokens', () => {
+		const archive = Buffer.from(
+			zipSync({
+				'Example.E01.1080p.srt': strToU8('episode one'),
+				'Example.E02.1080p.srt': strToU8('episode two')
+			})
+		);
+		const content = extractSuperSubtitlesArchive(
+			archive,
+			BASE_RESULT,
+			decodeDownloadContext('123|1|2|1')
+		);
+		expect(content.toString()).toBe('episode two');
+	});
+
+	it('fails instead of silently returning the wrong episode', () => {
+		const archive = Buffer.from(
+			zipSync({
+				'Example.S01E01.srt': strToU8('episode one'),
+				'notes.nfo': strToU8('metadata')
+			})
+		);
+		expect(() =>
+			extractSuperSubtitlesArchive(archive, BASE_RESULT, decodeDownloadContext('123|1|2|1'))
+		).toThrow(/S01E02/);
+	});
+});
+
+describe.skipIf(process.env.LIVE_TESTS !== 'true')('SuperSubtitlesProvider live flow', () => {
+	const provider = new SuperSubtitlesProvider({
+		id: 'live-supersubtitles',
+		name: 'Super Subtitles',
+		implementation: 'supersubtitles',
+		enabled: true,
+		priority: 1,
+		requestsPerMinute: 30,
+		consecutiveFailures: 0
+	});
+
+	it('searches and downloads the requested episode from a real season pack', async () => {
+		const results = await provider.search({
+			title: 'Infected',
+			seriesTitle: 'The Last of Us',
+			originalTitle: 'The Last of Us',
+			year: 2023,
+			season: 1,
+			episode: 2,
+			languages: ['en'],
+			filePath: '/media/The.Last.Of.Us.S01E02.1080p.BluRay.x264-PEDRO.mkv'
+		});
+		const pack = results.find((result) => decodeDownloadContext(result.providerSubtitleId).isPack);
+		expect(pack).toBeDefined();
+		const content = await provider.download(pack!);
+		expect(content.length).toBeGreaterThan(1000);
+		expect(content.toString('utf8', 0, 4096)).toContain('-->');
+	}, 90000);
+
+	it('searches and downloads a real movie subtitle', async () => {
+		const results = await provider.search({
+			title: 'Dune: Part Two',
+			originalTitle: 'Dune: Part Two',
+			year: 2024,
+			languages: ['hu']
+		});
+		expect(results.length).toBeGreaterThan(0);
+		const content = await provider.download(results[0]);
+		expect(content.length).toBeGreaterThan(1000);
+		expect(content.toString('utf8', 0, 4096)).toContain('-->');
+	}, 60000);
+});

--- a/src/lib/server/subtitles/providers/supersubtitles/SuperSubtitlesProvider.ts
+++ b/src/lib/server/subtitles/providers/supersubtitles/SuperSubtitlesProvider.ts
@@ -1,0 +1,654 @@
+/**
+ * Super Subtitles (feliratok.eu) provider.
+ *
+ * The public request flow is based on Bazarr's SuperSubtitles provider. The
+ * parsers intentionally support both the legacy object-shaped XBMC response
+ * and the array response currently returned by feliratok.eu.
+ */
+
+import * as cheerio from 'cheerio';
+import { basename, extname } from 'node:path';
+import { BaseSubtitleProvider } from '../BaseProvider';
+import { extractAllFromZip, type ExtractedFile } from '../mixins';
+import type { ProviderTestResult } from '../interfaces';
+import type {
+	LanguageCode,
+	ProviderSearchOptions,
+	SubtitleFormat,
+	SubtitleProviderConfig,
+	SubtitleSearchCriteria,
+	SubtitleSearchResult
+} from '../../types';
+import {
+	ParseResponseError,
+	ServiceUnavailable,
+	TooManyRequests
+} from '../../errors/ProviderErrors';
+import {
+	SUPERSUBTITLES_BASE_URL,
+	SUPERSUBTITLES_LANGUAGES,
+	type SuperSubtitlesAutocompleteEntry,
+	type SuperSubtitlesCandidate,
+	type SuperSubtitlesDownloadContext,
+	type SuperSubtitlesEpisodeEntry
+} from './types';
+
+const USER_AGENT =
+	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const SUBTITLE_EXTENSIONS = new Set(['.srt', '.ass', '.ssa', '.sub', '.vtt']);
+
+function asString(value: unknown): string {
+	return typeof value === 'string' || typeof value === 'number' ? String(value).trim() : '';
+}
+
+function asNumber(value: unknown): number | undefined {
+	const parsed = Number.parseInt(asString(value), 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalize(value: string | undefined): string {
+	return (value ?? '')
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, ' ')
+		.trim();
+}
+
+function unique(values: Array<string | undefined>): string[] {
+	return [
+		...new Set(values.map((value) => value?.trim()).filter((value): value is string => !!value))
+	];
+}
+
+function languageFromLabel(value: unknown): LanguageCode | undefined {
+	const label = normalize(asString(value));
+	if (label === 'magyar') return 'hu';
+	if (label === 'angol') return 'en';
+	return undefined;
+}
+
+function isForcedText(value: string): boolean {
+	const text = normalize(value);
+	return text.includes('szinkronoshoz') || text.includes('forced');
+}
+
+function parseMovieTitle(value: string): { title: string; year?: number; releases: string[] } {
+	const text = value.trim();
+	const match = text.match(/^(.*?)\s*\(((?:19|20)\d{2})\)\s*(?:\((.*)\))?\s*$/s);
+	if (!match) return { title: text, releases: [] };
+	return {
+		title: match[1].trim(),
+		year: Number.parseInt(match[2], 10),
+		releases: unique((match[3] ?? '').split(',').map((part) => part.trim()))
+	};
+}
+
+function parseEpisodeName(value: string): { title: string; release?: string } {
+	const text = value.trim();
+	const match = text.match(/^(.*?)\s*(?:-\s*\d+x\d+|\(Season\s+\d+\))?\s*\((.*)\)\s*$/i);
+	if (match) return { title: match[1].trim(), release: match[2].trim() };
+	return { title: text.split(/\s+\(Season\s+/i)[0].trim() };
+}
+
+function detailUrl(id: string): string {
+	return `${SUPERSUBTITLES_BASE_URL}/index.php?tipus=adatlap&azon=a_${encodeURIComponent(id)}`;
+}
+
+export function parseMovieRows(html: string): SuperSubtitlesCandidate[] {
+	const $ = cheerio.load(html);
+	const results: SuperSubtitlesCandidate[] = [];
+	const seen = new Set<string>();
+
+	$('tr#vilagit, tr[id="vilagit"]').each((_, element) => {
+		const row = $(element);
+		const link = row.find('a[href*="action=letolt"][href*="felirat="]').last();
+		const href = link.attr('href');
+		if (!href) return;
+
+		const url = new URL(href, `${SUPERSUBTITLES_BASE_URL}/`);
+		const id = url.searchParams.get('felirat')?.trim();
+		const language = languageFromLabel(row.find('small').first().text());
+		if (!id || !language || seen.has(`${id}:${language}`)) return;
+
+		const originalText = row.find('.eredeti').first().text().trim();
+		const localTitle = row
+			.find('.magyar')
+			.first()
+			.text()
+			.replace(/\s*\([^)]*SubRip[^)]*\)\s*$/i, '')
+			.trim();
+		const parsed = parseMovieTitle(originalText);
+		if (!parsed.title) return;
+
+		const cells = row.children('td');
+		const uploader = cells.eq(3).text().trim() || undefined;
+		const fileName = url.searchParams.get('fnev')?.trim() || undefined;
+		seen.add(`${id}:${language}`);
+		results.push({
+			id,
+			language,
+			title: parsed.title,
+			year: parsed.year,
+			isPack: false,
+			isForced: isForcedText(`${row.text()} ${href} ${fileName ?? ''}`),
+			releases: parsed.releases,
+			fileName,
+			uploader,
+			downloadUrl: url.toString(),
+			pageLink: detailUrl(id)
+		});
+
+		// Preserve the localized title as a matching alias without expanding the public type.
+		(results.at(-1) as SuperSubtitlesCandidate & { localTitle?: string }).localTitle = localTitle;
+	});
+
+	return results;
+}
+
+function episodeEntries(payload: unknown): SuperSubtitlesEpisodeEntry[] {
+	if (Array.isArray(payload)) return payload.filter((entry) => entry && typeof entry === 'object');
+	if (payload && typeof payload === 'object') {
+		return Object.values(payload).filter((entry) => entry && typeof entry === 'object');
+	}
+	return [];
+}
+
+export function parseEpisodeRows(
+	payload: unknown,
+	criteria: Pick<SubtitleSearchCriteria, 'seriesTitle' | 'title' | 'season' | 'episode'>
+): SuperSubtitlesCandidate[] {
+	const grouped = new Map<string, SuperSubtitlesCandidate>();
+
+	for (const entry of episodeEntries(payload)) {
+		const id = asString(entry.felirat);
+		const language = languageFromLabel(entry.language);
+		if (!id || !language) continue;
+
+		const parsedName = parseEpisodeName(asString(entry.nev));
+		const isPack = (asNumber(entry.evadpakk) ?? 0) !== 0;
+		const season = asNumber(entry.evad);
+		const rawEpisode = asNumber(entry.ep);
+		const episode = isPack
+			? criteria.episode
+			: rawEpisode !== undefined && rawEpisode >= 0
+				? rawEpisode
+				: undefined;
+		const fileName = asString(entry.fnev) || undefined;
+		const key = `${id}:${language}`;
+		const existing = grouped.get(key);
+
+		if (existing) {
+			if (parsedName.release && !existing.releases.includes(parsedName.release)) {
+				existing.releases.push(parsedName.release);
+			}
+			continue;
+		}
+
+		const downloadParams = new URLSearchParams({ action: 'letolt' });
+		if (fileName) downloadParams.set('fnev', fileName);
+		downloadParams.set('felirat', id);
+		grouped.set(key, {
+			id,
+			language,
+			title: parsedName.title || criteria.seriesTitle || criteria.title,
+			season: isPack ? criteria.season : season,
+			episode,
+			isPack,
+			isForced: isForcedText(`${asString(entry.nev)} ${fileName ?? ''}`),
+			releases: parsedName.release ? [parsedName.release] : [],
+			fileName,
+			uploader: asString(entry.feltolto) || undefined,
+			downloadUrl: `${SUPERSUBTITLES_BASE_URL}/index.php?${downloadParams.toString()}`,
+			pageLink: detailUrl(id)
+		});
+	}
+
+	return [...grouped.values()];
+}
+
+export function parseAutocomplete(
+	payload: unknown
+): Array<{ id: string; title: string; year?: number }> {
+	const entries = Array.isArray(payload)
+		? payload
+		: payload && typeof payload === 'object'
+			? [payload]
+			: [];
+	const results: Array<{ id: string; title: string; year?: number }> = [];
+	for (const raw of entries as SuperSubtitlesAutocompleteEntry[]) {
+		const id = asString(raw.ID) || asString(raw.id);
+		const name = asString(raw.name);
+		if (!id || !name) continue;
+		const parsed = parseMovieTitle(name);
+		results.push({ id, title: parsed.title || name, year: parsed.year });
+	}
+	return results;
+}
+
+export function selectSeriesId(
+	entries: Array<{ id: string; title: string; year?: number }>,
+	title: string,
+	year?: number
+): string | undefined {
+	const matches = entries.filter((entry) => normalize(entry.title) === normalize(title));
+	return (
+		matches.find((entry) => year === undefined || entry.year === year)?.id ??
+		(year === undefined ? matches[0]?.id : undefined)
+	);
+}
+
+function sourceToken(value: string): string | undefined {
+	const text = normalize(value);
+	if (text.includes('web')) return 'web';
+	if (/(?:bluray|blu ray|bdrip|brrip)/.test(text)) return 'bluray';
+	if (text.includes('hdtv')) return 'hdtv';
+	if (text.includes('dvd')) return 'dvd';
+	return undefined;
+}
+
+function resolutionToken(value: string): string | undefined {
+	return value.toLowerCase().match(/\b(?:480p|576p|720p|1080p|2160p|4k)\b/)?.[0];
+}
+
+function releaseGroup(value: string): string | undefined {
+	const withoutExtension = value.replace(/\.[a-z0-9]{2,4}$/i, '');
+	return [...withoutExtension.matchAll(/-([a-z0-9][a-z0-9._]+)\b/gi)].at(-1)?.[1];
+}
+
+function releaseScore(release: string, videoName: string): number {
+	const normalizedRelease = normalize(release);
+	const normalizedVideo = normalize(videoName);
+	let score = 0;
+	const group = releaseGroup(videoName);
+	if (
+		group &&
+		new RegExp(`\\b${group.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(release)
+	)
+		score += 50;
+	const resolution = resolutionToken(videoName);
+	if (resolution && normalizedRelease.includes(resolution)) score += 15;
+	const source = sourceToken(videoName);
+	if (source && sourceToken(release) === source) score += 10;
+	const videoTokens = new Set(normalizedVideo.split(' ').filter((token) => token.length >= 3));
+	score += normalizedRelease.split(' ').filter((token) => videoTokens.has(token)).length;
+	return score;
+}
+
+export function selectBestRelease(releases: string[], filePath?: string): string | undefined {
+	if (releases.length === 0) return undefined;
+	if (!filePath) return releases[0];
+	const videoName = basename(filePath);
+	return [...releases].sort((a, b) => releaseScore(b, videoName) - releaseScore(a, videoName))[0];
+}
+
+function encodeDownloadContext(candidate: SuperSubtitlesCandidate): string {
+	if (candidate.season === undefined || candidate.episode === undefined) return candidate.id;
+	return `${candidate.id}|${candidate.season}|${candidate.episode}|${candidate.isPack ? 1 : 0}`;
+}
+
+export function decodeDownloadContext(value: string): SuperSubtitlesDownloadContext {
+	const [id, season, episode, isPack] = value.split('|');
+	return {
+		id,
+		season: asNumber(season),
+		episode: asNumber(episode),
+		isPack: isPack === '1'
+	};
+}
+
+function memberHasEpisode(name: string, season: number, episode: number): boolean {
+	const text = normalize(basename(name));
+	return (
+		new RegExp(`\\bs0*${season}[\\s._-]*e0*${episode}(?!\\d)`, 'i').test(text) ||
+		new RegExp(`(?<!\\d)${season}x0*${episode}(?!\\d)`, 'i').test(text)
+	);
+}
+
+function memberHasSeasonEpisode(name: string): boolean {
+	const text = normalize(basename(name));
+	return /\bs0*\d+[\s._-]*e0*\d+(?!\d)/i.test(text) || /(?<!\d)\d+x0*\d+(?!\d)/i.test(text);
+}
+
+function memberHasBareEpisode(name: string, episode: number): boolean {
+	return new RegExp(`\\be0*${episode}(?!\\d)`, 'i').test(normalize(basename(name)));
+}
+
+function isUsableSubtitleEntry(file: ExtractedFile): boolean {
+	const name = basename(file.filename);
+	return (
+		!!name &&
+		!name.startsWith('.') &&
+		!file.filename.split(/[\\/]/).includes('__MACOSX') &&
+		SUBTITLE_EXTENSIONS.has(extname(name).toLowerCase()) &&
+		file.content.length > 0
+	);
+}
+
+function languageMemberScore(name: string, language: LanguageCode): number {
+	const text = normalize(basename(name));
+	const tokens =
+		language === 'hu' ? ['hu', 'hun', 'hungarian', 'magyar'] : ['en', 'eng', 'english', 'angol'];
+	return tokens.some((token) => new RegExp(`(?:^| )${token}(?: |$)`, 'i').test(text)) ? 20 : 0;
+}
+
+function memberScore(file: ExtractedFile, result: SubtitleSearchResult): number {
+	let score = releaseScore(file.filename, result.releaseName ?? result.fileName ?? '');
+	score += languageMemberScore(file.filename, result.language);
+	if (extname(file.filename).toLowerCase() === '.srt') score += 5;
+	if (!result.isForced && /(?:^|[. _-])forced(?:[. _-]|$)/i.test(basename(file.filename)))
+		score -= 100;
+	if (result.isForced && /(?:^|[. _-])forced(?:[. _-]|$)/i.test(basename(file.filename)))
+		score += 25;
+	return score;
+}
+
+export function extractSuperSubtitlesArchive(
+	data: Buffer,
+	result: SubtitleSearchResult,
+	context: SuperSubtitlesDownloadContext
+): Buffer {
+	let files = extractAllFromZip(data).filter(isUsableSubtitleEntry);
+	if (files.length === 0)
+		throw new Error('Super Subtitles archive contains no supported subtitle files');
+
+	if (context.season !== undefined && context.episode !== undefined) {
+		let episodeFiles = files.filter((file) =>
+			memberHasEpisode(file.filename, context.season!, context.episode!)
+		);
+		if (episodeFiles.length === 0 && !files.some((file) => memberHasSeasonEpisode(file.filename))) {
+			episodeFiles = files.filter((file) => memberHasBareEpisode(file.filename, context.episode!));
+		}
+		if (episodeFiles.length === 0) {
+			throw new Error(
+				`Super Subtitles archive has no subtitle for S${String(context.season).padStart(2, '0')}E${String(context.episode).padStart(2, '0')}`
+			);
+		}
+		files = episodeFiles;
+	} else if (context.isPack) {
+		throw new Error('Super Subtitles season pack is missing episode context');
+	}
+
+	files.sort(
+		(a, b) => memberScore(b, result) - memberScore(a, result) || b.content.length - a.content.length
+	);
+	return files[0].content;
+}
+
+function isZip(data: Buffer): boolean {
+	return data.length >= 4 && data[0] === 0x50 && data[1] === 0x4b;
+}
+
+function isRar(data: Buffer): boolean {
+	return data.subarray(0, 7).toString('binary').startsWith('Rar!\x1a\x07');
+}
+
+function isHtml(data: Buffer): boolean {
+	const head = data.subarray(0, 1024).toString('utf8').trimStart().toLowerCase();
+	return head.startsWith('<!doctype html') || head.startsWith('<html') || head.includes('<body');
+}
+
+function subtitleFormat(fileName?: string): SubtitleFormat {
+	const extension = extname(fileName ?? '')
+		.toLowerCase()
+		.slice(1);
+	return ['srt', 'ass', 'ssa', 'sub', 'vtt'].includes(extension)
+		? (extension as SubtitleFormat)
+		: 'srt';
+}
+
+export class SuperSubtitlesProvider extends BaseSubtitleProvider {
+	constructor(config: SubtitleProviderConfig) {
+		super(config);
+		this._capabilities = {
+			hashVerifiable: false,
+			hearingImpairedVerifiable: false,
+			skipWrongFps: false,
+			supportsTvShows: true,
+			supportsMovies: true,
+			supportsAnime: false
+		};
+	}
+
+	get implementation(): string {
+		return 'supersubtitles';
+	}
+
+	get supportedLanguages(): LanguageCode[] {
+		return SUPERSUBTITLES_LANGUAGES;
+	}
+
+	get supportsHashSearch(): boolean {
+		return false;
+	}
+
+	private async request(url: string, timeout: number, accept = 'text/html,*/*'): Promise<Response> {
+		const response = await this.fetchWithTimeout(url, {
+			timeout,
+			headers: {
+				Accept: accept,
+				'Accept-Language': 'hu-HU,hu;q=0.9,en-US;q=0.8,en;q=0.7',
+				Referer: `${SUPERSUBTITLES_BASE_URL}/index.php`,
+				'User-Agent': USER_AGENT
+			}
+		});
+		if (response.status === 429) {
+			const retryAfter = response.headers.get('retry-after');
+			throw new TooManyRequests(
+				this.implementation,
+				retryAfter ? Number.parseInt(retryAfter, 10) : undefined
+			);
+		}
+		if (response.status >= 500) throw new ServiceUnavailable(this.implementation);
+		if (!response.ok) throw new Error(`Super Subtitles request failed: HTTP ${response.status}`);
+		return response;
+	}
+
+	async search(
+		criteria: SubtitleSearchCriteria,
+		options?: ProviderSearchOptions
+	): Promise<SubtitleSearchResult[]> {
+		const languages = new Set(
+			criteria.languages.filter((language) => SUPERSUBTITLES_LANGUAGES.includes(language))
+		);
+		if (languages.size === 0) return [];
+
+		try {
+			const timeout = options?.timeout ?? 30000;
+			const candidates =
+				criteria.season !== undefined && criteria.episode !== undefined
+					? await this.searchEpisode(criteria, timeout)
+					: await this.searchMovie(criteria, timeout);
+			const results = candidates
+				.filter((candidate) => languages.has(candidate.language))
+				.map((candidate) => this.toResult(candidate, criteria));
+			const limited = results.slice(0, options?.maxResults ?? 25);
+			this.logSearch(criteria, limited.length);
+			this.recordSuccess();
+			return limited;
+		} catch (error) {
+			this.recordFailure(error instanceof Error ? error : new Error(String(error)));
+			this.logError('search', error);
+			throw error;
+		}
+	}
+
+	private async searchMovie(
+		criteria: SubtitleSearchCriteria,
+		timeout: number
+	): Promise<SuperSubtitlesCandidate[]> {
+		const wantedTitles = unique([criteria.originalTitle, criteria.title]);
+		for (const query of wantedTitles) {
+			const params = new URLSearchParams({
+				search: query,
+				soriSorszam: '',
+				nyelv: '',
+				tab: 'film'
+			});
+			const response = await this.request(
+				`${SUPERSUBTITLES_BASE_URL}/index.php?${params}`,
+				timeout
+			);
+			const rows = parseMovieRows(await response.text()).filter((row) => {
+				if (criteria.year !== undefined && row.year !== undefined && criteria.year !== row.year)
+					return false;
+				const localTitle = (row as SuperSubtitlesCandidate & { localTitle?: string }).localTitle;
+				return wantedTitles.some((title) =>
+					[normalize(row.title), normalize(localTitle)].includes(normalize(title))
+				);
+			});
+			if (rows.length > 0) return rows;
+		}
+		return [];
+	}
+
+	private async searchEpisode(
+		criteria: SubtitleSearchCriteria,
+		timeout: number
+	): Promise<SuperSubtitlesCandidate[]> {
+		const titles = unique([criteria.originalTitle, criteria.seriesTitle, criteria.title]);
+		let seriesId: string | undefined;
+		for (const title of titles) {
+			const params = new URLSearchParams({ term: title, nyelv: '0', action: 'autoname' });
+			const response = await this.request(
+				`${SUPERSUBTITLES_BASE_URL}/index.php?${params}`,
+				timeout,
+				'application/json,*/*'
+			);
+			let payload: unknown;
+			try {
+				payload = JSON.parse(await response.text());
+			} catch {
+				throw new ParseResponseError(this.implementation, 'invalid series autocomplete JSON');
+			}
+			seriesId = selectSeriesId(parseAutocomplete(payload), title, criteria.year);
+			if (seriesId) break;
+		}
+		if (!seriesId) return [];
+
+		const exactRows = await this.fetchEpisodeRows(seriesId, criteria, timeout, true);
+		const seasonRows = await this.fetchEpisodeRows(seriesId, criteria, timeout, false);
+		const merged = new Map<string, SuperSubtitlesCandidate>();
+		for (const row of [...exactRows, ...seasonRows]) {
+			const matchesEpisode = row.isPack || row.episode === criteria.episode;
+			if (row.season !== criteria.season || !matchesEpisode) continue;
+			const key = `${row.id}:${row.language}`;
+			const existing = merged.get(key);
+			if (!existing) {
+				merged.set(key, row);
+			} else {
+				existing.releases = unique([...existing.releases, ...row.releases]);
+			}
+		}
+		return [...merged.values()];
+	}
+
+	private async fetchEpisodeRows(
+		seriesId: string,
+		criteria: SubtitleSearchCriteria,
+		timeout: number,
+		exactEpisode: boolean
+	): Promise<SuperSubtitlesCandidate[]> {
+		const params = new URLSearchParams({
+			action: 'xbmc',
+			sid: seriesId,
+			ev: String(criteria.season)
+		});
+		if (exactEpisode) params.set('rtol', String(criteria.episode));
+		const response = await this.request(
+			`${SUPERSUBTITLES_BASE_URL}/index.php?${params}`,
+			timeout,
+			'application/json,*/*'
+		);
+		try {
+			return parseEpisodeRows(JSON.parse(await response.text()), criteria);
+		} catch {
+			throw new ParseResponseError(this.implementation, 'invalid episode JSON');
+		}
+	}
+
+	private toResult(
+		candidate: SuperSubtitlesCandidate,
+		criteria: SubtitleSearchCriteria
+	): SubtitleSearchResult {
+		const releaseName =
+			selectBestRelease(candidate.releases, criteria.filePath) ?? candidate.fileName;
+		const isEpisode = candidate.season !== undefined && candidate.episode !== undefined;
+		return {
+			providerId: this.id,
+			providerName: this.name,
+			providerSubtitleId: encodeDownloadContext(candidate),
+			language: candidate.language,
+			title: isEpisode
+				? `${candidate.title} S${String(candidate.season).padStart(2, '0')}E${String(candidate.episode).padStart(2, '0')}`
+				: `${candidate.title}${candidate.year ? ` (${candidate.year})` : ''}`,
+			releaseName,
+			fileName: candidate.fileName,
+			isForced: candidate.isForced,
+			isHearingImpaired: false,
+			format: subtitleFormat(candidate.fileName),
+			isHashMatch: false,
+			matchScore: isEpisode ? 210 : 70,
+			scoreBreakdown: {
+				hashMatch: 0,
+				titleMatch: isEpisode ? 150 : 50,
+				yearMatch: !isEpisode && candidate.year === criteria.year ? 20 : 0,
+				releaseGroupMatch: releaseName ? 15 : 0,
+				sourceMatch: releaseName && sourceToken(releaseName) ? 10 : 0,
+				codecMatch: 0,
+				hiPenalty: 0,
+				forcedBonus: candidate.isForced && criteria.includeForced ? 10 : 0
+			},
+			downloadUrl: candidate.downloadUrl,
+			uploader: candidate.uploader,
+			pageLink: candidate.pageLink
+		};
+	}
+
+	async download(result: SubtitleSearchResult): Promise<Buffer> {
+		try {
+			const context = decodeDownloadContext(result.providerSubtitleId);
+			const fallbackParams = new URLSearchParams({ action: 'letolt', felirat: context.id });
+			const url = result.downloadUrl ?? `${SUPERSUBTITLES_BASE_URL}/index.php?${fallbackParams}`;
+			const response = await this.request(url, 30000, 'application/zip,text/plain,*/*');
+			const data = Buffer.from(await response.arrayBuffer());
+			if (data.length === 0) throw new Error('Super Subtitles returned an empty download');
+			if (isHtml(data)) throw new Error('Super Subtitles returned an HTML error page');
+			if (isRar(data)) throw new Error('RAR archives from Super Subtitles are not supported');
+			return isZip(data) ? extractSuperSubtitlesArchive(data, result, context) : data;
+		} catch (error) {
+			this.logError('download', error);
+			throw error;
+		}
+	}
+
+	async test(): Promise<ProviderTestResult> {
+		const start = Date.now();
+		try {
+			const params = new URLSearchParams({
+				term: 'The Last of Us',
+				nyelv: '0',
+				action: 'autoname'
+			});
+			const response = await this.request(
+				`${SUPERSUBTITLES_BASE_URL}/index.php?${params}`,
+				10000,
+				'application/json,*/*'
+			);
+			const payload = JSON.parse(await response.text());
+			if (parseAutocomplete(payload).length === 0)
+				throw new Error('Unexpected autocomplete response');
+			return {
+				success: true,
+				message: 'Connected to Super Subtitles',
+				responseTime: Date.now() - start
+			};
+		} catch (error) {
+			return {
+				success: false,
+				message: error instanceof Error ? error.message : 'Connection failed',
+				responseTime: Date.now() - start
+			};
+		}
+	}
+}

--- a/src/lib/server/subtitles/providers/supersubtitles/index.ts
+++ b/src/lib/server/subtitles/providers/supersubtitles/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Super Subtitles (feliratok.eu) provider module.
+ *
+ * The request flow follows Bazarr's proven provider while accepting the site's
+ * current array-shaped episode response in addition to the legacy object shape.
+ */
+
+import { SuperSubtitlesProvider } from './SuperSubtitlesProvider';
+import { SUPERSUBTITLES_LANGUAGES } from './types';
+import type { ProviderInfo } from '../registry';
+
+export { SuperSubtitlesProvider } from './SuperSubtitlesProvider';
+export * from './types';
+
+export const PROVIDER_INFO: ProviderInfo = {
+	implementation: 'supersubtitles',
+	providerClass: SuperSubtitlesProvider,
+	definition: {
+		implementation: 'supersubtitles',
+		name: 'Super Subtitles',
+		description: 'Hungarian and English subtitles from feliratok.eu.',
+		website: 'https://feliratok.eu',
+		requiresApiKey: false,
+		requiresCredentials: false,
+		accessType: 'free',
+		supportedLanguages: SUPERSUBTITLES_LANGUAGES,
+		supportsHashSearch: false,
+		features: ['Hungarian & English', 'Movies & TV', 'Forced subtitles', 'Season packs'],
+		settings: []
+	}
+};

--- a/src/lib/server/subtitles/providers/supersubtitles/types.ts
+++ b/src/lib/server/subtitles/providers/supersubtitles/types.ts
@@ -1,0 +1,46 @@
+import type { LanguageCode } from '../../types';
+
+export const SUPERSUBTITLES_BASE_URL = 'https://feliratok.eu';
+export const SUPERSUBTITLES_LANGUAGES: LanguageCode[] = ['hu', 'en'];
+
+export interface SuperSubtitlesAutocompleteEntry {
+	name?: unknown;
+	ID?: unknown;
+	id?: unknown;
+}
+
+export interface SuperSubtitlesEpisodeEntry {
+	language?: unknown;
+	nev?: unknown;
+	baselink?: unknown;
+	fnev?: unknown;
+	felirat?: unknown;
+	evad?: unknown;
+	ep?: unknown;
+	feltolto?: unknown;
+	pontos_talalat?: unknown;
+	evadpakk?: unknown;
+}
+
+export interface SuperSubtitlesCandidate {
+	id: string;
+	language: LanguageCode;
+	title: string;
+	year?: number;
+	season?: number;
+	episode?: number;
+	isPack: boolean;
+	isForced: boolean;
+	releases: string[];
+	fileName?: string;
+	uploader?: string;
+	downloadUrl: string;
+	pageLink: string;
+}
+
+export interface SuperSubtitlesDownloadContext {
+	id: string;
+	season?: number;
+	episode?: number;
+	isPack: boolean;
+}

--- a/src/lib/server/subtitles/types.ts
+++ b/src/lib/server/subtitles/types.ts
@@ -175,6 +175,7 @@ export const PROVIDER_IMPLEMENTATIONS = [
 	'yifysubtitles',
 	'gestdown',
 	'subf2m',
+	'supersubtitles',
 	// Regional providers
 	'napiprojekt',
 	'legendasdivx',


### PR DESCRIPTION
## Summary

Add a native **Super Subtitles** provider for Hungarian and English subtitles from [feliratok.eu](https://feliratok.eu), without requiring a bridge, API key, or credentials.

The request flow follows Bazarr's proven Super Subtitles provider, with a few compatibility and reliability improvements for the site's current behavior. In particular, Cinephage accepts both the legacy object-shaped episode response and the array-shaped response observed from the live endpoint, avoids an extra detail-page request for every result, and handles season-pack archives without returning the wrong episode.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Changes Made

- Register `supersubtitles` as a built-in, free subtitle provider supporting movies and TV shows in Hungarian and English.
- Use the public feliratok.eu movie search, series autocomplete, episode JSON, and download endpoints.
- Match movies and series by normalized title and year, and select the release variant closest to the local video filename.
- Support both the legacy object-shaped and current array-shaped episode JSON responses.
- Search both the requested episode and its full season so season packs and individual episode uploads are available.
- Extract ZIP downloads inside the provider, ignore README/metadata/hidden files, and only accept supported subtitle extensions.
- Select the exact requested `SxxEyy`, `NxNN`, or unambiguous `Exx` member from season packs; fail explicitly instead of silently returning another episode.
- Detect forced subtitles and reject empty, HTML error, and unsupported RAR responses with clear errors.
- Add parser, matching, release-selection, archive-filtering, season-pack, and live end-to-end coverage.

## Areas Affected

- [ ] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [ ] Library Management
- [ ] Database/Schema
- [x] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

Validation performed:

- `SuperSubtitlesProvider.test.ts`: 9/9 unit tests passed.
- Live provider flow: 11/11 tests passed, including a real *The Last of Us* season-pack extraction and a real Hungarian *Dune: Part Two* movie subtitle download.
- Subtitle schema, search, integration, provider, and download regression tests passed locally.
- Upstream CI passed: Test, Type Check, Lint, application Build, and amd64/arm64 Docker builds.
- Prettier and `git diff --check` passed.

## Checklist

- [x] Code follows project conventions
- [x] Ran formatting checks on all modified files
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (not applicable; no Svelte files changed)
- [x] No new warnings in console or CI output
- [x] Documentation updated (not applicable; provider metadata describes the integration in the UI)

## Screenshots

N/A — backend subtitle-provider integration only.
