### PR TITLE
fix: resolve library freeze/hang issues and audit logging/scan performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ ENV NODE_ENV=production \
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10m --retries=3 \
-  CMD node -e "const port=process.env.PORT||3000;fetch('http://127.0.0.1:'+port+'/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD node -e "const port=process.env.PORT||3000;fetch('http://127.0.0.1:'+port+'/api/health',{signal:AbortSignal.timeout(9000)}).then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["/usr/local/bin/cinephage-entrypoint"]
 CMD ["node", "server.js"]

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -47,7 +47,7 @@ Cinephage uses the following npm packages. All are MIT licensed and compatible w
 | js-yaml         | MIT     | YAML parsing for indexer definitions |
 | parse-torrent   | MIT     | Torrent file/magnet parsing          |
 | adm-zip         | MIT     | ZIP file handling                    |
-| chokidar        | MIT     | File system watching                 |
+| @parcel/watcher | MIT     | File system watching                 |
 | zod             | MIT     | Runtime type validation              |
 
 ## External Services

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@better-auth/api-key": "^1.6.25",
+				"@parcel/watcher": "^2.6.0",
 				"adm-zip": "^0.6.0",
 				"better-auth": "^1.6.25",
 				"better-sqlite3": "^13.0.2",
 				"camoufox-js": "^0.11.5",
 				"cheerio": "^1.2.0",
-				"chokidar": "^5.0.0",
 				"date-format-parse": "^0.2.7",
 				"dotenv": "^17.4.2",
 				"fast-xml-parser": "^5.10.1",
@@ -1193,6 +1193,304 @@
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
+		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+			"integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.3",
+				"is-glob": "^4.0.3",
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.6.0",
+				"@parcel/watcher-darwin-arm64": "2.6.0",
+				"@parcel/watcher-darwin-x64": "2.6.0",
+				"@parcel/watcher-freebsd-x64": "2.6.0",
+				"@parcel/watcher-linux-arm-glibc": "2.6.0",
+				"@parcel/watcher-linux-arm-musl": "2.6.0",
+				"@parcel/watcher-linux-arm64-glibc": "2.6.0",
+				"@parcel/watcher-linux-arm64-musl": "2.6.0",
+				"@parcel/watcher-linux-x64-glibc": "2.6.0",
+				"@parcel/watcher-linux-x64-musl": "2.6.0",
+				"@parcel/watcher-win32-arm64": "2.6.0",
+				"@parcel/watcher-win32-x64": "2.6.0"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+			"integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+			"integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+			"integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+			"integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+			"integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+			"cpu": [
+				"arm"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+			"integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+			"cpu": [
+				"arm"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+			"integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+			"integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+			"integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+			"integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+			"integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+			"integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher/node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
 		},
 		"node_modules/@pinojs/redact": {
 			"version": "0.4.0",
@@ -4071,21 +4369,6 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
-		"node_modules/chokidar": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4901,7 +5184,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
@@ -6689,7 +6971,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6708,7 +6989,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -10491,7 +10771,6 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
 			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -11208,19 +11487,6 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/real-require": {

--- a/package.json
+++ b/package.json
@@ -88,12 +88,12 @@
 	},
 	"dependencies": {
 		"@better-auth/api-key": "^1.6.25",
+		"@parcel/watcher": "^2.6.0",
 		"adm-zip": "^0.6.0",
 		"better-auth": "^1.6.25",
 		"better-sqlite3": "^13.0.2",
 		"camoufox-js": "^0.11.5",
 		"cheerio": "^1.2.0",
-		"chokidar": "^5.0.0",
 		"date-format-parse": "^0.2.7",
 		"dotenv": "^17.4.2",
 		"fast-xml-parser": "^5.10.1",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -259,8 +259,8 @@ export async function getLogSettings() {
 	return apiGet('/api/settings/logs/settings');
 }
 
-export async function updateLogSettings(retentionDays: number) {
-	return apiPut('/api/settings/logs/settings', { retentionDays });
+export async function updateLogSettings(update: { retentionDays?: number; minLevel?: string }) {
+	return apiPut('/api/settings/logs/settings', update);
 }
 
 export async function downloadLogs(params?: Record<string, string>) {

--- a/src/lib/components/storage/StorageDashboard.svelte
+++ b/src/lib/components/storage/StorageDashboard.svelte
@@ -413,7 +413,7 @@
 							<div class="min-w-0 flex-1">
 								<div class="truncate text-sm font-medium text-base-content">{mediaTitle(item)}</div>
 								<div class="text-xs text-base-content/50">
-									{item.videoCodec?.toUpperCase() ?? '?'} \u00B7 {heightToRes(item.height)}
+									{item.videoCodec?.toUpperCase() ?? '?'} &middot; {heightToRes(item.height)}
 								</div>
 							</div>
 							<span class="shrink-0 text-sm font-medium text-base-content"
@@ -474,35 +474,38 @@
 				<h3 class="text-sm font-semibold text-base-content/70">Disk Usage</h3>
 				<div class="card space-y-3 bg-base-200 p-3">
 					{#each rootFolderBreakdown as folder (folder.id)}
+						<!-- usedBytes is a real per-folder SUM(file sizes) (same source
+						RootFolderOverview.svelte uses) - totalSpaceBytes/freeSpaceBytes
+						are disk-level statfs() stats that were never wired up to refresh
+						after folder creation, so using them here as "used" showed stale,
+						identical-across-folders numbers. -->
+						{@const total = folder.usedBytes + (folder.freeSpaceBytes ?? 0)}
 						<div>
 							<div class="mb-1 flex items-center justify-between text-xs">
 								<span class="truncate text-base-content/70">{folder.name}</span>
 								<span class="shrink-0 text-base-content/50">
-									{folder.totalSpaceBytes
-										? `${Math.round(((folder.totalSpaceBytes - (folder.freeSpaceBytes ?? 0)) / folder.totalSpaceBytes) * 100)}%`
-										: '?'}
+									{total > 0 ? `${Math.round((folder.usedBytes / total) * 100)}%` : '?'}
 								</span>
 							</div>
-							{#if folder.totalSpaceBytes && folder.freeSpaceBytes !== null && folder.freeSpaceBytes !== undefined}
-								{@const used = folder.totalSpaceBytes - folder.freeSpaceBytes}
+							{#if folder.freeSpaceBytes !== null && folder.freeSpaceBytes !== undefined && total > 0}
 								<div class="flex h-2 overflow-hidden rounded-full bg-base-300/60">
 									<div
 										class="h-full bg-primary"
-										style="width: {(used / folder.totalSpaceBytes) * 100}%"
-										title={`Used: ${formatBytes(used)}`}
+										style="width: {(folder.usedBytes / total) * 100}%"
+										title={`Used: ${formatBytes(folder.usedBytes)}`}
 										role="img"
-										aria-label={`${folder.name}: ${formatBytes(used)} used of ${formatBytes(folder.totalSpaceBytes)}`}
+										aria-label={`${folder.name}: ${formatBytes(folder.usedBytes)} used of ${formatBytes(total)}`}
 									></div>
 									<div
 										class="h-full bg-success/30"
-										style="width: ${(folder.freeSpaceBytes / folder.totalSpaceBytes) * 100}%"
+										style="width: {(folder.freeSpaceBytes / total) * 100}%"
 										title={`Free: ${formatBytes(folder.freeSpaceBytes)}`}
 										role="img"
 										aria-label={`${formatBytes(folder.freeSpaceBytes)} free`}
 									></div>
 								</div>
 								<div class="mt-0.5 flex justify-between text-xs text-base-content/40">
-									<span>{formatBytes(used)} used</span>
+									<span>{formatBytes(folder.usedBytes)} used</span>
 									<span>{formatBytes(folder.freeSpaceBytes)} free</span>
 								</div>
 							{:else}

--- a/src/lib/components/storage/utils.ts
+++ b/src/lib/components/storage/utils.ts
@@ -218,21 +218,16 @@ export function getRootFolderTotalBytes(item: RootFolderBreakdownItem): number |
 }
 
 export function getUsedRatio(item: RootFolderBreakdownItem): number | null {
-	const totalBytes = getRootFolderTotalBytes(item);
-	if (!totalBytes || totalBytes <= 0) return null;
+	if (item.freeSpaceBytes === null || item.freeSpaceBytes === undefined) return null;
+	const totalBytes = item.usedBytes + Number(item.freeSpaceBytes);
+	if (totalBytes <= 0) return null;
 	return item.usedBytes / totalBytes;
 }
 
 export function getFreeRatio(item: RootFolderBreakdownItem): number | null {
-	const totalBytes = getRootFolderTotalBytes(item);
-	if (
-		!totalBytes ||
-		totalBytes <= 0 ||
-		item.freeSpaceBytes === null ||
-		item.freeSpaceBytes === undefined
-	) {
-		return null;
-	}
+	if (item.freeSpaceBytes === null || item.freeSpaceBytes === undefined) return null;
+	const totalBytes = item.usedBytes + Number(item.freeSpaceBytes);
+	if (totalBytes <= 0) return null;
 	return Number(item.freeSpaceBytes) / totalBytes;
 }
 

--- a/src/lib/library/naming/types.ts
+++ b/src/lib/library/naming/types.ts
@@ -74,6 +74,26 @@ export interface RenameExecuteResult {
 }
 
 /**
+ * NDJSON stream events emitted by GET /api/rename/preview
+ */
+export type RenameStreamEvent =
+	| { type: 'start'; totalFiles: number; computing: boolean }
+	| {
+			type: 'items';
+			category: 'willChange' | 'alreadyCorrect' | 'errors' | 'collisions';
+			data: RenamePreviewItem[];
+	  }
+	| {
+			type: 'done';
+			totalFiles: number;
+			totalWillChange: number;
+			totalAlreadyCorrect: number;
+			totalCollisions: number;
+			totalErrors: number;
+	  }
+	| { type: 'error'; message: string };
+
+/**
  * A single item in a batched reorganize request
  */
 export interface ReorganizeRequestItem {

--- a/src/lib/logging/log-capture.ts
+++ b/src/lib/logging/log-capture.ts
@@ -35,6 +35,23 @@ export const CAPTURED_LOG_DOMAINS = [
 	'downloads'
 ] as const;
 
+/** Friendly display labels for CAPTURED_LOG_DOMAINS - used wherever a domain is shown to a user. */
+export const DOMAIN_LABELS: Record<CapturedLogDomain, string> = {
+	system: 'System',
+	http: 'HTTP',
+	client: 'Client',
+	auth: 'Auth',
+	main: 'Main',
+	streams: 'Streams',
+	imports: 'Imports',
+	monitoring: 'Monitoring',
+	scans: 'Scans',
+	indexers: 'Indexers',
+	subtitles: 'Subtitles',
+	livetv: 'Live TV',
+	downloads: 'Downloads'
+};
+
 export interface CapturedLogEntry {
 	id: string;
 	timestamp: string;

--- a/src/lib/logging/log-capture.ts
+++ b/src/lib/logging/log-capture.ts
@@ -1,55 +1,56 @@
 export type CapturedLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+// Alphabetical by display label (see DOMAIN_LABELS below) - standard convention
+// for a filter dropdown where the user scans for a domain they already have in
+// mind, rather than one ranked by usage frequency or subjective "importance"
+// (which would need constant upkeep and isn't obvious to someone filtering).
 export type CapturedLogDomain =
-	| 'system'
-	| 'http'
-	| 'client'
 	| 'auth'
-	| 'main'
-	| 'streams'
+	| 'client'
+	| 'downloads'
+	| 'http'
 	| 'imports'
+	| 'indexers'
+	| 'livetv'
 	| 'monitoring'
 	| 'scans'
-	| 'indexers'
+	| 'streams'
 	| 'subtitles'
-	| 'livetv'
-	| 'downloads';
+	| 'system';
 
 export const CAPTURED_LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
 
 export const DEFAULT_CAPTURED_LOG_LEVEL: CapturedLogLevel = 'info';
 
 export const CAPTURED_LOG_DOMAINS = [
-	'system',
-	'http',
-	'client',
 	'auth',
-	'main',
-	'streams',
+	'client',
+	'downloads',
+	'http',
 	'imports',
+	'indexers',
+	'livetv',
 	'monitoring',
 	'scans',
-	'indexers',
+	'streams',
 	'subtitles',
-	'livetv',
-	'downloads'
+	'system'
 ] as const;
 
 /** Friendly display labels for CAPTURED_LOG_DOMAINS - used wherever a domain is shown to a user. */
 export const DOMAIN_LABELS: Record<CapturedLogDomain, string> = {
-	system: 'System',
-	http: 'HTTP',
-	client: 'Client',
 	auth: 'Auth',
-	main: 'Main',
-	streams: 'Streams',
+	client: 'Client',
+	downloads: 'Downloads',
+	http: 'HTTP',
 	imports: 'Imports',
+	indexers: 'Indexers',
+	livetv: 'Live TV',
 	monitoring: 'Monitoring',
 	scans: 'Scans',
-	indexers: 'Indexers',
+	streams: 'Streams',
 	subtitles: 'Subtitles',
-	livetv: 'Live TV',
-	downloads: 'Downloads'
+	system: 'System'
 };
 
 export interface CapturedLogEntry {

--- a/src/lib/server/activity/ActivityService.ts
+++ b/src/lib/server/activity/ActivityService.ts
@@ -12,7 +12,7 @@ import {
 import { and, desc, gte, inArray, eq, lte, lt, sql, count, or } from 'drizzle-orm';
 import { upsertQueueTombstoneFromQueueItem } from '$lib/server/downloadClients/monitoring/QueueTombstoneService';
 import { getDownloadClientManager } from '$lib/server/downloadClients/DownloadClientManager';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { SQL } from 'drizzle-orm';
 import {
 	ActivityDeduplicationService,
@@ -58,6 +58,8 @@ import {
 	buildActivitySummary,
 	parseRetentionDays
 } from './activity-filters.js';
+
+const logger = createChildLogger({ module: 'ActivityService', logDomain: 'monitoring' });
 
 interface PaginationOptions {
 	limit: number;

--- a/src/lib/server/calendar/queries.ts
+++ b/src/lib/server/calendar/queries.ts
@@ -1,6 +1,6 @@
 import { db } from '$lib/server/db';
 import { movies, series, episodes } from '$lib/server/db/schema';
-import { eq, and, gte, lte } from 'drizzle-orm';
+import { eq, and, gte, lte, inArray } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import type { DiscoverItem } from '$lib/server/tmdb.js';
 import { toDateString, todayDateString } from '$lib/utils/format.js';
@@ -147,10 +147,15 @@ export async function getCalendarData(
 	const includeEpisodes = type === 'all' || type === 'episodes';
 
 	if (includeMovies) {
-		const [tmdbItems, libraryMovies] = await Promise.all([
-			fetchTmdbUpcoming(certifications),
-			db.select({ tmdbId: movies.tmdbId, id: movies.id }).from(movies)
-		]);
+		const tmdbItems = await fetchTmdbUpcoming(certifications);
+		const tmdbIds = tmdbItems.map((item) => item.id);
+		const libraryMovies =
+			tmdbIds.length > 0
+				? await db
+						.select({ tmdbId: movies.tmdbId, id: movies.id })
+						.from(movies)
+						.where(inArray(movies.tmdbId, tmdbIds))
+				: [];
 
 		const libraryMovieMap = new Map(libraryMovies.map((m) => [m.tmdbId, m.id]));
 		const libraryTmdbIds = new Set(libraryMovieMap.keys());
@@ -268,9 +273,18 @@ export async function getUpcomingItems(
 	}
 
 	if (items.length < limit) {
+		const movieTmdbIds = tmdbItems.map((item) => item.id);
+		const tvTmdbIds = tmdbTvItems.map((item) => item.id);
 		const [libraryMovies, librarySeries] = await Promise.all([
-			db.select({ tmdbId: movies.tmdbId, id: movies.id }).from(movies),
-			db.select({ tmdbId: series.tmdbId }).from(series)
+			movieTmdbIds.length > 0
+				? db
+						.select({ tmdbId: movies.tmdbId, id: movies.id })
+						.from(movies)
+						.where(inArray(movies.tmdbId, movieTmdbIds))
+				: Promise.resolve([]),
+			tvTmdbIds.length > 0
+				? db.select({ tmdbId: series.tmdbId }).from(series).where(inArray(series.tmdbId, tvTmdbIds))
+				: Promise.resolve([])
 		]);
 		const libraryMovieMap = new Map(libraryMovies.map((m) => [m.tmdbId, m.id]));
 		const libraryMovieTmdbIds = new Set(libraryMovieMap.keys());

--- a/src/lib/server/cinephage/CinephageApiService.ts
+++ b/src/lib/server/cinephage/CinephageApiService.ts
@@ -1,4 +1,4 @@
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ServiceStatus } from '$lib/server/services/background-service.js';
 import type { CinephageSettingsService } from './settings/CinephageSettingsService.js';
 import { getCinephageSettingsService } from './settings/CinephageSettingsService.js';
@@ -23,6 +23,8 @@ import { registerBuiltinModules } from './modules/index.js';
  * Modules (library-streaming, remote-streaming) land in subsequent phases
  * and register themselves via static imports at module load time.
  */
+const logger = createChildLogger({ module: 'CinephageApiService', logDomain: 'system' });
+
 export class CinephageApiService {
 	readonly name = 'cinephage-api';
 	private _status: ServiceStatus = 'pending';

--- a/src/lib/server/cinephage/core/CinephageCore.ts
+++ b/src/lib/server/cinephage/core/CinephageCore.ts
@@ -1,6 +1,6 @@
 import { createIndexerHttp } from '$lib/server/indexers/http';
 import type { IndexerHttp } from '$lib/server/indexers/http';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { CinephageSettingsService } from '../settings/CinephageSettingsService.js';
 import { getCinephageSettingsService } from '../settings/CinephageSettingsService.js';
 import { getServerIdentity, type CinephageServerIdentity } from './version.js';
@@ -21,6 +21,8 @@ import { getServerIdentity, type CinephageServerIdentity } from './version.js';
  * fetcher). All api.cinephage.net traffic in the codebase should route
  * through this object.
  */
+const logger = createChildLogger({ module: 'CinephageCore', logDomain: 'system' });
+
 export class CinephageCore {
 	private readonly http: IndexerHttp;
 	private readonly settings: CinephageSettingsService;

--- a/src/lib/server/cinephage/registry/CinephageModuleRegistry.ts
+++ b/src/lib/server/cinephage/registry/CinephageModuleRegistry.ts
@@ -1,9 +1,11 @@
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type {
 	CinephageModule,
 	CinephageModuleCapabilities,
 	CinephageModuleContext
 } from '../modules/types.js';
+
+const logger = createChildLogger({ module: 'CinephageModuleRegistry', logDomain: 'system' });
 
 type CapabilityKey = keyof CinephageModuleCapabilities;
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -913,66 +913,70 @@ export const episodes = sqliteTable(
 /**
  * Episode Files - Actual episode files on disk
  */
-export const episodeFiles = sqliteTable('episode_files', {
-	id: text('id')
-		.primaryKey()
-		.$defaultFn(() => randomUUID()),
-	seriesId: text('series_id')
-		.notNull()
-		.references(() => series.id, { onDelete: 'cascade' }),
-	seasonNumber: integer('season_number').notNull(),
-	// Can contain multiple episodes (e.g., double episodes)
-	episodeIds: text('episode_ids', { mode: 'json' }).$type<string[]>(),
-	// Path relative to the series folder
-	relativePath: text('relative_path').notNull(),
-	// File size in bytes
-	size: integer('size'),
-	// When the file was added to library
-	dateAdded: text('date_added').$defaultFn(() => new Date().toISOString()),
-	// Scene name if detected
-	sceneName: text('scene_name'),
-	// Release group if detected
-	releaseGroup: text('release_group'),
-	// Edition info (IMAX, Extended, etc.)
-	edition: text('edition'),
-	// Release type (singleEpisode, multiEpisode, seasonPack, etc.)
-	releaseType: text('release_type'),
-	// Parsed quality info as JSON
-	quality: text('quality', { mode: 'json' }).$type<{
-		resolution?: string;
-		source?: string;
-		codec?: string;
-		hdr?: string;
-	}>(),
-	// MediaInfo extracted data (same structure as movieFiles)
-	mediaInfo: text('media_info', { mode: 'json' }).$type<{
-		containerFormat?: string;
-		videoCodec?: string;
-		videoProfile?: string;
-		videoBitrate?: number;
-		videoBitDepth?: number;
-		videoHdrFormat?: string;
-		width?: number;
-		height?: number;
-		fps?: number;
-		runtime?: number;
-		audioCodec?: string;
-		audioChannels?: number;
-		audioBitrate?: number;
-		audioLanguages?: string[];
-		subtitleLanguages?: string[];
-	}>(),
-	// Languages detected in file
-	languages: text('languages', { mode: 'json' }).$type<string[]>(),
-	// Info hash of the torrent used to download this file (for duplicate detection)
-	infoHash: text('info_hash'),
-	lastSeenScanId: text('last_seen_scan_id'),
-	// Content categorization: 'main' | 'bonus' (Phase 1 pattern recognition)
-	contentCategory: text('content_category').notNull().default('main'),
-	filenameSignature: text('filename_signature'),
-	contentHash: text('content_hash'),
-	contentHashAlgorithm: text('content_hash_algorithm')
-});
+export const episodeFiles = sqliteTable(
+	'episode_files',
+	{
+		id: text('id')
+			.primaryKey()
+			.$defaultFn(() => randomUUID()),
+		seriesId: text('series_id')
+			.notNull()
+			.references(() => series.id, { onDelete: 'cascade' }),
+		seasonNumber: integer('season_number').notNull(),
+		// Can contain multiple episodes (e.g., double episodes)
+		episodeIds: text('episode_ids', { mode: 'json' }).$type<string[]>(),
+		// Path relative to the series folder
+		relativePath: text('relative_path').notNull(),
+		// File size in bytes
+		size: integer('size'),
+		// When the file was added to library
+		dateAdded: text('date_added').$defaultFn(() => new Date().toISOString()),
+		// Scene name if detected
+		sceneName: text('scene_name'),
+		// Release group if detected
+		releaseGroup: text('release_group'),
+		// Edition info (IMAX, Extended, etc.)
+		edition: text('edition'),
+		// Release type (singleEpisode, multiEpisode, seasonPack, etc.)
+		releaseType: text('release_type'),
+		// Parsed quality info as JSON
+		quality: text('quality', { mode: 'json' }).$type<{
+			resolution?: string;
+			source?: string;
+			codec?: string;
+			hdr?: string;
+		}>(),
+		// MediaInfo extracted data (same structure as movieFiles)
+		mediaInfo: text('media_info', { mode: 'json' }).$type<{
+			containerFormat?: string;
+			videoCodec?: string;
+			videoProfile?: string;
+			videoBitrate?: number;
+			videoBitDepth?: number;
+			videoHdrFormat?: string;
+			width?: number;
+			height?: number;
+			fps?: number;
+			runtime?: number;
+			audioCodec?: string;
+			audioChannels?: number;
+			audioBitrate?: number;
+			audioLanguages?: string[];
+			subtitleLanguages?: string[];
+		}>(),
+		// Languages detected in file
+		languages: text('languages', { mode: 'json' }).$type<string[]>(),
+		// Info hash of the torrent used to download this file (for duplicate detection)
+		infoHash: text('info_hash'),
+		lastSeenScanId: text('last_seen_scan_id'),
+		// Content categorization: 'main' | 'bonus' (Phase 1 pattern recognition)
+		contentCategory: text('content_category').notNull().default('main'),
+		filenameSignature: text('filename_signature'),
+		contentHash: text('content_hash'),
+		contentHashAlgorithm: text('content_hash_algorithm')
+	},
+	(table) => [uniqueIndex('idx_episode_files_unique_path').on(table.seriesId, table.relativePath)]
+);
 
 // ============================================================================
 // Alternate Titles - For multi-title search support

--- a/src/lib/server/downloadClients/import/ImportService.ts
+++ b/src/lib/server/downloadClients/import/ImportService.ts
@@ -1798,10 +1798,13 @@ export class ImportService extends EventEmitter {
 		} else {
 			// Create new file record
 			fileId = randomUUID();
-			await db.insert(episodeFiles).values({
-				id: fileId,
-				...fileData
-			});
+			await db
+				.insert(episodeFiles)
+				.values({
+					id: fileId,
+					...fileData
+				})
+				.onConflictDoNothing();
 		}
 
 		// Update episode hasFile flags

--- a/src/lib/server/downloadClients/monitoring/DownloadMonitorService.ts
+++ b/src/lib/server/downloadClients/monitoring/DownloadMonitorService.ts
@@ -19,7 +19,7 @@ import {
 	episodes,
 	stalledOrphanTracking
 } from '$lib/server/db/schema';
-import { eq, and, or, inArray, not, notInArray, isNull, isNotNull, desc } from 'drizzle-orm';
+import { eq, and, or, inArray, not, notInArray, isNull, isNotNull, desc, sql } from 'drizzle-orm';
 import { getDownloadClientManager } from '../DownloadClientManager';
 import { mapClientPathToLocal } from './PathMapping';
 import { resolveInfoHash } from '../utils/hashUtils';
@@ -937,24 +937,21 @@ export class DownloadMonitorService extends EventEmitter implements BackgroundSe
 
 		logger.info({ olderThanDays, dryRun }, 'Clearing failed queue items');
 
-		// Get all failed items
-		let failedItems = await db
+		const ageCutoffCondition =
+			olderThanDays !== undefined && olderThanDays > 0
+				? sql`coalesce(${downloadQueue.lastAttemptAt}, ${downloadQueue.addedAt}) < ${new Date(
+						Date.now() - olderThanDays * 24 * 60 * 60 * 1000
+					).toISOString()}`
+				: undefined;
+
+		const failedItems = await db
 			.select()
 			.from(downloadQueue)
-			.where(eq(downloadQueue.status, 'failed'));
-
-		// Filter by age if specified
-		if (olderThanDays !== undefined && olderThanDays > 0) {
-			const cutoff = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
-			failedItems = failedItems.filter((item) => {
-				const failedAt = item.lastAttemptAt
-					? new Date(item.lastAttemptAt).getTime()
-					: item.addedAt
-						? new Date(item.addedAt).getTime()
-						: Date.now();
-				return failedAt < cutoff;
-			});
-		}
+			.where(
+				ageCutoffCondition
+					? and(eq(downloadQueue.status, 'failed'), ageCutoffCondition)
+					: eq(downloadQueue.status, 'failed')
+			);
 
 		const result = {
 			cleared: [] as { id: string; title: string; errorMessage?: string | null }[],

--- a/src/lib/server/downloads/MultiSeasonSearchStrategy.ts
+++ b/src/lib/server/downloads/MultiSeasonSearchStrategy.ts
@@ -15,11 +15,13 @@
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
 import { todayDateString } from '$lib/utils/format.js';
 import { grabService } from './GrabService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import { db } from '$lib/server/db/index.js';
 import { episodes } from '$lib/server/db/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import type { SearchCriteria } from '$lib/server/indexers/types';
+
+const logger = createChildLogger({ module: 'MultiSeasonSearchStrategy', logDomain: 'downloads' });
 import { isSeasonPack } from '$lib/server/indexers/types/release.js';
 import { getSeriesSearchTitles } from '$lib/server/services/AlternateTitleService.js';
 

--- a/src/lib/server/downloads/handlers/NzbStreamingHandler.ts
+++ b/src/lib/server/downloads/handlers/NzbStreamingHandler.ts
@@ -46,7 +46,10 @@ async function upsertEpisodeFileByPath(record: EpisodeFileUpsertInput): Promise<
 	}
 
 	const id = requestedId ?? randomUUID();
-	await db.insert(episodeFiles).values({ id, ...values });
+	await db
+		.insert(episodeFiles)
+		.values({ id, ...values })
+		.onConflictDoNothing();
 	return id;
 }
 

--- a/src/lib/server/downloads/handlers/StreamingHandler.ts
+++ b/src/lib/server/downloads/handlers/StreamingHandler.ts
@@ -55,7 +55,10 @@ async function upsertEpisodeFileByPath(record: EpisodeFileUpsertInput): Promise<
 	}
 
 	const id = requestedId ?? randomUUID();
-	await db.insert(episodeFiles).values({ id, ...values });
+	await db
+		.insert(episodeFiles)
+		.values({ id, ...values })
+		.onConflictDoNothing();
 	return id;
 }
 

--- a/src/lib/server/indexers/http/EncodingUtils.ts
+++ b/src/lib/server/indexers/http/EncodingUtils.ts
@@ -6,7 +6,9 @@
  */
 
 import iconv from 'iconv-lite';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'EncodingUtils', logDomain: 'indexers' });
 
 // Encoding name normalization mapping
 const ENCODING_ALIASES: Record<string, string> = {

--- a/src/lib/server/library/disk-scan.ts
+++ b/src/lib/server/library/disk-scan.ts
@@ -1268,6 +1268,7 @@ export class DiskScanService extends EventEmitter {
 							releaseType: episodeNums.length > 1 ? 'multiEpisode' : 'singleEpisode',
 							quality
 						})
+						.onConflictDoNothing()
 						.run();
 
 					for (const epId of episodeIds) {

--- a/src/lib/server/library/library-watcher.test.ts
+++ b/src/lib/server/library/library-watcher.test.ts
@@ -13,12 +13,11 @@ vi.mock('$lib/server/db', () => ({
 	initializeDatabase: vi.fn().mockResolvedValue(undefined)
 }));
 
-vi.mock('chokidar', () => ({
+vi.mock('@parcel/watcher', () => ({
 	default: {
-		watch: vi.fn(() => ({
-			on: vi.fn().mockReturnThis(),
-			close: vi.fn().mockResolvedValue(undefined)
-		}))
+		subscribe: vi.fn().mockResolvedValue({
+			unsubscribe: vi.fn().mockResolvedValue(undefined)
+		})
 	}
 }));
 
@@ -41,9 +40,23 @@ vi.mock('./media-info.js', () => ({
 
 let mockScanning = false;
 
-const { LibraryWatcherService } = await import('./library-watcher.js');
+const { LibraryWatcherService, IGNORED_PATTERNS } = await import('./library-watcher.js');
 const { diskScanService } = await import('./disk-scan.js');
 const { libraryOperationLock } = await import('./library-operation-lock.js');
+
+describe('LibraryWatcherService IGNORED_PATTERNS', () => {
+	// @parcel/watcher's subscribe() throws synchronously if any ignore RegExp
+	// carries flags ("RegExp ignore patterns must not have flags") - it has no
+	// native concept of them. Chokidar's /i-flagged patterns don't survive the
+	// swap as-is; this pins the invariant so a reintroduced flag fails loudly
+	// here instead of silently breaking every watchFolder() call in prod.
+	it('contains no flagged RegExp entries', () => {
+		for (const pattern of IGNORED_PATTERNS) {
+			expect(pattern).toBeInstanceOf(RegExp);
+			expect(pattern.flags).toBe('');
+		}
+	});
+});
 
 describe('LibraryWatcherService.processPendingChanges', () => {
 	// Access the singleton's internals for seeding/inspection (private fields).

--- a/src/lib/server/library/library-watcher.ts
+++ b/src/lib/server/library/library-watcher.ts
@@ -5,6 +5,7 @@
  * Triggers incremental scans when files are added, removed, or changed.
  */
 
+import { promises as fsPromises } from 'node:fs';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { db } from '$lib/server/db/index.js';
 import { rootFolders, librarySettings } from '$lib/server/db/schema.js';
@@ -19,6 +20,44 @@ import { createChildLogger } from '$lib/logging';
 const logger = createChildLogger({ logDomain: 'scans' as const });
 
 const DEBOUNCE_TIME = 5000;
+
+const NETWORK_FS_TYPES = new Set([
+	'nfs',
+	'nfs4',
+	'cifs',
+	'smbfs',
+	'smb2',
+	'fuse.sshfs',
+	'fuse.rclone',
+	'fuse.s3fs',
+	'glusterfs',
+	'davfs',
+	'overlay' // Docker bind mounts from Windows hosts appear as overlay
+]);
+
+async function detectFilesystemType(targetPath: string): Promise<string | null> {
+	try {
+		const mounts = await fsPromises.readFile('/proc/mounts', 'utf8');
+		let bestLength = 0;
+		let bestFsType: string | null = null;
+		for (const line of mounts.split('\n')) {
+			const parts = line.split(' ');
+			if (parts.length < 3) continue;
+			const mountPoint = parts[1];
+			const fsType = parts[2];
+			if (
+				(targetPath === mountPoint || targetPath.startsWith(mountPoint + '/')) &&
+				mountPoint.length > bestLength
+			) {
+				bestLength = mountPoint.length;
+				bestFsType = fsType;
+			}
+		}
+		return bestFsType;
+	} catch {
+		return null;
+	}
+}
 
 interface FileChange {
 	type: 'add' | 'change' | 'unlink';
@@ -102,6 +141,18 @@ export class LibraryWatcherService extends EventEmitter {
 
 		this.rootFolderMap.set(folderPath, folderId);
 
+		const fsType = await detectFilesystemType(folderPath);
+		if (fsType !== null) {
+			if (NETWORK_FS_TYPES.has(fsType)) {
+				logger.warn(
+					{ folderId, folderPath, fsType },
+					'[LibraryWatcher] Path is on a network filesystem: inotify-based watching may not function reliably over this mount type; scan-on-change may miss events'
+				);
+			} else {
+				logger.info({ folderId, folderPath, fsType }, '[LibraryWatcher] Filesystem type detected');
+			}
+		}
+
 		const watcher = chokidar.watch(folderPath, {
 			persistent: true,
 			ignoreInitial: true,
@@ -114,16 +165,35 @@ export class LibraryWatcherService extends EventEmitter {
 			ignored: [/(^|[/\\])\../, /node_modules/, /@eaDir/, /#recycle/i, /\$RECYCLE\.BIN/i]
 		});
 
+		// Suppress duplicate ENOSPC warnings.
+		let enospcWarned = false;
+
 		watcher
 			.on('add', (path) => this.handleFileEvent('add', path, folderId))
 			.on('change', (path) => this.handleFileEvent('change', path, folderId))
 			.on('unlink', (path) => this.handleFileEvent('unlink', path, folderId))
 			.on('error', (error) => {
-				logger.error({ err: error, ...{ folderId } }, '[LibraryWatcher] Error in folder');
+				if ((error as NodeJS.ErrnoException).code === 'ENOSPC') {
+					if (!enospcWarned) {
+						enospcWarned = true;
+						logger.warn(
+							{ folderId, folderPath },
+							'[LibraryWatcher] ENOSPC: system inotify watch limit reached. ' +
+								'Increase fs.inotify.max_user_watches (e.g. echo 524288 | sudo tee /proc/sys/fs/inotify/max_user_watches), ' +
+								'or disable "Watch filesystem for changes" in Settings and rely on scheduled scans instead.'
+						);
+					}
+					// ENOSPC is not recoverable by the scheduler;s suppress re-emit to avoid log spam.
+					return;
+				}
+				logger.error({ err: error, folderId }, '[LibraryWatcher] Error in folder');
 				this.emit('error', { folderId, error });
 			})
 			.on('ready', () => {
-				logger.info({ folderPath }, '[LibraryWatcher] Watching folder');
+				const watched = watcher.getWatched();
+				const dirCount = Object.keys(watched).length;
+				const fileCount = Object.values(watched).reduce((sum, files) => sum + files.length, 0);
+				logger.info({ folderPath, dirCount, fileCount }, '[LibraryWatcher] Watching folder');
 			});
 
 		this.watchers.set(folderId, watcher);

--- a/src/lib/server/library/library-watcher.ts
+++ b/src/lib/server/library/library-watcher.ts
@@ -1,12 +1,23 @@
 /**
  * Library Watcher Service
  *
- * Watches root folders for filesystem changes using chokidar.
+ * Watches root folders for filesystem changes using @parcel/watcher.
  * Triggers incremental scans when files are added, removed, or changed.
+ *
+ * @parcel/watcher (not chokidar) is used deliberately: chokidar creates one
+ * native watch per FILE in addition to one per directory (confirmed by
+ * reading chokidar's handler.js - _handleFile and _handleDir both call
+ * _watchWithNodeFs, which maps 1:1 to fs.watch/inotify_add_watch). For a
+ * large ~10k+ file library that exhausts fs.inotify.max_user_watches. Linux inotify
+ * already reports create/modify/delete of files within a watched directory
+ * through that single directory-level watch, so a per-file watch is
+ * unnecessary. @parcel/watcher's native backend (inotify/FSEvents/
+ * ReadDirectoryChangesW depending on platform) watches at the directory
+ * level only, which is the structural fix.
  */
 
 import { promises as fsPromises } from 'node:fs';
-import chokidar, { type FSWatcher } from 'chokidar';
+import watcher, { type AsyncSubscription, type Event as ParcelEvent } from '@parcel/watcher';
 import { db } from '$lib/server/db/index.js';
 import { rootFolders, librarySettings } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
@@ -66,13 +77,45 @@ interface FileChange {
 	timestamp: number;
 }
 
+/**
+ * @parcel/watcher's `ignore` option rejects RegExp entries that carry flags
+ * ("RegExp ignore patterns must not have flags" - its native matcher has no
+ * concept of them), so a flagged /i pattern throws synchronously inside
+ * subscribe() rather than just being case-sensitive. Case-fold each literal
+ * character into a [xX] class instead, producing an equivalent flagless
+ * pattern chokidar's /i regexes can't express here.
+ */
+function caseInsensitiveLiteral(literal: string): string {
+	return literal
+		.split('')
+		.map((ch) => {
+			const lower = ch.toLowerCase();
+			const upper = ch.toUpperCase();
+			if (lower === upper) return ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			return `[${lower}${upper}]`;
+		})
+		.join('');
+}
+
+// Same set chokidar's `ignored` used, minus the two /i flags @parcel/watcher can't accept.
+// Exported so tests can assert every RegExp here stays flagless.
+export const IGNORED_PATTERNS = [
+	/(^|[/\\])\../,
+	/node_modules/,
+	/@eaDir/,
+	new RegExp(caseInsensitiveLiteral('#recycle')),
+	new RegExp(caseInsensitiveLiteral('$RECYCLE.BIN'))
+];
+
 export class LibraryWatcherService extends EventEmitter {
 	private static instance: LibraryWatcherService;
-	private watchers: Map<string, FSWatcher> = new Map();
+	private subscriptions: Map<string, AsyncSubscription> = new Map();
 	private pendingChanges: Map<string, FileChange> = new Map();
 	private processTimeout: NodeJS.Timeout | null = null;
 	private enabled = false;
 	private rootFolderMap: Map<string, string> = new Map();
+	// Suppress duplicate ENOSPC warnings per folder (events can keep arriving after the first).
+	private enospcWarned: Set<string> = new Set();
 
 	private constructor() {
 		super();
@@ -117,14 +160,15 @@ export class LibraryWatcherService extends EventEmitter {
 	}
 
 	async shutdown(): Promise<void> {
-		for (const [folderId, watcher] of this.watchers) {
-			await watcher.close();
+		for (const [folderId, subscription] of this.subscriptions) {
+			await subscription.unsubscribe();
 			logger.debug({ folderId }, '[LibraryWatcher] Stopped watching folder');
 		}
 
-		this.watchers.clear();
+		this.subscriptions.clear();
 		this.rootFolderMap.clear();
 		this.pendingChanges.clear();
+		this.enospcWarned.clear();
 
 		if (this.processTimeout) {
 			clearTimeout(this.processTimeout);
@@ -135,11 +179,12 @@ export class LibraryWatcherService extends EventEmitter {
 	}
 
 	async watchFolder(folderId: string, folderPath: string): Promise<void> {
-		if (this.watchers.has(folderId)) {
-			await this.watchers.get(folderId)?.close();
+		if (this.subscriptions.has(folderId)) {
+			await this.subscriptions.get(folderId)?.unsubscribe();
 		}
 
 		this.rootFolderMap.set(folderPath, folderId);
+		this.enospcWarned.delete(folderId);
 
 		const fsType = await detectFilesystemType(folderPath);
 		if (fsType !== null) {
@@ -153,57 +198,65 @@ export class LibraryWatcherService extends EventEmitter {
 			}
 		}
 
-		const watcher = chokidar.watch(folderPath, {
-			persistent: true,
-			ignoreInitial: true,
-			followSymlinks: false,
-			depth: 10,
-			awaitWriteFinish: {
-				stabilityThreshold: 2000,
-				pollInterval: 500
-			},
-			ignored: [/(^|[/\\])\../, /node_modules/, /@eaDir/, /#recycle/i, /\$RECYCLE\.BIN/i]
-		});
+		try {
+			const subscription = await watcher.subscribe(
+				folderPath,
+				(err, events) => this.handleParcelEvents(folderId, folderPath, err, events),
+				{ ignore: IGNORED_PATTERNS }
+			);
+			this.subscriptions.set(folderId, subscription);
+			logger.info({ folderId, folderPath }, '[LibraryWatcher] Watching folder');
+		} catch (error) {
+			this.handleWatchError(folderId, folderPath, error);
+		}
+	}
 
-		// Suppress duplicate ENOSPC warnings.
-		let enospcWarned = false;
+	/**
+	 * Handles both the initial subscribe() rejection and later async errors
+	 * delivered via the subscribe() callback (e.g. a nested directory created
+	 * after subscription pushes past the watch-descriptor limit).
+	 */
+	private handleWatchError(folderId: string, folderPath: string, error: unknown): void {
+		if ((error as NodeJS.ErrnoException)?.code === 'ENOSPC') {
+			if (!this.enospcWarned.has(folderId)) {
+				this.enospcWarned.add(folderId);
+				logger.warn(
+					{ folderId, folderPath },
+					'[LibraryWatcher] ENOSPC: system inotify watch limit reached. ' +
+						'Increase fs.inotify.max_user_watches (e.g. echo 524288 | sudo tee /proc/sys/fs/inotify/max_user_watches), ' +
+						'or disable "Watch filesystem for changes" in Settings and rely on scheduled scans instead.'
+				);
+			}
+			// ENOSPC is not recoverable by the scheduler; suppress re-emit to avoid log spam.
+			return;
+		}
+		logger.error({ err: error, folderId }, '[LibraryWatcher] Error in folder');
+		this.emit('error', { folderId, error });
+	}
 
-		watcher
-			.on('add', (path) => this.handleFileEvent('add', path, folderId))
-			.on('change', (path) => this.handleFileEvent('change', path, folderId))
-			.on('unlink', (path) => this.handleFileEvent('unlink', path, folderId))
-			.on('error', (error) => {
-				if ((error as NodeJS.ErrnoException).code === 'ENOSPC') {
-					if (!enospcWarned) {
-						enospcWarned = true;
-						logger.warn(
-							{ folderId, folderPath },
-							'[LibraryWatcher] ENOSPC: system inotify watch limit reached. ' +
-								'Increase fs.inotify.max_user_watches (e.g. echo 524288 | sudo tee /proc/sys/fs/inotify/max_user_watches), ' +
-								'or disable "Watch filesystem for changes" in Settings and rely on scheduled scans instead.'
-						);
-					}
-					// ENOSPC is not recoverable by the scheduler;s suppress re-emit to avoid log spam.
-					return;
-				}
-				logger.error({ err: error, folderId }, '[LibraryWatcher] Error in folder');
-				this.emit('error', { folderId, error });
-			})
-			.on('ready', () => {
-				const watched = watcher.getWatched();
-				const dirCount = Object.keys(watched).length;
-				const fileCount = Object.values(watched).reduce((sum, files) => sum + files.length, 0);
-				logger.info({ folderPath, dirCount, fileCount }, '[LibraryWatcher] Watching folder');
-			});
+	private handleParcelEvents(
+		folderId: string,
+		folderPath: string,
+		err: Error | null,
+		events: ParcelEvent[]
+	): void {
+		if (err) {
+			this.handleWatchError(folderId, folderPath, err);
+			return;
+		}
 
-		this.watchers.set(folderId, watcher);
+		for (const event of events) {
+			const type = event.type === 'create' ? 'add' : event.type === 'delete' ? 'unlink' : 'change';
+			this.handleFileEvent(type, event.path, folderId);
+		}
 	}
 
 	async unwatchFolder(folderId: string): Promise<void> {
-		const watcher = this.watchers.get(folderId);
-		if (watcher) {
-			await watcher.close();
-			this.watchers.delete(folderId);
+		const subscription = this.subscriptions.get(folderId);
+		if (subscription) {
+			await subscription.unsubscribe();
+			this.subscriptions.delete(folderId);
+			this.enospcWarned.delete(folderId);
 
 			for (const [path, id] of this.rootFolderMap) {
 				if (id === folderId) {
@@ -306,7 +359,7 @@ export class LibraryWatcherService extends EventEmitter {
 	getStatus(): { enabled: boolean; watchedFolders: string[] } {
 		return {
 			enabled: this.enabled,
-			watchedFolders: Array.from(this.watchers.keys())
+			watchedFolders: Array.from(this.subscriptions.keys())
 		};
 	}
 

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -161,14 +161,6 @@ export class MediaMatcherService {
 		);
 	}
 
-	private isUniqueTmdbConstraintError(error: unknown, tableName: 'movies' | 'series'): boolean {
-		if (!(error instanceof Error)) {
-			return false;
-		}
-
-		return error.message.includes(`UNIQUE constraint failed: ${tableName}.tmdb_id`);
-	}
-
 	/**
 	 * Search TMDB and find best matches for a file
 	 *
@@ -1033,57 +1025,44 @@ export class MediaMatcherService {
 				title: tmdbMovie.title,
 				originalTitle: tmdbMovie.original_title
 			});
-			try {
-				const [newMovie] = await db
-					.insert(movies)
-					.values({
-						tmdbId,
-						imdbId: externalIds.imdb_id,
-						title: tmdbMovie.title,
-						originalTitle: tmdbMovie.original_title,
-						year: tmdbMovie.release_date
-							? parseInt(tmdbMovie.release_date.split('-')[0])
-							: undefined,
-						overview: tmdbMovie.overview,
-						posterPath: tmdbMovie.poster_path,
-						backdropPath: tmdbMovie.backdrop_path,
-						runtime: tmdbMovie.runtime,
-						genres: tmdbMovie.genres?.map((g) => g.name),
-						path: movieFolder || fileName,
-						libraryId: owningLibrary.id,
-						rootFolderId: rootFolder.id,
-						hasFile: true,
-						monitored: rootFolder.defaultMonitored ?? true,
-						scoringProfileId: owningLibrary.qualityProfileId,
-						languageProfileId: wantsSubtitles ? defaultProfileId : null,
-						wantsSubtitles
-					})
-					.returning();
+			const [newMovie] = await db
+				.insert(movies)
+				.values({
+					tmdbId,
+					imdbId: externalIds.imdb_id,
+					title: tmdbMovie.title,
+					originalTitle: tmdbMovie.original_title,
+					year: tmdbMovie.release_date ? parseInt(tmdbMovie.release_date.split('-')[0]) : undefined,
+					overview: tmdbMovie.overview,
+					posterPath: tmdbMovie.poster_path,
+					backdropPath: tmdbMovie.backdrop_path,
+					runtime: tmdbMovie.runtime,
+					genres: tmdbMovie.genres?.map((g) => g.name),
+					path: movieFolder || fileName,
+					libraryId: owningLibrary.id,
+					rootFolderId: rootFolder.id,
+					hasFile: true,
+					monitored: rootFolder.defaultMonitored ?? true,
+					scoringProfileId: owningLibrary.qualityProfileId,
+					languageProfileId: wantsSubtitles ? defaultProfileId : null,
+					wantsSubtitles
+				})
+				.onConflictDoNothing()
+				.returning();
 
+			if (newMovie) {
 				movieId = newMovie.id;
 				logger.debug(
-					{
-						movieId,
-						title: tmdbMovie.title,
-						languageProfileId: defaultProfileId
-					},
+					{ movieId, title: tmdbMovie.title, languageProfileId: defaultProfileId },
 					'[MediaMatcher] Assigned default language profile to new movie'
 				);
-			} catch (error) {
-				if (!this.isUniqueTmdbConstraintError(error, 'movies')) {
-					throw error;
-				}
-
+			} else {
 				const [concurrentMovie] = await db
 					.select({ id: movies.id })
 					.from(movies)
 					.where(eq(movies.tmdbId, tmdbId))
 					.limit(1);
-
-				if (!concurrentMovie) {
-					throw error;
-				}
-
+				if (!concurrentMovie) throw new Error(`Movie insert failed and row not found: ${tmdbId}`);
 				movieId = concurrentMovie.id;
 				await db.update(movies).set({ hasFile: true }).where(eq(movies.id, movieId));
 			}
@@ -1200,60 +1179,49 @@ export class MediaMatcherService {
 			});
 			let createdSeries = false;
 
-			try {
-				const [newSeries] = await db
-					.insert(series)
-					.values({
-						tmdbId,
-						imdbId: externalIds.imdb_id,
-						tvdbId: externalIds.tvdb_id,
-						title: tmdbSeries.name,
-						originalTitle: tmdbSeries.original_name,
-						year: tmdbSeries.first_air_date
-							? parseInt(tmdbSeries.first_air_date.split('-')[0])
-							: undefined,
-						overview: tmdbSeries.overview,
-						posterPath: tmdbSeries.poster_path,
-						backdropPath: tmdbSeries.backdrop_path,
-						status: tmdbSeries.status,
-						network: tmdbSeries.networks?.[0]?.name,
-						genres: tmdbSeries.genres?.map((g) => g.name),
-						path: seriesFolder,
-						libraryId: owningLibrary.id,
-						rootFolderId: rootFolder.id,
-						seriesType: rootFolder.mediaSubType === 'anime' || animeSignal ? 'anime' : 'standard',
-						monitored: rootFolder.defaultMonitored ?? true,
-						scoringProfileId: owningLibrary.qualityProfileId,
-						languageProfileId: wantsSubtitles ? defaultProfileId : null,
-						wantsSubtitles
-					})
-					.returning();
+			const [newSeries] = await db
+				.insert(series)
+				.values({
+					tmdbId,
+					imdbId: externalIds.imdb_id,
+					tvdbId: externalIds.tvdb_id,
+					title: tmdbSeries.name,
+					originalTitle: tmdbSeries.original_name,
+					year: tmdbSeries.first_air_date
+						? parseInt(tmdbSeries.first_air_date.split('-')[0])
+						: undefined,
+					overview: tmdbSeries.overview,
+					posterPath: tmdbSeries.poster_path,
+					backdropPath: tmdbSeries.backdrop_path,
+					status: tmdbSeries.status,
+					network: tmdbSeries.networks?.[0]?.name,
+					genres: tmdbSeries.genres?.map((g) => g.name),
+					path: seriesFolder,
+					libraryId: owningLibrary.id,
+					rootFolderId: rootFolder.id,
+					seriesType: rootFolder.mediaSubType === 'anime' || animeSignal ? 'anime' : 'standard',
+					monitored: rootFolder.defaultMonitored ?? true,
+					scoringProfileId: owningLibrary.qualityProfileId,
+					languageProfileId: wantsSubtitles ? defaultProfileId : null,
+					wantsSubtitles
+				})
+				.onConflictDoNothing()
+				.returning();
 
+			if (newSeries) {
 				seriesId = newSeries.id;
 				createdSeries = true;
 				logger.debug(
-					{
-						seriesId,
-						title: tmdbSeries.name,
-						languageProfileId: defaultProfileId
-					},
+					{ seriesId, title: tmdbSeries.name, languageProfileId: defaultProfileId },
 					'[MediaMatcher] Assigned default language profile to new series'
 				);
-			} catch (error) {
-				if (!this.isUniqueTmdbConstraintError(error, 'series')) {
-					throw error;
-				}
-
+			} else {
 				const [concurrentSeries] = await db
 					.select({ id: series.id })
 					.from(series)
 					.where(eq(series.tmdbId, tmdbId))
 					.limit(1);
-
-				if (!concurrentSeries) {
-					throw error;
-				}
-
+				if (!concurrentSeries) throw new Error(`Series insert failed and row not found: ${tmdbId}`);
 				seriesId = concurrentSeries.id;
 			}
 

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -104,8 +104,20 @@ export class MediaMatcherService {
 		const [inserted] = await db
 			.insert(episodeFiles)
 			.values(record)
+			.onConflictDoNothing()
 			.returning({ id: episodeFiles.id });
-		return inserted.id;
+		if (inserted) return inserted.id;
+		const [raced] = await db
+			.select({ id: episodeFiles.id })
+			.from(episodeFiles)
+			.where(
+				and(
+					eq(episodeFiles.seriesId, record.seriesId),
+					eq(episodeFiles.relativePath, record.relativePath)
+				)
+			)
+			.limit(1);
+		return raced.id;
 	}
 
 	/**
@@ -796,6 +808,66 @@ export class MediaMatcherService {
 			throw new Error(`Root folder not found: ${file.rootFolderId}`);
 		}
 
+		// Guard: if this file is already present in the library, the unmatchedFiles record
+		// is stale (e.g. retry after a prior partial failure). Remove it and return early
+		// rather than re-running the full create path and hitting UNIQUE constraints.
+		{
+			const relPath = file.path.replace(rootFolder.path, '').replace(/^\//, '');
+			let alreadyMatched = false;
+
+			if (mediaType === 'movie') {
+				const [existingMovie] = await db
+					.select({ id: movies.id })
+					.from(movies)
+					.where(eq(movies.tmdbId, tmdbId))
+					.limit(1);
+				if (existingMovie) {
+					const [existingFile] = await db
+						.select({ id: movieFiles.id })
+						.from(movieFiles)
+						.where(
+							and(
+								eq(movieFiles.movieId, existingMovie.id),
+								eq(movieFiles.relativePath, basename(relPath))
+							)
+						)
+						.limit(1);
+					alreadyMatched = !!existingFile;
+				}
+			} else {
+				const pathParts = relPath.split('/');
+				const seriesFolder = pathParts[0] || relPath;
+				const epRelPath = relPath.replace(seriesFolder + '/', '');
+				const [existingSeries] = await db
+					.select({ id: series.id })
+					.from(series)
+					.where(eq(series.tmdbId, tmdbId))
+					.limit(1);
+				if (existingSeries) {
+					const [existingFile] = await db
+						.select({ id: episodeFiles.id })
+						.from(episodeFiles)
+						.where(
+							and(
+								eq(episodeFiles.seriesId, existingSeries.id),
+								eq(episodeFiles.relativePath, epRelPath)
+							)
+						)
+						.limit(1);
+					alreadyMatched = !!existingFile;
+				}
+			}
+
+			if (alreadyMatched) {
+				logger.debug(
+					{ unmatchedFileId, filePath: file.path },
+					'[MediaMatcher] File already in library; removing stale unmatched record'
+				);
+				await db.delete(unmatchedFiles).where(eq(unmatchedFiles.id, unmatchedFileId));
+				return;
+			}
+		}
+
 		// Refuse matches that would produce unresolvable file links: if the
 		// target movie/series already exists, every consumer resolves file
 		// rows through the existing entry's root folder + path. Linking a file
@@ -1298,6 +1370,7 @@ export class MediaMatcherService {
 						airDate: tmdbSeason.air_date,
 						monitored: defaultMon && seasonNumber !== 0
 					})
+					.onConflictDoNothing()
 					.returning();
 			} else {
 				// Create basic entry without TMDB data
@@ -1308,8 +1381,15 @@ export class MediaMatcherService {
 						seasonNumber,
 						monitored: defaultMon && seasonNumber !== 0
 					})
+					.onConflictDoNothing()
 					.returning();
 			}
+			// Concurrent insert; re-fetch if returning() came back empty.
+			season ??= await db
+				.select()
+				.from(seasons)
+				.where(and(eq(seasons.seriesId, seriesId), eq(seasons.seasonNumber, seasonNumber)))
+				.then((rows) => rows[0]);
 		}
 
 		// Ensure all episodes covered by this file exist and have hasFile: true.
@@ -1348,7 +1428,19 @@ export class MediaMatcherService {
 						hasFile: true,
 						monitored: episodeMonitored
 					})
+					.onConflictDoNothing()
 					.returning();
+				ep ??= await db
+					.select()
+					.from(episodes)
+					.where(
+						and(
+							eq(episodes.seriesId, seriesId),
+							eq(episodes.seasonNumber, seasonNumber),
+							eq(episodes.episodeNumber, epNum)
+						)
+					)
+					.then((rows) => rows[0]);
 			} else {
 				const updates: Record<string, unknown> = { hasFile: true };
 				if (tmdbEp && !ep.title) {
@@ -1472,8 +1564,20 @@ export class MediaMatcherService {
 						episodeFileCount: 0,
 						monitored: defaultMonitored && !isSpecials
 					})
+					.onConflictDoNothing()
 					.returning();
-				seasonId = newSeason.id;
+				seasonId =
+					newSeason?.id ??
+					(await db
+						.select({ id: seasons.id })
+						.from(seasons)
+						.where(
+							and(
+								eq(seasons.seriesId, seriesId),
+								eq(seasons.seasonNumber, seasonInfo.season_number)
+							)
+						)
+						.then((rows) => rows[0]?.id ?? ''));
 			}
 
 			// Fetch full season details to get episodes
@@ -1496,19 +1600,22 @@ export class MediaMatcherService {
 
 						if (!existingEpisode) {
 							// Create episode with TMDB metadata
-							await db.insert(episodes).values({
-								seriesId,
-								seasonId,
-								tmdbId: ep.id,
-								seasonNumber: ep.season_number,
-								episodeNumber: ep.episode_number,
-								title: ep.name,
-								overview: ep.overview,
-								airDate: ep.air_date,
-								runtime: ep.runtime,
-								monitored: defaultMonitored && !isSpecials,
-								hasFile: false
-							});
+							await db
+								.insert(episodes)
+								.values({
+									seriesId,
+									seasonId,
+									tmdbId: ep.id,
+									seasonNumber: ep.season_number,
+									episodeNumber: ep.episode_number,
+									title: ep.name,
+									overview: ep.overview,
+									airDate: ep.air_date,
+									runtime: ep.runtime,
+									monitored: defaultMonitored && !isSpecials,
+									hasFile: false
+								})
+								.onConflictDoNothing();
 						}
 					}
 				}

--- a/src/lib/server/library/media-matcher.ts
+++ b/src/lib/server/library/media-matcher.ts
@@ -1096,21 +1096,24 @@ export class MediaMatcherService {
 		const parsedQuality = parseRelease(parseableFilename || originalFilename);
 
 		// Create movie file entry with proper sceneName, releaseGroup, and quality data
-		await db.insert(movieFiles).values({
-			movieId,
-			relativePath: fileName,
-			size: file.size,
-			mediaInfo,
-			sceneName: originalFilename,
-			releaseGroup: parsedQuality.releaseGroup ?? undefined,
-			edition: parsedQuality.edition ?? undefined,
-			quality: {
-				resolution: parsedQuality.resolution ?? undefined,
-				source: parsedQuality.source ?? undefined,
-				codec: parsedQuality.codec ?? undefined,
-				hdr: parsedQuality.hdr ?? undefined
-			}
-		});
+		await db
+			.insert(movieFiles)
+			.values({
+				movieId,
+				relativePath: fileName,
+				size: file.size,
+				mediaInfo,
+				sceneName: originalFilename,
+				releaseGroup: parsedQuality.releaseGroup ?? undefined,
+				edition: parsedQuality.edition ?? undefined,
+				quality: {
+					resolution: parsedQuality.resolution ?? undefined,
+					source: parsedQuality.source ?? undefined,
+					codec: parsedQuality.codec ?? undefined,
+					hdr: parsedQuality.hdr ?? undefined
+				}
+			})
+			.onConflictDoNothing();
 
 		// Trigger subtitle search if enabled (after metadata is fetched)
 		this.triggerSubtitleSearch('movie', movieId).catch((err) => {

--- a/src/lib/server/library/naming/NamingSettingsService.ts
+++ b/src/lib/server/library/naming/NamingSettingsService.ts
@@ -174,8 +174,12 @@ export class NamingSettingsService {
 			}
 		}
 
-		// Invalidate cache and return updated config
+		// Invalidate NamingSettingsService config cache and rename-preview cache.
+		// A naming format change invalidates every computed path in the library.
 		this.invalidateCache();
+		import('./RenamePreviewCache.js').then(({ renamePreviewCache }) => {
+			renamePreviewCache.invalidateAll();
+		});
 		return this.getConfig();
 	}
 

--- a/src/lib/server/library/naming/RenamePreviewCache.ts
+++ b/src/lib/server/library/naming/RenamePreviewCache.ts
@@ -1,0 +1,130 @@
+import type { RenamePreviewItem, RenamePreviewResult } from '$lib/library/naming/types.js';
+import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+
+interface MediaTypeCache {
+	result: RenamePreviewResult;
+	staleIds: Set<string>;
+	fullyStale: boolean;
+}
+
+class RenamePreviewCacheStore {
+	private movie: MediaTypeCache | null = null;
+	private tv: MediaTypeCache | null = null;
+
+	constructor() {
+		libraryMediaEvents.onMovieUpdated(({ movieId }) => this.invalidateMovie(movieId));
+		libraryMediaEvents.onSeriesUpdated(({ seriesId }) => this.invalidateSeries(seriesId));
+	}
+
+	isFresh(mediaType: 'movie' | 'tv'): boolean {
+		const c = mediaType === 'movie' ? this.movie : this.tv;
+		return !!c && !c.fullyStale && c.staleIds.size === 0;
+	}
+
+	isPartiallyCached(mediaType: 'movie' | 'tv'): boolean {
+		const c = mediaType === 'movie' ? this.movie : this.tv;
+		return !!c && !c.fullyStale && c.staleIds.size > 0;
+	}
+
+	get(mediaType: 'movie' | 'tv'): RenamePreviewResult | null {
+		const c = mediaType === 'movie' ? this.movie : this.tv;
+		return c ? c.result : null;
+	}
+
+	getStaleIds(mediaType: 'movie' | 'tv'): Set<string> {
+		const c = mediaType === 'movie' ? this.movie : this.tv;
+		return c ? new Set(c.staleIds) : new Set();
+	}
+
+	set(mediaType: 'movie' | 'tv', result: RenamePreviewResult): void {
+		const entry: MediaTypeCache = { result, staleIds: new Set(), fullyStale: false };
+		if (mediaType === 'movie') this.movie = entry;
+		else this.tv = entry;
+	}
+
+	invalidateAll(): void {
+		if (this.movie) this.movie.fullyStale = true;
+		if (this.tv) this.tv.fullyStale = true;
+	}
+
+	invalidateMovie(movieId: string): void {
+		if (this.movie) this.movie.staleIds.add(movieId);
+	}
+
+	invalidateSeries(seriesId: string): void {
+		if (this.tv) this.tv.staleIds.add(seriesId);
+	}
+
+	/**
+	 * Patch a partially-stale cache: remove stale items, merge fresh ones, re-run
+	 * collision detection over the combined willChange set.
+	 */
+	applyPatch(
+		mediaType: 'movie' | 'tv',
+		staleIds: Set<string>,
+		freshResult: RenamePreviewResult
+	): void {
+		const c = mediaType === 'movie' ? this.movie : this.tv;
+		if (!c) return;
+
+		const notStale = (item: RenamePreviewItem) => !staleIds.has(item.mediaId);
+
+		// Move previous collisions back into willChange before merging so
+		// collision detection sees the full combined set.
+		const prevWillChange: RenamePreviewItem[] = [
+			...c.result.willChange.filter(notStale),
+			...c.result.collisions.filter(notStale).map((item) => ({
+				...item,
+				status: 'will_change' as const,
+				collisionsWith: undefined
+			})),
+			...freshResult.willChange
+		];
+
+		c.result.willChange = prevWillChange;
+		c.result.alreadyCorrect = [
+			...c.result.alreadyCorrect.filter(notStale),
+			...freshResult.alreadyCorrect
+		];
+		c.result.errors = [...c.result.errors.filter(notStale), ...freshResult.errors];
+		c.result.collisions = [];
+
+		this.detectCollisions(c.result);
+
+		c.result.totalWillChange = c.result.willChange.length;
+		c.result.totalAlreadyCorrect = c.result.alreadyCorrect.length;
+		c.result.totalCollisions = c.result.collisions.length;
+		c.result.totalErrors = c.result.errors.length;
+		c.result.totalFiles =
+			c.result.totalWillChange +
+			c.result.totalAlreadyCorrect +
+			c.result.totalCollisions +
+			c.result.totalErrors;
+
+		c.staleIds.clear();
+	}
+
+	private detectCollisions(result: RenamePreviewResult): void {
+		const pathMap = new Map<string, RenamePreviewItem[]>();
+		for (const item of result.willChange) {
+			const existing = pathMap.get(item.newFullPath) || [];
+			existing.push(item);
+			pathMap.set(item.newFullPath, existing);
+		}
+		for (const items of pathMap.values()) {
+			if (items.length > 1) {
+				for (const item of items) {
+					item.status = 'collision';
+					item.collisionsWith = items.filter((i) => i.fileId !== item.fileId).map((i) => i.fileId);
+					const idx = result.willChange.indexOf(item);
+					if (idx !== -1) {
+						result.willChange.splice(idx, 1);
+						result.collisions.push(item);
+					}
+				}
+			}
+		}
+	}
+}
+
+export const renamePreviewCache = new RenamePreviewCacheStore();

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -23,7 +23,6 @@ import { createChildLogger, getRequestId } from '$lib/logging';
 import { todayDateString } from '$lib/utils/format.js';
 import { randomUUID } from 'node:crypto';
 
-const logger = createChildLogger({ logDomain: 'scans' as const });
 import { NamingService, type MediaNamingInfo } from './NamingService';
 import { namingSettingsService } from './NamingSettingsService';
 import { libraryOperationLock } from '../library-operation-lock.js';
@@ -36,6 +35,20 @@ import {
 	getMediaBrowserManager,
 	getMediaBrowserNotifier
 } from '$lib/server/notifications/mediabrowser';
+
+const logger = createChildLogger({ logDomain: 'scans' as const });
+
+// Yield to the event loop every N files during preview computation so other
+// requests are not starved while processing large libraries.
+const PREVIEW_BATCH_SIZE = 500;
+
+// Number of media groups to process concurrently during rename execution.
+// Bounds open file handles and OS I/O queue depth.
+const EXECUTE_GROUP_BATCH_SIZE = 20;
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 // Types are defined in $lib/library/naming/types.ts (outside the server
 // bundle) so .svelte files can import them without pulling server code
@@ -175,6 +188,7 @@ export class RenamePreviewService {
 		}
 
 		const result = emptyPreviewResult();
+		let processed = 0;
 
 		for (const movie of allMovies) {
 			const rootFolder = movie.rootFolderId ? rootFolderById.get(movie.rootFolderId) : undefined;
@@ -200,6 +214,9 @@ export class RenamePreviewService {
 					item.status = 'will_change';
 					result.willChange.push(item);
 					result.totalWillChange++;
+				}
+				if (++processed % PREVIEW_BATCH_SIZE === 0) {
+					await yieldToEventLoop();
 				}
 			}
 		}
@@ -233,6 +250,7 @@ export class RenamePreviewService {
 		}
 
 		const result = emptyPreviewResult();
+		let processed = 0;
 
 		for (const show of allSeries) {
 			const rootFolder = show.rootFolderId ? rootFolderById.get(show.rootFolderId) : undefined;
@@ -268,6 +286,9 @@ export class RenamePreviewService {
 					item.status = 'will_change';
 					result.willChange.push(item);
 					result.totalWillChange++;
+				}
+				if (++processed % PREVIEW_BATCH_SIZE === 0) {
+					await yieldToEventLoop();
 				}
 			}
 		}
@@ -482,148 +503,159 @@ export class RenamePreviewService {
 		const touchedMovieIds = new Set<string>();
 		const touchedSeriesIds = new Set<string>();
 
-		// Process each media group concurrently. Files in the same group are
-		// processed sequentially to avoid filesystem races in the same folder.
-		const groupResults = await Promise.allSettled(
-			[...groups.entries()].map(async ([mediaId, items]) => {
-				const firstItem = items[0];
-				if (firstItem?.mediaType === 'movie') {
-					touchedMovieIds.add(mediaId);
-				} else if (firstItem?.mediaType === 'episode') {
-					touchedSeriesIds.add(mediaId);
-				}
+		// Process media groups in batches to bound concurrency and avoid
+		// exhausting file descriptors or OS I/O queues on large renames.
+		// Files within each group are processed sequentially to avoid
+		// filesystem races inside the same folder.
+		const groupEntries = [...groups.entries()];
 
-				const groupResult: RenameExecuteResult['results'] = [];
+		const processGroup = async ([mediaId, items]: [string, RenamePreviewItem[]]) => {
+			const firstItem = items[0];
+			if (firstItem?.mediaType === 'movie') {
+				touchedMovieIds.add(mediaId);
+			} else if (firstItem?.mediaType === 'episode') {
+				touchedSeriesIds.add(mediaId);
+			}
 
-				for (const item of items) {
-					if (item.status === 'collision') {
-						const failResult = {
-							fileId: item.fileId,
-							mediaType: item.mediaType,
-							success: false,
-							oldPath: item.currentFullPath,
-							newPath: item.newFullPath,
-							error: 'Cannot rename: collision with another file'
-						};
-						groupResult.push(failResult);
-						await this.writeRenameHistory(item, failResult.success, failResult.error);
-						recordRenamingFailure({
-							fileId: item.fileId,
-							fileType: item.mediaType,
-							sourcePath: item.currentFullPath,
-							intendedPath: item.newFullPath,
-							reason: 'collision',
-							reasonDetail: failResult.error
-						}).catch((err) =>
-							logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
-						);
-						continue;
-					}
+			const groupResult: RenameExecuteResult['results'] = [];
 
-					if (item.status === 'error') {
-						const failResult = {
-							fileId: item.fileId,
-							mediaType: item.mediaType,
-							success: false,
-							oldPath: item.currentFullPath,
-							newPath: item.newFullPath,
-							error: item.error ?? 'Cannot rename file'
-						};
-						groupResult.push(failResult);
-						await this.writeRenameHistory(item, failResult.success, failResult.error);
-						recordRenamingFailure({
-							fileId: item.fileId,
-							fileType: item.mediaType,
-							sourcePath: item.currentFullPath,
-							intendedPath: item.newFullPath,
-							reason: 'preview_error',
-							reasonDetail: failResult.error
-						}).catch((err) =>
-							logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
-						);
-						continue;
-					}
-
-					const renameResult = await this.executeFileRename(item, result.warnings);
-					groupResult.push(renameResult);
-					await this.writeRenameHistory(item, renameResult.success, renameResult.error);
-					if (!renameResult.success) {
-						recordRenamingFailure({
-							fileId: item.fileId,
-							fileType: item.mediaType,
-							sourcePath: item.currentFullPath,
-							intendedPath: item.newFullPath,
-							reason: 'io_error',
-							reasonDetail: renameResult.error
-						}).catch((err) =>
-							logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
-						);
-					}
-				}
-
-				// After all files in this group are processed, handle any folder rename.
-				// A folder rename occurs when at least one file successfully moved to a
-				// new parent path. We update the DB path record, move remaining extra
-				// files (artwork, nfo, etc.) to the new folder, and clean up empty dirs.
-				const successfulFolderChange = items.find((item) => {
-					const matched = groupResult.find((r) => r.fileId === item.fileId);
-					return matched?.success && item.currentParentPath !== item.newParentPath;
-				});
-				if (successfulFolderChange && firstItem) {
-					const originalStem = basename(
-						successfulFolderChange.currentFullPath,
-						extname(successfulFolderChange.currentFullPath)
+			for (const item of items) {
+				if (item.status === 'collision') {
+					const failResult = {
+						fileId: item.fileId,
+						mediaType: item.mediaType,
+						success: false,
+						oldPath: item.currentFullPath,
+						newPath: item.newFullPath,
+						error: 'Cannot rename: collision with another file'
+					};
+					groupResult.push(failResult);
+					await this.writeRenameHistory(item, failResult.success, failResult.error);
+					recordRenamingFailure({
+						fileId: item.fileId,
+						fileType: item.mediaType,
+						sourcePath: item.currentFullPath,
+						intendedPath: item.newFullPath,
+						reason: 'collision',
+						reasonDetail: failResult.error
+					}).catch((err) =>
+						logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
 					);
-					const folderWarnings = await this.applyFolderRename(
-						mediaId,
-						firstItem.mediaType as 'movie' | 'episode',
-						successfulFolderChange.currentParentPath,
-						successfulFolderChange.newParentPath,
-						originalStem
+					continue;
+				}
+
+				if (item.status === 'error') {
+					const failResult = {
+						fileId: item.fileId,
+						mediaType: item.mediaType,
+						success: false,
+						oldPath: item.currentFullPath,
+						newPath: item.newFullPath,
+						error: item.error ?? 'Cannot rename file'
+					};
+					groupResult.push(failResult);
+					await this.writeRenameHistory(item, failResult.success, failResult.error);
+					recordRenamingFailure({
+						fileId: item.fileId,
+						fileType: item.mediaType,
+						sourcePath: item.currentFullPath,
+						intendedPath: item.newFullPath,
+						reason: 'preview_error',
+						reasonDetail: failResult.error
+					}).catch((err) =>
+						logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
 					);
-					if (folderWarnings.length > 0) {
-						result.warnings ??= [];
-						result.warnings.push(...folderWarnings);
-					}
+					continue;
 				}
 
-				// Clean up empty season subdirectories left behind when files moved
-				// between season folders within the same series folder (e.g. Season 00
-				// -> Specials). The series-level parent path is unchanged so
-				// applyFolderRename never runs, but the old season dir may now be empty.
-				const oldSeasonDirs = new Set<string>();
-				for (const item of items) {
-					const matched = groupResult.find((r) => r.fileId === item.fileId);
-					if (!matched?.success) continue;
-					const oldSeasonDir = dirname(item.currentFullPath);
-					const newSeasonDir = dirname(item.newFullPath);
-					if (oldSeasonDir !== newSeasonDir) {
-						oldSeasonDirs.add(oldSeasonDir);
-					}
+				const renameResult = await this.executeFileRename(item, result.warnings);
+				groupResult.push(renameResult);
+				await this.writeRenameHistory(item, renameResult.success, renameResult.error);
+				if (!renameResult.success) {
+					recordRenamingFailure({
+						fileId: item.fileId,
+						fileType: item.mediaType,
+						sourcePath: item.currentFullPath,
+						intendedPath: item.newFullPath,
+						reason: 'io_error',
+						reasonDetail: renameResult.error
+					}).catch((err) =>
+						logger.warn({ err }, '[RenamePreviewService] Failed to record renaming failure')
+					);
 				}
-				for (const dir of oldSeasonDirs) {
-					await this.tryRemoveEmptyDir(dir);
-				}
+			}
 
-				return groupResult;
-			})
-		);
-
-		// Aggregate results from parallel groups.
-		for (const settled of groupResults) {
-			if (settled.status === 'fulfilled') {
-				for (const r of settled.value) {
-					result.results.push(r);
-					result.processed++;
-					if (r.success) {
-						result.succeeded++;
-					} else {
-						result.failed++;
-						result.success = false;
-					}
+			// After all files in this group are processed, handle any folder rename.
+			// A folder rename occurs when at least one file successfully moved to a
+			// new parent path. We update the DB path record, move remaining extra
+			// files (artwork, nfo, etc.) to the new folder, and clean up empty dirs.
+			const successfulFolderChange = items.find((item) => {
+				const matched = groupResult.find((r) => r.fileId === item.fileId);
+				return matched?.success && item.currentParentPath !== item.newParentPath;
+			});
+			if (successfulFolderChange && firstItem) {
+				const originalStem = basename(
+					successfulFolderChange.currentFullPath,
+					extname(successfulFolderChange.currentFullPath)
+				);
+				const folderWarnings = await this.applyFolderRename(
+					mediaId,
+					firstItem.mediaType as 'movie' | 'episode',
+					successfulFolderChange.currentParentPath,
+					successfulFolderChange.newParentPath,
+					originalStem
+				);
+				if (folderWarnings.length > 0) {
+					result.warnings ??= [];
+					result.warnings.push(...folderWarnings);
 				}
-			} else {
-				result.success = false;
+			}
+
+			// Clean up empty season subdirectories left behind when files moved
+			// between season folders within the same series folder (e.g. Season 00
+			// -> Specials). The series-level parent path is unchanged so
+			// applyFolderRename never runs, but the old season dir may now be empty.
+			const oldSeasonDirs = new Set<string>();
+			for (const item of items) {
+				const matched = groupResult.find((r) => r.fileId === item.fileId);
+				if (!matched?.success) continue;
+				const oldSeasonDir = dirname(item.currentFullPath);
+				const newSeasonDir = dirname(item.newFullPath);
+				if (oldSeasonDir !== newSeasonDir) {
+					oldSeasonDirs.add(oldSeasonDir);
+				}
+			}
+			for (const dir of oldSeasonDirs) {
+				await this.tryRemoveEmptyDir(dir);
+			}
+
+			return groupResult;
+		};
+
+		for (let i = 0; i < groupEntries.length; i += EXECUTE_GROUP_BATCH_SIZE) {
+			const batch = groupEntries.slice(i, i + EXECUTE_GROUP_BATCH_SIZE);
+			const batchResults = await Promise.allSettled(batch.map(processGroup));
+
+			// Aggregate results for this batch.
+			for (const settled of batchResults) {
+				if (settled.status === 'fulfilled') {
+					for (const r of settled.value) {
+						result.results.push(r);
+						result.processed++;
+						if (r.success) {
+							result.succeeded++;
+						} else {
+							result.failed++;
+							result.success = false;
+						}
+					}
+				} else {
+					result.success = false;
+				}
+			}
+
+			if (i + EXECUTE_GROUP_BATCH_SIZE < groupEntries.length) {
+				await yieldToEventLoop();
 			}
 		}
 

--- a/src/lib/server/library/naming/RenamePreviewService.ts
+++ b/src/lib/server/library/naming/RenamePreviewService.ts
@@ -17,7 +17,7 @@ import {
 	renameHistory,
 	renamingFailures
 } from '$lib/server/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { extname, join, dirname, basename, resolve } from 'path';
 import { createChildLogger, getRequestId } from '$lib/logging';
 import { todayDateString } from '$lib/utils/format.js';
@@ -41,6 +41,9 @@ const logger = createChildLogger({ logDomain: 'scans' as const });
 // Yield to the event loop every N files during preview computation so other
 // requests are not starved while processing large libraries.
 const PREVIEW_BATCH_SIZE = 500;
+
+export type { RenameStreamEvent } from '$lib/library/naming/types.js';
+import type { RenameStreamEvent } from '$lib/library/naming/types.js';
 
 // Number of media groups to process concurrently during rename execution.
 // Bounds open file handles and OS I/O queue depth.
@@ -174,7 +177,7 @@ export class RenamePreviewService {
 	 * Preview renames for all movies.
 	 * Batches DB queries to avoid N+1 per-movie lookups on large libraries.
 	 */
-	async previewAllMovies(): Promise<RenamePreviewResult> {
+	async previewAllMovies(emit?: (event: RenameStreamEvent) => void): Promise<RenamePreviewResult> {
 		const allMovies = db.select().from(movies).all();
 		const allRootFolders = db.select().from(rootFolders).all();
 		const allFiles = db.select().from(movieFiles).all();
@@ -189,8 +192,94 @@ export class RenamePreviewService {
 
 		const result = emptyPreviewResult();
 		let processed = 0;
+		const batchWillChange: RenamePreviewItem[] = [];
+		const batchAlreadyCorrect: RenamePreviewItem[] = [];
+		const batchErrors: RenamePreviewItem[] = [];
+
+		const flushBatch = () => {
+			if (!emit) return;
+			if (batchWillChange.length)
+				emit({ type: 'items', category: 'willChange', data: [...batchWillChange] });
+			if (batchAlreadyCorrect.length)
+				emit({ type: 'items', category: 'alreadyCorrect', data: [...batchAlreadyCorrect] });
+			if (batchErrors.length) emit({ type: 'items', category: 'errors', data: [...batchErrors] });
+			batchWillChange.length = 0;
+			batchAlreadyCorrect.length = 0;
+			batchErrors.length = 0;
+		};
 
 		for (const movie of allMovies) {
+			const rootFolder = movie.rootFolderId ? rootFolderById.get(movie.rootFolderId) : undefined;
+			const rootFolderPath = rootFolder?.path ?? '';
+			const rootFolderReadOnly = rootFolder?.readOnly ?? false;
+			const files = filesByMovieId.get(movie.id) ?? [];
+
+			for (const file of files) {
+				const item = this.buildMoviePreviewItem(movie, file, rootFolderPath, rootFolderReadOnly);
+				result.totalFiles++;
+
+				if (item.status === 'error') {
+					result.errors.push(item);
+					result.totalErrors++;
+					if (emit) batchErrors.push(item);
+				} else if (
+					item.currentRelativePath === item.newRelativePath &&
+					item.currentParentPath === item.newParentPath
+				) {
+					item.status = 'already_correct';
+					result.alreadyCorrect.push(item);
+					result.totalAlreadyCorrect++;
+					if (emit) batchAlreadyCorrect.push(item);
+				} else {
+					item.status = 'will_change';
+					result.willChange.push(item);
+					result.totalWillChange++;
+					if (emit) batchWillChange.push(item);
+				}
+				if (++processed % PREVIEW_BATCH_SIZE === 0) {
+					flushBatch();
+					await yieldToEventLoop();
+				}
+			}
+		}
+
+		flushBatch();
+		this.detectCollisions(result);
+
+		if (emit) {
+			if (result.collisions.length) {
+				emit({ type: 'items', category: 'collisions', data: result.collisions });
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Preview renames for a specific set of movies (partial/targeted recompute).
+	 */
+	async previewMoviesByIds(movieIds: string[]): Promise<RenamePreviewResult> {
+		if (movieIds.length === 0) return emptyPreviewResult();
+
+		const targetMovies = db.select().from(movies).where(inArray(movies.id, movieIds)).all();
+		const allRootFolders = db.select().from(rootFolders).all();
+		const targetFiles = db
+			.select()
+			.from(movieFiles)
+			.where(inArray(movieFiles.movieId, movieIds))
+			.all();
+
+		const rootFolderById = new Map(allRootFolders.map((rf) => [rf.id, rf]));
+		const filesByMovieId = new Map<string, (typeof movieFiles.$inferSelect)[]>();
+		for (const file of targetFiles) {
+			const list = filesByMovieId.get(file.movieId) || [];
+			list.push(file);
+			filesByMovieId.set(file.movieId, list);
+		}
+
+		const result = emptyPreviewResult();
+
+		for (const movie of targetMovies) {
 			const rootFolder = movie.rootFolderId ? rootFolderById.get(movie.rootFolderId) : undefined;
 			const rootFolderPath = rootFolder?.path ?? '';
 			const rootFolderReadOnly = rootFolder?.readOnly ?? false;
@@ -215,13 +304,8 @@ export class RenamePreviewService {
 					result.willChange.push(item);
 					result.totalWillChange++;
 				}
-				if (++processed % PREVIEW_BATCH_SIZE === 0) {
-					await yieldToEventLoop();
-				}
 			}
 		}
-
-		this.detectCollisions(result);
 		return result;
 	}
 
@@ -229,7 +313,9 @@ export class RenamePreviewService {
 	 * Preview renames for all episode files.
 	 * Batches DB queries to avoid N+1 per-series lookups on large libraries.
 	 */
-	async previewAllEpisodes(): Promise<RenamePreviewResult> {
+	async previewAllEpisodes(
+		emit?: (event: RenameStreamEvent) => void
+	): Promise<RenamePreviewResult> {
 		const allSeries = db.select().from(series).all();
 		const allRootFolders = db.select().from(rootFolders).all();
 		const allFiles = db.select().from(episodeFiles).all();
@@ -251,8 +337,113 @@ export class RenamePreviewService {
 
 		const result = emptyPreviewResult();
 		let processed = 0;
+		const batchWillChange: RenamePreviewItem[] = [];
+		const batchAlreadyCorrect: RenamePreviewItem[] = [];
+		const batchErrors: RenamePreviewItem[] = [];
+
+		const flushBatch = () => {
+			if (!emit) return;
+			if (batchWillChange.length)
+				emit({ type: 'items', category: 'willChange', data: [...batchWillChange] });
+			if (batchAlreadyCorrect.length)
+				emit({ type: 'items', category: 'alreadyCorrect', data: [...batchAlreadyCorrect] });
+			if (batchErrors.length) emit({ type: 'items', category: 'errors', data: [...batchErrors] });
+			batchWillChange.length = 0;
+			batchAlreadyCorrect.length = 0;
+			batchErrors.length = 0;
+		};
 
 		for (const show of allSeries) {
+			const rootFolder = show.rootFolderId ? rootFolderById.get(show.rootFolderId) : undefined;
+			const rootFolderPath = rootFolder?.path ?? '';
+			const rootFolderReadOnly = rootFolder?.readOnly ?? false;
+			const files = filesBySeriesId.get(show.id) ?? [];
+			const seriesEpisodes = episodesBySeriesId.get(show.id) ?? [];
+			const episodeMap = new Map(seriesEpisodes.map((ep) => [ep.id, ep]));
+			const absoluteEpisodeMap = this.buildAbsoluteEpisodeFallbackMap(seriesEpisodes);
+
+			for (const file of files) {
+				const item = this.buildEpisodePreviewItem(
+					show,
+					file,
+					episodeMap,
+					rootFolderPath,
+					absoluteEpisodeMap,
+					rootFolderReadOnly
+				);
+				result.totalFiles++;
+
+				if (item.status === 'error') {
+					result.errors.push(item);
+					result.totalErrors++;
+					if (emit) batchErrors.push(item);
+				} else if (
+					item.currentRelativePath === item.newRelativePath &&
+					item.currentParentPath === item.newParentPath
+				) {
+					item.status = 'already_correct';
+					result.alreadyCorrect.push(item);
+					result.totalAlreadyCorrect++;
+					if (emit) batchAlreadyCorrect.push(item);
+				} else {
+					item.status = 'will_change';
+					result.willChange.push(item);
+					result.totalWillChange++;
+					if (emit) batchWillChange.push(item);
+				}
+				if (++processed % PREVIEW_BATCH_SIZE === 0) {
+					flushBatch();
+					await yieldToEventLoop();
+				}
+			}
+		}
+
+		flushBatch();
+		this.detectCollisions(result);
+
+		if (emit && result.collisions.length) {
+			emit({ type: 'items', category: 'collisions', data: result.collisions });
+		}
+
+		return result;
+	}
+
+	/**
+	 * Preview renames for a specific set of series (partial/targeted recompute).
+	 */
+	async previewSeriesByIds(seriesIds: string[]): Promise<RenamePreviewResult> {
+		if (seriesIds.length === 0) return emptyPreviewResult();
+
+		const targetSeries = db.select().from(series).where(inArray(series.id, seriesIds)).all();
+		const allRootFolders = db.select().from(rootFolders).all();
+		const targetFiles = db
+			.select()
+			.from(episodeFiles)
+			.where(inArray(episodeFiles.seriesId, seriesIds))
+			.all();
+		const targetEpisodes = db
+			.select()
+			.from(episodes)
+			.where(inArray(episodes.seriesId, seriesIds))
+			.all();
+
+		const rootFolderById = new Map(allRootFolders.map((rf) => [rf.id, rf]));
+		const filesBySeriesId = new Map<string, (typeof episodeFiles.$inferSelect)[]>();
+		for (const file of targetFiles) {
+			const list = filesBySeriesId.get(file.seriesId) || [];
+			list.push(file);
+			filesBySeriesId.set(file.seriesId, list);
+		}
+		const episodesBySeriesId = new Map<string, (typeof episodes.$inferSelect)[]>();
+		for (const ep of targetEpisodes) {
+			const list = episodesBySeriesId.get(ep.seriesId) || [];
+			list.push(ep);
+			episodesBySeriesId.set(ep.seriesId, list);
+		}
+
+		const result = emptyPreviewResult();
+
+		for (const show of targetSeries) {
 			const rootFolder = show.rootFolderId ? rootFolderById.get(show.rootFolderId) : undefined;
 			const rootFolderPath = rootFolder?.path ?? '';
 			const rootFolderReadOnly = rootFolder?.readOnly ?? false;
@@ -287,13 +478,9 @@ export class RenamePreviewService {
 					result.willChange.push(item);
 					result.totalWillChange++;
 				}
-				if (++processed % PREVIEW_BATCH_SIZE === 0) {
-					await yieldToEventLoop();
-				}
 			}
 		}
 
-		this.detectCollisions(result);
 		return result;
 	}
 

--- a/src/lib/server/library/searchOnAdd/alt-titles.ts
+++ b/src/lib/server/library/searchOnAdd/alt-titles.ts
@@ -2,13 +2,15 @@
  * Alternate title refresh helpers — shared caching logic for searchOnAdd
  */
 
-import { logger } from '$lib/logging/index.js';
 import {
 	getMovieSearchTitles,
 	getSeriesSearchTitles,
 	fetchAndStoreMovieAlternateTitles,
 	fetchAndStoreSeriesAlternateTitles
 } from '$lib/server/services/AlternateTitleService.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'AltTitlesSearch', logDomain: 'scans' });
 
 export const ALT_TITLE_REFRESH_COOLDOWN_MS = 60 * 60 * 1000;
 export const ALT_TITLE_REFRESH_CACHE_MAX_ENTRIES = 2000;

--- a/src/lib/server/library/searchOnAdd/search-bulk.ts
+++ b/src/lib/server/library/searchOnAdd/search-bulk.ts
@@ -1,12 +1,14 @@
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
 import { evaluateIndexerSearchAvailability } from '$lib/server/indexers/search/availability.js';
-import { logger } from '$lib/logging/index.js';
 import { db } from '$lib/server/db/index.js';
 import { episodes, series } from '$lib/server/db/schema.js';
 import { eq, inArray } from 'drizzle-orm';
 import type { EpisodeToSearch } from '$lib/server/downloads/index.js';
 import type { AutoSearchItemResult, MultiSearchResult } from './types.js';
 import { AltTitleRefresher } from './alt-titles.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchBulk', logDomain: 'scans' });
 
 export async function searchBulkEpisodes(
 	episodeIds: string[],

--- a/src/lib/server/library/searchOnAdd/search-episode.ts
+++ b/src/lib/server/library/searchOnAdd/search-episode.ts
@@ -3,7 +3,6 @@
  */
 
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging/index.js';
 import { db } from '$lib/server/db/index.js';
 import { series, episodes, episodeFiles } from '$lib/server/db/schema.js';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
@@ -13,6 +12,9 @@ import type { SearchCriteria } from '$lib/server/indexers/types';
 import type { SearchForEpisodeParams, GrabResult } from './types.js';
 import type { AltTitleRefresher } from './alt-titles.js';
 import { AUTO_GRAB_MIN_SCORE } from './search-utils.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchEpisode', logDomain: 'scans' });
 
 export async function searchForEpisode(
 	params: SearchForEpisodeParams,

--- a/src/lib/server/library/searchOnAdd/search-missing.ts
+++ b/src/lib/server/library/searchOnAdd/search-missing.ts
@@ -2,7 +2,6 @@
  * Search On Add — missing episodes search
  */
 
-import { logger } from '$lib/logging/index.js';
 import { todayDateString } from '$lib/utils/format.js';
 import { db } from '$lib/server/db/index.js';
 import { series, episodes } from '$lib/server/db/schema.js';
@@ -20,6 +19,9 @@ import type { SearchProgressUpdate } from '$lib/server/downloads/MultiSeasonSear
 import { resolveAutoMissingSearchStrategy } from './search-utils.js';
 import { searchForEpisode as searchForEpisodeImpl } from './search-episode.js';
 import { searchForSeason as searchForSeasonImpl } from './search-season.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchMissing', logDomain: 'scans' });
 
 export async function searchForMissingEpisodes(
 	seriesId: string,

--- a/src/lib/server/library/searchOnAdd/search-movie.ts
+++ b/src/lib/server/library/searchOnAdd/search-movie.ts
@@ -1,5 +1,4 @@
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging/index.js';
 import { db } from '$lib/server/db/index.js';
 import { movieFiles, movies, scoringProfiles } from '$lib/server/db/schema.js';
 import { grabService } from '$lib/server/downloads/GrabService.js';
@@ -16,6 +15,9 @@ import type { SearchCriteria, EnhancedReleaseResult } from '$lib/server/indexers
 import { AUTO_GRAB_MIN_SCORE } from './search-utils.js';
 import type { AltTitleRefresher } from './alt-titles.js';
 import type { SearchForMovieParams, GrabResult } from './types.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchMovie', logDomain: 'scans' });
 
 /**
  * Build and send a grab request for a single movie release. Shared by the

--- a/src/lib/server/library/searchOnAdd/search-season.ts
+++ b/src/lib/server/library/searchOnAdd/search-season.ts
@@ -4,11 +4,13 @@ import { eq, and } from 'drizzle-orm';
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
 import { evaluateIndexerSearchAvailability } from '$lib/server/indexers/search/availability.js';
 import type { SearchCriteria } from '$lib/server/indexers/types';
-import { logger } from '$lib/logging/index.js';
 import { grabService } from '$lib/server/downloads/GrabService.js';
 import type { SearchForSeasonParams, GrabResult } from './types.js';
 import type { AltTitleRefresher } from './alt-titles.js';
 import { AUTO_GRAB_MIN_SCORE } from './search-utils.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchSeason', logDomain: 'scans' });
 
 export async function searchForSeason(
 	params: SearchForSeasonParams,

--- a/src/lib/server/library/searchOnAdd/search-series.ts
+++ b/src/lib/server/library/searchOnAdd/search-series.ts
@@ -5,12 +5,14 @@
 import { getIndexerManager } from '$lib/server/indexers/IndexerManager.js';
 import { evaluateIndexerSearchAvailability } from '$lib/server/indexers/search/availability';
 import { grabService } from '$lib/server/downloads/GrabService.js';
-import { logger } from '$lib/logging/index.js';
 import { db } from '$lib/server/db/index.js';
 import { episodes } from '$lib/server/db/schema.js';
 import { and, eq, ne } from 'drizzle-orm';
 import type { SearchForSeriesParams, GrabResult, SearchCriteria } from './types.js';
 import type { AltTitleRefresher } from './alt-titles.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SearchSeries', logDomain: 'scans' });
 
 export const AUTO_GRAB_MIN_SCORE = 0;
 

--- a/src/lib/server/logging/log-history.ts
+++ b/src/lib/server/logging/log-history.ts
@@ -5,7 +5,12 @@ import { stderr } from 'node:process';
 
 import { eq } from 'drizzle-orm';
 
-import type { CapturedLogEntry, CapturedLogFilters } from '$lib/logging/log-capture';
+import type {
+	CapturedLogEntry,
+	CapturedLogFilters,
+	CapturedLogLevel
+} from '$lib/logging/log-capture';
+import { DEFAULT_CAPTURED_LOG_LEVEL } from '$lib/logging/log-capture';
 import { db } from '$lib/server/db/index.js';
 import { settings } from '$lib/server/db/schema.js';
 
@@ -35,6 +40,16 @@ const LOG_RETENTION_SETTINGS_KEY = 'logs_retention_days';
 export const DEFAULT_LOG_RETENTION_DAYS = 7;
 export const MIN_LOG_RETENTION_DAYS = 1;
 export const MAX_LOG_RETENTION_DAYS = 90;
+
+const LOG_MIN_LEVEL_SETTINGS_KEY = 'logs_min_level';
+const LEVEL_ORDER: Record<CapturedLogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+function normalizeMinLevel(value: unknown): CapturedLogLevel {
+	if (value === 'debug' || value === 'info' || value === 'warn' || value === 'error') {
+		return value;
+	}
+	return DEFAULT_CAPTURED_LOG_LEVEL;
+}
 
 export interface LogHistoryFilters extends CapturedLogFilters {
 	from?: string;
@@ -321,6 +336,42 @@ class LogHistoryService {
 
 	private pendingWrites = Promise.resolve();
 
+	private minCaptureLevel: CapturedLogLevel | null = null;
+
+	private async ensureMinCaptureLevelLoaded(): Promise<CapturedLogLevel> {
+		if (this.minCaptureLevel === null) {
+			this.minCaptureLevel = await this.getMinCaptureLevel();
+		}
+		return this.minCaptureLevel;
+	}
+
+	async getMinCaptureLevel(): Promise<CapturedLogLevel> {
+		const row = await db
+			.select({ value: settings.value })
+			.from(settings)
+			.where(eq(settings.key, LOG_MIN_LEVEL_SETTINGS_KEY))
+			.get();
+
+		return normalizeMinLevel(row?.value);
+	}
+
+	async setMinCaptureLevel(level: string): Promise<CapturedLogLevel> {
+		const normalized = normalizeMinLevel(level);
+		await db
+			.insert(settings)
+			.values({
+				key: LOG_MIN_LEVEL_SETTINGS_KEY,
+				value: normalized
+			})
+			.onConflictDoUpdate({
+				target: settings.key,
+				set: { value: normalized }
+			});
+
+		this.minCaptureLevel = normalized;
+		return normalized;
+	}
+
 	async getRetentionDays(): Promise<number> {
 		const row = await db
 			.select({ value: settings.value })
@@ -351,6 +402,9 @@ class LogHistoryService {
 	append(entry: CapturedLogEntry): void {
 		this.pendingWrites = this.pendingWrites
 			.then(async () => {
+				const minLevel = await this.ensureMinCaptureLevelLoaded();
+				if (LEVEL_ORDER[entry.level] < LEVEL_ORDER[minLevel]) return;
+
 				await mkdir(LOGS_DIR, { recursive: true });
 				const filePath = getLogFilePath(new Date(entry.timestamp));
 				this.rotateIfNeeded(filePath);

--- a/src/lib/server/logging/log-history.ts
+++ b/src/lib/server/logging/log-history.ts
@@ -25,6 +25,12 @@ const serviceLogger = {
 const DATA_DIR = process.env.DATA_DIR || 'data';
 const LOGS_DIR = join(DATA_DIR, 'logs');
 
+const LINE_YIELD_INTERVAL = 500;
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
 const LOG_RETENTION_SETTINGS_KEY = 'logs_retention_days';
 export const DEFAULT_LOG_RETENTION_DAYS = 7;
 export const MIN_LOG_RETENTION_DAYS = 1;
@@ -119,6 +125,7 @@ async function readLinesReverse(filePath: string, visitor: ReverseLineVisitor): 
 		const chunkSize = 1024 * 1024;
 		let position = size;
 		let remainder = '';
+		let linesSinceYield = 0;
 
 		while (position > 0) {
 			const readSize = Math.min(chunkSize, position);
@@ -134,6 +141,10 @@ async function readLinesReverse(filePath: string, visitor: ReverseLineVisitor): 
 				const shouldContinue = await visitor(lines[index]);
 				if (shouldContinue === false) {
 					return;
+				}
+				if (++linesSinceYield >= LINE_YIELD_INTERVAL) {
+					linesSinceYield = 0;
+					await yieldToEventLoop();
 				}
 			}
 		}

--- a/src/lib/server/mediaServerStats/MediaServerStatsSyncService.ts
+++ b/src/lib/server/mediaServerStats/MediaServerStatsSyncService.ts
@@ -6,11 +6,12 @@ import { getMediaBrowserManager } from '$lib/server/notifications/mediabrowser/M
 import { createStatsProvider } from './providers/index.js';
 import { db } from '$lib/server/db';
 import { mediaServerSyncedItems, mediaServerSyncedRuns } from '$lib/server/db/schema';
-import { eq, and, notInArray } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 
 const DEFAULT_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const CHUNK_SIZE = 500;
 
 class MediaServerStatsSyncService extends EventEmitter implements BackgroundService {
 	readonly name = 'MediaServerStatsSyncService';
@@ -216,15 +217,28 @@ class MediaServerStatsSyncService extends EventEmitter implements BackgroundServ
 			}
 
 			if (result.serverItemIds.size > 0) {
-				const idsArray = Array.from(result.serverItemIds);
-				await db
-					.delete(mediaServerSyncedItems)
-					.where(
-						and(
-							eq(mediaServerSyncedItems.serverId, server.id),
-							notInArray(mediaServerSyncedItems.serverItemId, idsArray)
-						)
-					);
+				// notInArray with large arrays exceeds SQLite's variable limit.
+				// Load existing IDs, compute stale set locally, delete in chunks.
+				const existingRows = await db
+					.select({ serverItemId: mediaServerSyncedItems.serverItemId })
+					.from(mediaServerSyncedItems)
+					.where(eq(mediaServerSyncedItems.serverId, server.id));
+
+				const staleIds = existingRows
+					.map((r) => r.serverItemId)
+					.filter((id) => !result.serverItemIds.has(id));
+
+				for (let i = 0; i < staleIds.length; i += CHUNK_SIZE) {
+					const batch = staleIds.slice(i, i + CHUNK_SIZE);
+					await db
+						.delete(mediaServerSyncedItems)
+						.where(
+							and(
+								eq(mediaServerSyncedItems.serverId, server.id),
+								inArray(mediaServerSyncedItems.serverItemId, batch)
+							)
+						);
+				}
 			}
 
 			const completedAt = new Date().toISOString();

--- a/src/lib/server/monitoring/search/MonitoringSearchService.test.ts
+++ b/src/lib/server/monitoring/search/MonitoringSearchService.test.ts
@@ -79,7 +79,13 @@ vi.mock('$lib/logging/index.js', () => ({
 		warn: vi.fn(),
 		error: vi.fn(),
 		debug: vi.fn()
-	}
+	},
+	createChildLogger: vi.fn(() => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn()
+	}))
 }));
 
 // Mock all specifications using class syntax so they survive clearAllMocks.

--- a/src/lib/server/monitoring/search/MonitoringSearchService.ts
+++ b/src/lib/server/monitoring/search/MonitoringSearchService.ts
@@ -28,7 +28,7 @@ import {
 	parseEpisodePointerFromTitle
 } from '$lib/server/downloads/episode-pointer.js';
 import { ReleaseParser } from '$lib/server/indexers/parser/ReleaseParser.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { SearchCriteria, EnhancedReleaseResult } from '$lib/server/indexers/types';
 import { scoreRelease, isUpgrade } from '$lib/server/scoring/scorer.js';
 import type { ScoringProfile } from '$lib/server/scoring/types.js';
@@ -63,6 +63,8 @@ import {
 	type EpisodeContext,
 	type ReleaseCandidate
 } from '../specifications/index.js';
+
+const logger = createChildLogger({ module: 'MonitoringSearchService', logDomain: 'monitoring' });
 
 const parser = new ReleaseParser();
 

--- a/src/lib/server/monitoring/specifications/DelaySpecification.ts
+++ b/src/lib/server/monitoring/specifications/DelaySpecification.ts
@@ -14,8 +14,10 @@
 import { db } from '$lib/server/db/index.js';
 import { delayProfiles, pendingReleases, movies, series } from '$lib/server/db/schema.js';
 import { eq, and, lte, desc } from 'drizzle-orm';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { ReleaseCandidate } from './types.js';
+
+const logger = createChildLogger({ module: 'DelaySpecification', logDomain: 'monitoring' });
 
 /**
  * Result of delay calculation

--- a/src/lib/server/monitoring/tasks/CutoffUnmetTask.ts
+++ b/src/lib/server/monitoring/tasks/CutoffUnmetTask.ts
@@ -12,9 +12,11 @@ import { db } from '$lib/server/db/index.js';
 import { monitoringHistory, episodes } from '$lib/server/db/schema.js';
 import { inArray } from 'drizzle-orm';
 import { monitoringSearchService } from '../search/MonitoringSearchService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'CutoffUnmetTask', logDomain: 'monitoring' });
 
 /**
  * Execute cutoff unmet search task

--- a/src/lib/server/monitoring/tasks/DbBackupTask.ts
+++ b/src/lib/server/monitoring/tasks/DbBackupTask.ts
@@ -1,8 +1,10 @@
 import { sqlite } from '$lib/server/db/index.js';
 import { dbBackupService } from '$lib/server/db/DbBackupService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'DbBackupTask', logDomain: 'monitoring' });
 
 export async function executeDbBackupTask(ctx: TaskExecutionContext | null): Promise<TaskResult> {
 	const executedAt = new Date();

--- a/src/lib/server/monitoring/tasks/HistoryCleanupTask.ts
+++ b/src/lib/server/monitoring/tasks/HistoryCleanupTask.ts
@@ -16,9 +16,11 @@ import { subtitleHistory } from '$lib/server/db/schema.js';
 import { lt } from 'drizzle-orm';
 import { ActivityService } from '$lib/server/activity/ActivityService.js';
 import { getTaskHistoryService } from '$lib/server/tasks/TaskHistoryService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'HistoryCleanupTask', logDomain: 'monitoring' });
 
 /**
  * Default retention period for task history (days).

--- a/src/lib/server/monitoring/tasks/LibraryReconcileTask.ts
+++ b/src/lib/server/monitoring/tasks/LibraryReconcileTask.ts
@@ -13,9 +13,11 @@
  */
 
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'LibraryReconcileTask', logDomain: 'monitoring' });
 
 export async function executeLibraryReconcileTask(
 	ctx: TaskExecutionContext | null

--- a/src/lib/server/monitoring/tasks/MetadataRefreshTask.ts
+++ b/src/lib/server/monitoring/tasks/MetadataRefreshTask.ts
@@ -2,11 +2,13 @@ import { db } from '$lib/server/db/index.js';
 import { movies, series } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
 import { TaskCancelledException } from '$lib/server/tasks/TaskCancelledException.js';
 import { extractReleaseDates, type ExtractedReleaseDates } from '$lib/utils/extractReleaseDates.js';
+
+const logger = createChildLogger({ module: 'MetadataRefreshTask', logDomain: 'monitoring' });
 
 type HomeMedium = 'digital' | 'physical' | 'tv';
 

--- a/src/lib/server/monitoring/tasks/MissingContentTask.ts
+++ b/src/lib/server/monitoring/tasks/MissingContentTask.ts
@@ -9,9 +9,11 @@ import { db } from '$lib/server/db/index.js';
 import { monitoringHistory, episodes } from '$lib/server/db/schema.js';
 import { inArray } from 'drizzle-orm';
 import { monitoringSearchService } from '../search/MonitoringSearchService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'MissingContentTask', logDomain: 'monitoring' });
 
 interface MissingContentTaskOptions {
 	/**

--- a/src/lib/server/monitoring/tasks/MissingSubtitlesTask.ts
+++ b/src/lib/server/monitoring/tasks/MissingSubtitlesTask.ts
@@ -18,7 +18,7 @@ import { getSubtitleSearchService } from '$lib/server/subtitles/services/Subtitl
 import { getSubtitleDownloadService } from '$lib/server/subtitles/services/SubtitleDownloadService.js';
 import { getSubtitleProviderManager } from '$lib/server/subtitles/services/SubtitleProviderManager.js';
 import { LanguageProfileService } from '$lib/server/subtitles/services/LanguageProfileService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import { normalizeLanguageCode } from '$lib/shared/languages';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
@@ -31,6 +31,8 @@ import {
 	recordEpisodeSearchFailure,
 	resetEpisodeSearchFailures
 } from '$lib/server/subtitles/adaptive-searching.js';
+
+const logger = createChildLogger({ module: 'MissingSubtitlesTask', logDomain: 'monitoring' });
 
 /**
  * Default minimum score for auto-download (used if profile doesn't specify)

--- a/src/lib/server/monitoring/tasks/NewEpisodeMonitorTask.ts
+++ b/src/lib/server/monitoring/tasks/NewEpisodeMonitorTask.ts
@@ -9,9 +9,11 @@ import { db } from '$lib/server/db/index.js';
 import { monitoringHistory, episodes } from '$lib/server/db/schema.js';
 import { inArray } from 'drizzle-orm';
 import { monitoringSearchService } from '../search/MonitoringSearchService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'NewEpisodeMonitorTask', logDomain: 'monitoring' });
 
 /**
  * Execute new episode search task

--- a/src/lib/server/monitoring/tasks/PendingReleaseTask.ts
+++ b/src/lib/server/monitoring/tasks/PendingReleaseTask.ts
@@ -17,9 +17,11 @@ import { eq, inArray } from 'drizzle-orm';
 import { delayProfileService } from '../specifications/DelaySpecification.js';
 import { blocklistService } from '../specifications/BlocklistSpecification.js';
 import { grabService } from '$lib/server/downloads/GrabService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'PendingReleaseTask', logDomain: 'monitoring' });
 
 /**
  * Statistics for pending release processing

--- a/src/lib/server/monitoring/tasks/SubtitleUpgradeTask.ts
+++ b/src/lib/server/monitoring/tasks/SubtitleUpgradeTask.ts
@@ -19,11 +19,13 @@ import { getSubtitleSearchService } from '$lib/server/subtitles/services/Subtitl
 import { getSubtitleDownloadService } from '$lib/server/subtitles/services/SubtitleDownloadService.js';
 import { getSubtitleProviderManager } from '$lib/server/subtitles/services/SubtitleProviderManager.js';
 import { LanguageProfileService } from '$lib/server/subtitles/services/LanguageProfileService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import { normalizeLanguageCode } from '$lib/shared/languages';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
 import { isMovieMonitored } from '$lib/server/monitoring/specifications/MonitoredSpecification.js';
+
+const logger = createChildLogger({ module: 'SubtitleUpgradeTask', logDomain: 'monitoring' });
 
 /**
  * Maximum subtitles to process per run to prevent overwhelming providers

--- a/src/lib/server/monitoring/tasks/UpgradeMonitorTask.ts
+++ b/src/lib/server/monitoring/tasks/UpgradeMonitorTask.ts
@@ -13,9 +13,11 @@ import { db } from '$lib/server/db/index.js';
 import { monitoringHistory, episodes } from '$lib/server/db/schema.js';
 import { inArray } from 'drizzle-orm';
 import { monitoringSearchService } from '../search/MonitoringSearchService.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { TaskResult } from '../MonitoringScheduler.js';
 import type { TaskExecutionContext } from '$lib/server/tasks/TaskExecutionContext.js';
+
+const logger = createChildLogger({ module: 'UpgradeMonitorTask', logDomain: 'monitoring' });
 
 /**
  * Execute upgrade search task

--- a/src/lib/server/services/AlternateTitleService.ts
+++ b/src/lib/server/services/AlternateTitleService.ts
@@ -15,7 +15,9 @@ import { db } from '$lib/server/db/index.js';
 import { alternateTitles, movies, series } from '$lib/server/db/schema.js';
 import { eq, and } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'AlternateTitleService', logDomain: 'system' });
 
 /**
  * Maps ISO 639-1 language codes to the ISO 3166-1 country codes where that

--- a/src/lib/server/services/DataRepairService.ts
+++ b/src/lib/server/services/DataRepairService.ts
@@ -13,8 +13,10 @@ import { db } from '$lib/server/db/index.js';
 import { settings, series, seasons, episodes, episodeFiles } from '$lib/server/db/schema.js';
 import { eq, like, and } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import { todayDateString } from '$lib/utils/format.js';
+
+const logger = createChildLogger({ module: 'DataRepairService', logDomain: 'system' });
 
 interface RepairSeriesData {
 	tmdbId: number;

--- a/src/lib/server/services/DataRepairService.ts
+++ b/src/lib/server/services/DataRepairService.ts
@@ -11,7 +11,7 @@
 import type { BackgroundService, ServiceStatus } from './background-service.js';
 import { db } from '$lib/server/db/index.js';
 import { settings, series, seasons, episodes, episodeFiles } from '$lib/server/db/schema.js';
-import { eq, like } from 'drizzle-orm';
+import { eq, like, and } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import { logger } from '$lib/logging/index.js';
 import { todayDateString } from '$lib/utils/format.js';
@@ -217,7 +217,7 @@ export class DataRepairService implements BackgroundService {
 					const isSpecials = seasonInfo.season_number === 0;
 
 					// Create season record
-					const [newSeason] = await db
+					const [insertedSeason] = await db
 						.insert(seasons)
 						.values({
 							seriesId,
@@ -230,26 +230,42 @@ export class DataRepairService implements BackgroundService {
 							episodeFileCount: 0,
 							monitored: !isSpecials
 						})
+						.onConflictDoNothing()
 						.returning();
+					const newSeason =
+						insertedSeason ??
+						(await db
+							.select()
+							.from(seasons)
+							.where(
+								and(
+									eq(seasons.seriesId, seriesId),
+									eq(seasons.seasonNumber, seasonInfo.season_number)
+								)
+							)
+							.then((rows) => rows[0]));
 
-					result.seasonsCreated++;
+					if (insertedSeason) result.seasonsCreated++;
 
 					// Create episode records
 					if (fullSeason.episodes) {
 						for (const ep of fullSeason.episodes) {
-							await db.insert(episodes).values({
-								seriesId,
-								seasonId: newSeason.id,
-								seasonNumber: ep.season_number,
-								episodeNumber: ep.episode_number,
-								tmdbId: ep.id,
-								title: ep.name,
-								overview: ep.overview,
-								airDate: ep.air_date,
-								runtime: ep.runtime,
-								monitored: !isSpecials,
-								hasFile: false
-							});
+							await db
+								.insert(episodes)
+								.values({
+									seriesId,
+									seasonId: newSeason.id,
+									seasonNumber: ep.season_number,
+									episodeNumber: ep.episode_number,
+									tmdbId: ep.id,
+									title: ep.name,
+									overview: ep.overview,
+									airDate: ep.air_date,
+									runtime: ep.runtime,
+									monitored: !isSpecials,
+									hasFile: false
+								})
+								.onConflictDoNothing();
 							result.episodesCreated++;
 						}
 					}

--- a/src/lib/server/services/ExternalIdService.ts
+++ b/src/lib/server/services/ExternalIdService.ts
@@ -17,7 +17,9 @@ import { db } from '$lib/server/db/index.js';
 import { movies, series } from '$lib/server/db/schema.js';
 import { isNull, or } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'ExternalIdService', logDomain: 'system' });
 
 /**
  * Configuration for the external ID service

--- a/src/lib/server/services/initializer.ts
+++ b/src/lib/server/services/initializer.ts
@@ -1,5 +1,5 @@
 import { building } from '$app/environment';
-import { logger, registerServerLogSinks } from '$lib/logging';
+import { createChildLogger, registerServerLogSinks } from '$lib/logging';
 import { getLibraryScheduler } from '$lib/server/library/library-scheduler.js';
 import { libraryJobWorker } from '$lib/server/library/jobs/LibraryJobWorker.js';
 import { isFFprobeAvailable, getFFprobeVersion } from '$lib/server/library/ffprobe.js';
@@ -32,6 +32,8 @@ import { logCaptureStore } from '$lib/server/logging/log-capture-store.js';
 import { logHistoryService } from '$lib/server/logging/log-history.js';
 import { getCinephageApiService } from '$lib/server/cinephage/CinephageApiService.js';
 import { getDebridPollService } from '$lib/server/downloadClients/debrid/DebridPollService.js';
+
+const logger = createChildLogger({ module: 'Initializer', logDomain: 'system' });
 
 let initializationPromise: Promise<void> | null = null;
 let initializationStarted = false;

--- a/src/lib/server/services/service-manager.ts
+++ b/src/lib/server/services/service-manager.ts
@@ -6,7 +6,9 @@
  */
 
 import type { BackgroundService, ServiceStatusInfo } from './background-service.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'ServiceManager', logDomain: 'system' });
 
 class ServiceManager {
 	private services: Map<string, BackgroundService> = new Map();

--- a/src/lib/server/services/shutdown.ts
+++ b/src/lib/server/services/shutdown.ts
@@ -14,23 +14,32 @@ async function gracefulShutdown(signal: string): Promise<void> {
 	isShuttingDown = true;
 	logger.info(`Received ${signal}, starting graceful shutdown...`);
 
-	try {
-		const serviceManager = getServiceManager();
-		const timeout = setTimeout(() => {
-			logger.error('Graceful shutdown timed out after 30s, forcing exit');
-			process.exit(1);
-		}, 30000);
-
-		getImportService().stop();
-		await serviceManager.stopAll();
-		clearTimeout(timeout);
-
-		logger.info('All services stopped successfully');
-		sqlite.pragma('wal_checkpoint(TRUNCATE)');
+	const timeout = setTimeout(() => {
+		logger.error('Graceful shutdown timed out after 30s, forcing exit');
+		closeDb();
 		process.exit(0);
+	}, 30000);
+
+	try {
+		getImportService().stop();
+		await getServiceManager().stopAll();
+		clearTimeout(timeout);
+		logger.info('All services stopped successfully');
 	} catch (error) {
-		logger.error('Error during graceful shutdown', error);
-		process.exit(1);
+		clearTimeout(timeout);
+		logger.error('Error stopping services during shutdown', error);
+	}
+
+	closeDb();
+	process.exit(0);
+}
+
+function closeDb(): void {
+	try {
+		sqlite.pragma('wal_checkpoint(TRUNCATE)');
+		sqlite.close();
+	} catch (err) {
+		logger.error({ err }, 'Error closing database during shutdown');
 	}
 }
 

--- a/src/lib/server/services/shutdown.ts
+++ b/src/lib/server/services/shutdown.ts
@@ -1,7 +1,9 @@
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { getImportService } from '$lib/server/downloadClients/import/ImportService.js';
 import { getServiceManager } from '$lib/server/services/service-manager.js';
 import { sqlite } from '$lib/server/db/index.js';
+
+const logger = createChildLogger({ module: 'Shutdown', logDomain: 'system' });
 
 let isShuttingDown = false;
 

--- a/src/lib/server/settings/ConfigurationBackupService.ts
+++ b/src/lib/server/settings/ConfigurationBackupService.ts
@@ -606,7 +606,7 @@ export class ConfigurationBackupService {
 						{
 							table: config.name,
 							component: 'ConfigurationBackupService',
-							logDomain: 'settings'
+							logDomain: 'system'
 						},
 						'Configuration backup failed while reading required table'
 					);
@@ -619,7 +619,7 @@ export class ConfigurationBackupService {
 						err: error,
 						table: config.name,
 						component: 'ConfigurationBackupService',
-						logDomain: 'settings'
+						logDomain: 'system'
 					},
 					'Skipping table during backup export (table may not exist)'
 				);
@@ -743,7 +743,7 @@ export class ConfigurationBackupService {
 			) as unknown as BackupSecretPayload;
 		} catch (error) {
 			logger.error(
-				{ err: error, component: 'ConfigurationBackupService', logDomain: 'settings' },
+				{ err: error, component: 'ConfigurationBackupService', logDomain: 'system' },
 				'Failed to decrypt configuration backup'
 			);
 			throw new ValidationError('Invalid backup passphrase or corrupted secret payload');

--- a/src/lib/server/settings/layout-data.ts
+++ b/src/lib/server/settings/layout-data.ts
@@ -144,8 +144,12 @@ export async function loadStorageLayoutData() {
 				completedAt: libraryScanHistory.completedAt
 			})
 			.from(libraryScanHistory)
-			.where(sql`${libraryScanHistory.rootFolderId} IS NOT NULL`)
-			.orderBy(sql`${libraryScanHistory.startedAt} DESC`),
+			.where(
+				sql`${libraryScanHistory.rootFolderId} IS NOT NULL AND ${libraryScanHistory.startedAt} = (
+					SELECT MAX(started_at) FROM library_scan_history h2
+					WHERE h2.root_folder_id = ${libraryScanHistory.rootFolderId}
+				)`
+			),
 		db
 			.select({
 				status: libraryScanHistory.status,

--- a/src/lib/server/smartlists/SmartListService.ts
+++ b/src/lib/server/smartlists/SmartListService.ts
@@ -854,7 +854,7 @@ export class SmartListService {
 					'movie'
 				);
 
-				const [newMovie] = await db
+				const [insertedMovie] = await db
 					.insert(movies)
 					.values({
 						tmdbId: item.tmdbId,
@@ -877,7 +877,15 @@ export class SmartListService {
 						wantsSubtitles,
 						languageProfileId
 					})
+					.onConflictDoNothing()
 					.returning();
+				const newMovie =
+					insertedMovie ??
+					(await db
+						.select()
+						.from(movies)
+						.where(eq(movies.tmdbId, item.tmdbId))
+						.then((rows) => rows[0]));
 
 				await db
 					.update(smartListItems)
@@ -951,7 +959,7 @@ export class SmartListService {
 					'tv'
 				);
 
-				const [newSeries] = await db
+				const [insertedSeries] = await db
 					.insert(series)
 					.values({
 						tmdbId: item.tmdbId,
@@ -983,7 +991,15 @@ export class SmartListService {
 						wantsSubtitles,
 						languageProfileId
 					})
+					.onConflictDoNothing()
 					.returning();
+				const newSeries =
+					insertedSeries ??
+					(await db
+						.select()
+						.from(series)
+						.where(eq(series.tmdbId, item.tmdbId))
+						.then((rows) => rows[0]));
 
 				await this.createSeasonsAndEpisodes(newSeries.id, item.tmdbId, monitored);
 
@@ -1475,7 +1491,7 @@ export class SmartListService {
 				);
 
 				// Insert movie into database
-				const [newMovie] = await db
+				const [insertedMovie] = await db
 					.insert(movies)
 					.values({
 						tmdbId: item.tmdbId,
@@ -1498,7 +1514,15 @@ export class SmartListService {
 						wantsSubtitles,
 						languageProfileId
 					})
+					.onConflictDoNothing()
 					.returning();
+				const newMovie =
+					insertedMovie ??
+					(await db
+						.select()
+						.from(movies)
+						.where(eq(movies.tmdbId, item.tmdbId))
+						.then((rows) => rows[0]));
 
 				// Update smart list item
 				await db
@@ -1628,7 +1652,7 @@ export class SmartListService {
 				);
 
 				// Insert series into database
-				const [newSeries] = await db
+				const [insertedSeries] = await db
 					.insert(series)
 					.values({
 						tmdbId: item.tmdbId,
@@ -1660,7 +1684,15 @@ export class SmartListService {
 						wantsSubtitles,
 						languageProfileId
 					})
+					.onConflictDoNothing()
 					.returning();
+				const newSeries =
+					insertedSeries ??
+					(await db
+						.select()
+						.from(series)
+						.where(eq(series.tmdbId, item.tmdbId))
+						.then((rows) => rows[0]));
 
 				// Create seasons and episodes
 				await this.createSeasonsAndEpisodes(newSeries.id, item.tmdbId, monitored);
@@ -1730,7 +1762,7 @@ export class SmartListService {
 				const seasonMonitored = monitored && !isSpecials;
 
 				// Create season (episodeCount will be recalculated after episodes are inserted)
-				const [newSeason] = await db
+				const [insertedSeason] = await db
 					.insert(seasons)
 					.values({
 						seriesId,
@@ -1742,7 +1774,20 @@ export class SmartListService {
 						episodeCount: 0, // Will be recalculated to only aired episodes
 						monitored: seasonMonitored
 					})
+					.onConflictDoNothing()
 					.returning();
+				const newSeason =
+					insertedSeason ??
+					(await db
+						.select()
+						.from(seasons)
+						.where(
+							and(
+								eq(seasons.seriesId, seriesId),
+								eq(seasons.seasonNumber, seasonInfo.season_number)
+							)
+						)
+						.then((rows) => rows[0]));
 
 				// Fetch season details for episodes
 				try {
@@ -1763,7 +1808,7 @@ export class SmartListService {
 						}));
 
 						if (episodesToInsert.length > 0) {
-							await db.insert(episodes).values(episodesToInsert);
+							await db.insert(episodes).values(episodesToInsert).onConflictDoNothing();
 							// Only count aired episodes (exclude specials and unaired)
 							const today = todayDateString();
 							const airedCount = episodesToInsert.filter(

--- a/src/lib/server/storage/insights/rules/BrokenPathsRule.ts
+++ b/src/lib/server/storage/insights/rules/BrokenPathsRule.ts
@@ -11,6 +11,12 @@ import {
 } from '$lib/server/db/schema';
 import type { StorageInsightRule, RuleContext, InsightFinding } from '../types.js';
 
+const YIELD_INTERVAL = 500;
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
 /**
  * Verifies that file paths referenced by storage_items still exist on disk.
  * Builds full paths by joining storage_items -> movie_files/episode_files ->
@@ -61,22 +67,30 @@ export class BrokenPathsRule implements StorageInsightRule {
 			fullPath: string;
 		}> = [];
 
+		// existsSync() is a blocking syscall per file - yielding periodically
+		// keeps this rule from freezing the event loop for its full duration
+		// on a large library.
+		let processed = 0;
 		for (const row of movieBacked) {
 			const rootPath = row.rootFolderId ? folderPathById.get(row.rootFolderId) : null;
-			if (!rootPath) continue;
-			const fullPath = join(rootPath, row.moviePath ?? '', row.relativePath ?? '');
-			if (!existsSync(fullPath)) {
-				broken.push({ storageId: row.storageId, title: row.title, tmdbId: row.tmdbId, fullPath });
+			if (rootPath) {
+				const fullPath = join(rootPath, row.moviePath ?? '', row.relativePath ?? '');
+				if (!existsSync(fullPath)) {
+					broken.push({ storageId: row.storageId, title: row.title, tmdbId: row.tmdbId, fullPath });
+				}
 			}
+			if (++processed % YIELD_INTERVAL === 0) await yieldToEventLoop();
 		}
 
 		for (const row of episodeBacked) {
 			const rootPath = row.rootFolderId ? folderPathById.get(row.rootFolderId) : null;
-			if (!rootPath) continue;
-			const fullPath = join(rootPath, row.seriesPath ?? '', row.relativePath ?? '');
-			if (!existsSync(fullPath)) {
-				broken.push({ storageId: row.storageId, title: row.title, tmdbId: row.tmdbId, fullPath });
+			if (rootPath) {
+				const fullPath = join(rootPath, row.seriesPath ?? '', row.relativePath ?? '');
+				if (!existsSync(fullPath)) {
+					broken.push({ storageId: row.storageId, title: row.title, tmdbId: row.tmdbId, fullPath });
+				}
 			}
+			if (++processed % YIELD_INTERVAL === 0) await yieldToEventLoop();
 		}
 
 		if (broken.length === 0) return [];

--- a/src/lib/server/storage/insights/rules/DuplicateItemsRule.ts
+++ b/src/lib/server/storage/insights/rules/DuplicateItemsRule.ts
@@ -17,57 +17,50 @@ export class DuplicateItemsRule implements StorageInsightRule {
 	readonly type = 'duplicate-items' as const;
 
 	async evaluate(ctx: RuleContext): Promise<InsightFinding[]> {
-		type MovieFileRow = {
+		type DupeGroupRow = {
 			movieId: string;
 			tmdbId: number | null;
 			title: string | null;
-			quality: unknown;
+			resolution: string;
+			fileCount: number;
 		};
 
-		const rows = ctx.db
+		// GROUP BY movie+resolution HAVING COUNT(*) > 1 returns only the
+		// duplicate groups directly.
+		const resolutionExpr = sql`coalesce(json_extract(${movieFiles.quality}, '$.resolution'), 'unknown')`;
+		const dupeGroups = ctx.db
 			.select({
 				movieId: movies.id,
 				tmdbId: movies.tmdbId,
 				title: movies.title,
-				quality: movieFiles.quality
+				resolution: resolutionExpr.as('resolution'),
+				fileCount: sql<number>`count(*)`
 			})
 			.from(movies)
 			.innerJoin(movieFiles, sql`${movieFiles.movieId} = ${movies.id}`)
 			.where(sql`${movies.tmdbId} IS NOT NULL`)
-			.all() as MovieFileRow[];
+			.groupBy(movies.id, resolutionExpr)
+			.having(sql`count(*) > 1`)
+			.all() as DupeGroupRow[];
 
-		// Group files per movie into resolution buckets. A movie is a duplicate
-		// only when at least one resolution bucket contains more than one file.
+		// A movie can have more than one dupe-resolution group; fileCount is
+		// the max across them.
 		const movieMap = new Map<
 			string,
-			{
-				tmdbId: number | null;
-				title: string | null;
-				buckets: Map<string, number>;
-			}
+			{ tmdbId: number | null; title: string | null; fileCount: number }
 		>();
-
-		for (const row of rows) {
-			const resolution = (row.quality as { resolution?: string } | null)?.resolution ?? 'unknown';
-			let entry = movieMap.get(row.movieId);
-			if (!entry) {
-				entry = { tmdbId: row.tmdbId, title: row.title, buckets: new Map() };
-				movieMap.set(row.movieId, entry);
+		for (const row of dupeGroups) {
+			const entry = movieMap.get(row.movieId);
+			if (!entry || row.fileCount > entry.fileCount) {
+				movieMap.set(row.movieId, {
+					tmdbId: row.tmdbId,
+					title: row.title,
+					fileCount: row.fileCount
+				});
 			}
-			entry.buckets.set(resolution, (entry.buckets.get(resolution) ?? 0) + 1);
 		}
 
-		const duplicates = [...movieMap.values()]
-			.map((entry) => {
-				// fileCount is the max same-resolution dup count (not total files); name kept for frontend.
-				const maxSameResolution = Math.max(...entry.buckets.values());
-				return {
-					tmdbId: entry.tmdbId,
-					title: entry.title,
-					fileCount: maxSameResolution
-				};
-			})
-			.filter((d) => d.fileCount > 1);
+		const duplicates = [...movieMap.values()];
 
 		if (duplicates.length === 0) return [];
 

--- a/src/lib/server/storage/insights/rules/HealthIssuesRule.ts
+++ b/src/lib/server/storage/insights/rules/HealthIssuesRule.ts
@@ -48,14 +48,22 @@ export class HealthIssuesRule implements StorageInsightRule {
 			});
 		}
 
-		// 3. Root folders needing scan (warning) — no completed scan history
+		// 3. Root folders needing scan (warning) — no completed scan history.
+		// Scoped to one row per root folder (the most recent scan) via a
+		// correlated MAX(startedAt) subquery, instead of loading the entire
+		// scan-history table.
 		const latestScans = ctx.db
 			.select({
 				rootFolderId: libraryScanHistory.rootFolderId,
 				status: libraryScanHistory.status
 			})
 			.from(libraryScanHistory)
-			.orderBy(sql`${libraryScanHistory.startedAt} DESC`)
+			.where(
+				sql`${libraryScanHistory.startedAt} = (
+					SELECT MAX(started_at) FROM library_scan_history h2
+					WHERE h2.root_folder_id = ${libraryScanHistory.rootFolderId}
+				)`
+			)
 			.all();
 
 		const latestScanByFolder = new Map<string, string>();

--- a/src/lib/server/subtitles/adaptive-searching.ts
+++ b/src/lib/server/subtitles/adaptive-searching.ts
@@ -12,7 +12,9 @@
 import { db } from '$lib/server/db/index.js';
 import { movies, episodes } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'AdaptiveSubtitleSearching', logDomain: 'subtitles' });
 
 /**
  * After this many days of failed searches, switch to extended (weekly) searching.

--- a/src/lib/server/subtitles/sync/subtitle-sync.ts
+++ b/src/lib/server/subtitles/sync/subtitle-sync.ts
@@ -24,7 +24,9 @@ import { standardScoring, denormalizeSplitPenalty } from './scoring.js';
 import { alignNosplit } from './align-nosplit.js';
 import { alignWithSplits } from './align-split.js';
 import { extractSpeechSegments, mergeCloseSegments } from './vad.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'SubtitleSyncEngine', logDomain: 'subtitles' });
 
 /**
  * Maximum number of VAD speech segments to pass to alignment.

--- a/src/lib/server/workers/WorkerManager.ts
+++ b/src/lib/server/workers/WorkerManager.ts
@@ -85,7 +85,7 @@ class WorkerManagerImpl extends EventEmitter {
 			this.emitEvent({ type: 'removed', workerId: id });
 			logger.debug(
 				{
-					logDomain: 'main',
+					logDomain: 'system',
 					workerId: id
 				},
 				`Cleaned up completed worker`
@@ -131,7 +131,7 @@ class WorkerManagerImpl extends EventEmitter {
 
 		logger.info(
 			{
-				logDomain: 'main',
+				logDomain: 'system',
 				workerId: worker.id,
 				workerType: worker.type
 			},
@@ -194,7 +194,7 @@ class WorkerManagerImpl extends EventEmitter {
 					{
 						err: error,
 						...{
-							logDomain: 'main',
+							logDomain: 'system',
 							workerId: worker.id
 						}
 					},
@@ -341,7 +341,7 @@ class WorkerManagerImpl extends EventEmitter {
 
 		logger.info(
 			{
-				logDomain: 'main',
+				logDomain: 'system',
 				config: this.config
 			},
 			`Worker manager config updated`
@@ -364,7 +364,7 @@ class WorkerManagerImpl extends EventEmitter {
 		}
 
 		this.workers.clear();
-		logger.info({ logDomain: 'main' }, `Worker manager shut down`);
+		logger.info({ logDomain: 'system' }, `Worker manager shut down`);
 	}
 }
 

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -7,7 +7,9 @@ import type {
 	PersonDetails
 } from './types/tmdb';
 
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'tmdb', logDomain: 'system' });
 
 // Cache both the result AND the pending promise to prevent duplicate requests
 let configCache: TmdbConfiguration | null = null;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { activityService } from '$lib/server/activity';
 import {
 	getDashboardStats,
@@ -9,6 +10,8 @@ import {
 import { getUpcomingItems } from '$lib/server/calendar/queries.js';
 import { getCalendarPreferences } from '$lib/server/settings/calendar-preferences.js';
 import type { DashboardStats } from '$lib/types/dashboard.js';
+
+const logger = createChildLogger({ module: 'HomePage', logDomain: 'system' });
 
 export const load: PageServerLoad = async () => {
 	try {

--- a/src/routes/api/activity/+server.ts
+++ b/src/routes/api/activity/+server.ts
@@ -1,10 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { activityService, activityStreamEvents } from '$lib/server/activity';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ActivityFilters, ActivitySortOptions, ActivityScope } from '$lib/types/activity';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'ActivityApi', logDomain: 'monitoring' });
 
 const deleteHistorySchema = z.object({
 	activityIds: z.array(z.string().min(1)).min(1).max(500)

--- a/src/routes/api/activity/settings/+server.ts
+++ b/src/routes/api/activity/settings/+server.ts
@@ -7,8 +7,10 @@ import {
 	MAX_ACTIVITY_RETENTION_DAYS
 } from '$lib/server/activity';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'ActivitySettingsApi', logDomain: 'monitoring' });
 
 const updateRetentionSchema = z.object({
 	retentionDays: z.coerce.number().int().min(1).max(MAX_ACTIVITY_RETENTION_DAYS)

--- a/src/routes/api/activity/stream/+server.ts
+++ b/src/routes/api/activity/stream/+server.ts
@@ -5,8 +5,10 @@ import { mediaResolver } from '$lib/server/activity';
 import { activityStreamEvents } from '$lib/server/activity/ActivityStreamEvents';
 import type { UnifiedActivity, ActivityStatus } from '$lib/types/activity';
 import type { ActivityRefreshEvent } from '$lib/types/sse/events/activity-events.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { mapQueueStatus, projectQueueActivity } from '$lib/server/activity/projectors';
+
+const logger = createChildLogger({ module: 'ActivityStreamApi', logDomain: 'monitoring' });
 
 interface QueueItem {
 	id: string;

--- a/src/routes/api/captcha-bypass/+server.ts
+++ b/src/routes/api/captcha-bypass/+server.ts
@@ -2,9 +2,11 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { captchaSolverSettingsService, getCaptchaSolver } from '$lib/server/captcha';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { resolveAppVersion } from '$lib/server/version.js';
+
+const logger = createChildLogger({ module: 'CaptchaBypassApi', logDomain: 'indexers' });
 
 const requestSchema = z
 	.object({

--- a/src/routes/api/captcha-solver/+server.ts
+++ b/src/routes/api/captcha-solver/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { captchaSolverSettingsService } from '$lib/server/captcha';
 import { captchaSolverSettingsUpdateSchema } from '$lib/validation/schemas.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'CaptchaSolverApi', logDomain: 'indexers' });
 
 /**
  * GET /api/captcha-solver

--- a/src/routes/api/captcha-solver/health/+server.ts
+++ b/src/routes/api/captcha-solver/health/+server.ts
@@ -1,8 +1,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getCaptchaSolver } from '$lib/server/captcha';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'CaptchaSolverHealthApi', logDomain: 'indexers' });
 
 /**
  * GET /api/captcha-solver/health

--- a/src/routes/api/captcha-solver/test/+server.ts
+++ b/src/routes/api/captcha-solver/test/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getCaptchaSolver } from '$lib/server/captcha';
 import { captchaSolverTestSchema } from '$lib/validation/schemas.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'CaptchaSolverTestApi', logDomain: 'indexers' });
 
 /**
  * POST /api/captcha-solver/test

--- a/src/routes/api/discover/+server.ts
+++ b/src/routes/api/discover/+server.ts
@@ -5,7 +5,9 @@ import { tmdb } from '$lib/server/tmdb';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'DiscoverApi', logDomain: 'system' });
 
 /**
  * Query parameter validation schema for discover endpoint.

--- a/src/routes/api/discover/search/+server.ts
+++ b/src/routes/api/discover/search/+server.ts
@@ -4,7 +4,9 @@ import { tmdb } from '$lib/server/tmdb';
 import { contentFilterPipeline } from '$lib/server/filters/ContentFilterPipeline.js';
 import { enrichWithReleaseDates } from '$lib/server/release-enrichment.js';
 import { z } from 'zod';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'DiscoverSearchApi', logDomain: 'system' });
 
 const searchQuerySchema = z.object({
 	query: z.string().min(1, 'Search query is required'),

--- a/src/routes/api/library/backfill-quality/+server.ts
+++ b/src/routes/api/library/backfill-quality/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { backfillMissingQuality } from '$lib/server/library/quality-backfill.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryBackfillQualityApi', logDomain: 'scans' });
 
 /**
  * POST /api/library/backfill-quality

--- a/src/routes/api/library/backfill-release-metadata/+server.ts
+++ b/src/routes/api/library/backfill-release-metadata/+server.ts
@@ -1,6 +1,11 @@
 import { json } from '@sveltejs/kit';
-import { logger } from '$lib/logging';
 import { backfillReleaseMetadata } from '$lib/server/library/release-metadata-backfill.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({
+	module: 'LibraryBackfillReleaseMetadataApi',
+	logDomain: 'scans'
+});
 
 export async function POST({ request }: { request: Request }) {
 	try {

--- a/src/routes/api/library/collections/[tmdbId]/track/+server.ts
+++ b/src/routes/api/library/collections/[tmdbId]/track/+server.ts
@@ -6,7 +6,6 @@ import { movies } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
 import { requireAuth } from '$lib/server/auth/authorization.js';
-import { logger } from '$lib/logging';
 import { buildMovieFolderName } from '$lib/server/library/naming/naming-helpers.js';
 import { namingSettingsService } from '$lib/server/library/naming/NamingSettingsService.js';
 import {
@@ -26,6 +25,9 @@ import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { fetchAndStoreMovieAlternateTitles } from '$lib/server/services/AlternateTitleService.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryCollectionsTrackApi', logDomain: 'scans' });
 
 const trackSchema = z.object({
 	rootFolderId: z.string().min(1),

--- a/src/routes/api/library/episodes/[id]/+server.ts
+++ b/src/routes/api/library/episodes/[id]/+server.ts
@@ -5,10 +5,12 @@ import { episodes, episodeFiles, series, seasons, rootFolders } from '$lib/serve
 import { eq } from 'drizzle-orm';
 import { unlink, rmdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
-import { logger } from '$lib/logging';
 import { searchOnAdd } from '$lib/server/library/searchOnAdd.js';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryEpisodeByIdApi', logDomain: 'scans' });
 
 /**
  * PATCH /api/library/episodes/[id]

--- a/src/routes/api/library/episodes/[id]/files/[fileId]/+server.ts
+++ b/src/routes/api/library/episodes/[id]/files/[fileId]/+server.ts
@@ -5,8 +5,10 @@ import { episodes, episodeFiles, series, rootFolders } from '$lib/server/db/sche
 import { eq } from 'drizzle-orm';
 import { unlink, rmdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
-import { logger } from '$lib/logging';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryEpisodeFilesApi', logDomain: 'scans' });
 
 /**
  * DELETE /api/library/episodes/[id]/files/[fileId]

--- a/src/routes/api/library/episodes/[id]/score/+server.ts
+++ b/src/routes/api/library/episodes/[id]/score/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { computeEpisodeFileScore } from '$lib/server/scoring/file-scorer.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryEpisodeScoreApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/episodes/[id]/score

--- a/src/routes/api/library/episodes/batch/+server.ts
+++ b/src/routes/api/library/episodes/batch/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { episodes } from '$lib/server/db/schema.js';
 import { eq, inArray, and } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryEpisodesBatchApi', logDomain: 'scans' });
 
 /**
  * PATCH /api/library/episodes/batch

--- a/src/routes/api/library/import/bulk/+server.ts
+++ b/src/routes/api/library/import/bulk/+server.ts
@@ -5,8 +5,10 @@ import { manualImportSchema } from '$lib/validation/schemas.js';
 import { manualImportQueueService } from '$lib/server/library/ManualImportQueueService.js';
 import { isPathAllowed, isPathInsideManagedRoot } from '$lib/server/filesystem/path-guard.js';
 import { MAX_BULK_IMPORT_JOBS } from '$lib/shared/bulk-import.js';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryImportBulkApi', logDomain: 'scans' });
 
 const bulkSchema = z.object({
 	jobs: z

--- a/src/routes/api/library/import/detect/+server.ts
+++ b/src/routes/api/library/import/detect/+server.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 import { stat } from 'node:fs/promises';
 import { manualImportService } from '$lib/server/library/manual-import-service.js';
 import { isPathAllowed, isPathInsideManagedRoot } from '$lib/server/filesystem/path-guard.js';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryImportDetectApi', logDomain: 'scans' });
 
 const detectSchema = z.object({
 	sourcePath: z.string().min(1),

--- a/src/routes/api/library/import/execute/+server.ts
+++ b/src/routes/api/library/import/execute/+server.ts
@@ -3,9 +3,11 @@ import type { RequestHandler } from './$types.js';
 import { manualImportSchema } from '$lib/validation/schemas.js';
 import { manualImportService } from '$lib/server/library/manual-import-service.js';
 import { isPathAllowed, isPathInsideManagedRoot } from '$lib/server/filesystem/path-guard.js';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryImportExecuteApi', logDomain: 'scans' });
 
 function getExecuteErrorMessage(error: unknown): string {
 	const fsError = error as NodeJS.ErrnoException;

--- a/src/routes/api/library/movies/+server.ts
+++ b/src/routes/api/library/movies/+server.ts
@@ -24,8 +24,10 @@ import { fetchAndStoreMovieAlternateTitles } from '$lib/server/services/Alternat
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { ValidationError, isAppError } from '$lib/errors';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
-import { logger } from '$lib/logging';
 import { requireAuth } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMoviesApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/movies

--- a/src/routes/api/library/movies/[id]/+server.ts
+++ b/src/routes/api/library/movies/[id]/+server.ts
@@ -20,7 +20,6 @@ import { monitoringSearchService } from '$lib/server/monitoring/search/Monitorin
 import { getDownloadClientManager } from '$lib/server/downloadClients/DownloadClientManager.js';
 import { deleteAllAlternateTitles } from '$lib/server/services/index.js';
 import { deleteDirectoryWithinRoot } from '$lib/server/filesystem/delete-helpers.js';
-import { logger } from '$lib/logging';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
 import { tmdb } from '$lib/server/tmdb.js';
 import { movieUpdateSchema } from '$lib/validation/schemas';
@@ -724,3 +723,6 @@ export const DELETE: RequestHandler = async ({ params, url }) => {
 
 // Import for static method access
 import { MediaInfoService } from '$lib/server/library/index.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieByIdApi', logDomain: 'scans' });

--- a/src/routes/api/library/movies/[id]/alternate-titles/+server.ts
+++ b/src/routes/api/library/movies/[id]/alternate-titles/+server.ts
@@ -10,7 +10,9 @@ import {
 	removeAlternateTitle
 } from '$lib/server/services/AlternateTitleService.js';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieAlternateTitlesApi', logDomain: 'scans' });
 
 const addTitleSchema = z.object({
 	title: z.string().min(1).max(500)

--- a/src/routes/api/library/movies/[id]/auto-search/+server.ts
+++ b/src/routes/api/library/movies/[id]/auto-search/+server.ts
@@ -11,9 +11,11 @@ import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
 import { db } from '$lib/server/db/index.js';
 import { movies } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import { collectAutoSearchIssues } from '$lib/server/library/autoSearchIssues.js';
 import { getAutoSearchPreflightIssue } from '$lib/server/library/autoSearchPreflight.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieAutoSearchApi', logDomain: 'scans' });
 
 /**
  * POST /api/library/movies/[id]/auto-search

--- a/src/routes/api/library/movies/[id]/files/[fileId]/+server.ts
+++ b/src/routes/api/library/movies/[id]/files/[fileId]/+server.ts
@@ -5,10 +5,12 @@ import { movies, movieFiles, rootFolders } from '$lib/server/db/schema.js';
 import { eq, and } from 'drizzle-orm';
 import { rmdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
-import { logger } from '$lib/logging';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
 import { deletePhysicalFile } from '$lib/server/downloadClients/import/FileTransfer.js';
 import { getFileManagementSettings } from '$lib/server/settings/file-management.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieFilesApi', logDomain: 'scans' });
 
 /**
  * DELETE /api/library/movies/[id]/files/[fileId]

--- a/src/routes/api/library/movies/[id]/refresh/+server.ts
+++ b/src/routes/api/library/movies/[id]/refresh/+server.ts
@@ -11,14 +11,16 @@ import { db } from '$lib/server/db/index.js';
 import { movies } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging';
 import { enrichAnimeMetadata } from '$lib/server/metadata/provider-resolution.js';
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
+import { createChildLogger } from '$lib/logging';
 import {
 	startRefresh,
 	stopRefresh,
 	isMovieRefreshing
 } from '$lib/server/library/ActiveSearchTracker.js';
+
+const logger = createChildLogger({ module: 'LibraryMovieRefreshApi', logDomain: 'scans' });
 
 export const POST: RequestHandler = async ({ params }) => {
 	const { id } = params;

--- a/src/routes/api/library/movies/[id]/score/+server.ts
+++ b/src/routes/api/library/movies/[id]/score/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { computeMovieFileScore } from '$lib/server/scoring/file-scorer.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieScoreApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/movies/[id]/score

--- a/src/routes/api/library/movies/[id]/stream/+server.ts
+++ b/src/routes/api/library/movies/[id]/stream/+server.ts
@@ -9,8 +9,10 @@ import type { RequestHandler } from '@sveltejs/kit';
 import type { LibraryMovie, MovieFile } from '$lib/types/library';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
 import { tmdb } from '$lib/server/tmdb';
-import { logger } from '$lib/logging';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMovieStreamApi', logDomain: 'scans' });
 
 interface QueueItem {
 	id: string;

--- a/src/routes/api/library/movies/batch/+server.ts
+++ b/src/routes/api/library/movies/batch/+server.ts
@@ -4,10 +4,12 @@ import { db } from '$lib/server/db/index.js';
 import { downloadHistory, movies, movieFiles, rootFolders } from '$lib/server/db/schema.js';
 import { eq, inArray } from 'drizzle-orm';
 import { deleteDirectoryWithinRoot } from '$lib/server/filesystem/delete-helpers.js';
-import { logger } from '$lib/logging';
 import { deleteAllAlternateTitles } from '$lib/server/services/index.js';
 import { monitoringSearchService } from '$lib/server/monitoring/search/MonitoringSearchService.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMoviesBatchApi', logDomain: 'scans' });
 
 /**
  * PATCH /api/library/movies/batch

--- a/src/routes/api/library/movies/bulk/+server.ts
+++ b/src/routes/api/library/movies/bulk/+server.ts
@@ -22,8 +22,10 @@ import {
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMoviesBulkApi', logDomain: 'scans' });
 
 interface BulkAddResult {
 	added: number;

--- a/src/routes/api/library/reconcile/+server.ts
+++ b/src/routes/api/library/reconcile/+server.ts
@@ -2,7 +2,9 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'LibraryReconcileApi', logDomain: 'scans' });
 
 /**
  * POST /api/library/reconcile

--- a/src/routes/api/library/seasons/[id]/+server.ts
+++ b/src/routes/api/library/seasons/[id]/+server.ts
@@ -5,8 +5,10 @@ import { seasons, episodes, episodeFiles, series, rootFolders } from '$lib/serve
 import { eq } from 'drizzle-orm';
 import { unlink, rmdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { logger } from '$lib/logging';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeasonByIdApi', logDomain: 'scans' });
 
 /**
  * PATCH /api/library/seasons/[id]

--- a/src/routes/api/library/series/+server.ts
+++ b/src/routes/api/library/series/+server.ts
@@ -21,12 +21,14 @@ import {
 	buildSeasonsAndEpisodesFromGroup
 } from '$lib/server/metadata/EpisodeGroupService.js';
 import { ValidationError, isAppError } from '$lib/errors';
-import { logger } from '$lib/logging';
 import { requireAuth } from '$lib/server/auth/authorization.js';
 import { NamingService, type MediaNamingInfo } from '$lib/server/library/naming/NamingService.js';
 import { namingSettingsService } from '$lib/server/library/naming/NamingSettingsService.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesApi', logDomain: 'scans' });
 
 /**
  * Generate a folder name for a series using the naming service

--- a/src/routes/api/library/series/[id]/+server.ts
+++ b/src/routes/api/library/series/[id]/+server.ts
@@ -15,7 +15,6 @@ import {
 } from '$lib/server/db/schema.js';
 import { eq, inArray, and } from 'drizzle-orm';
 import { deleteDirectoryWithinRoot } from '$lib/server/filesystem/delete-helpers.js';
-import { logger } from '$lib/logging';
 import { todayDateString } from '$lib/utils/format.js';
 import { getLanguageProfileService } from '$lib/server/subtitles/services/LanguageProfileService.js';
 import { searchSubtitlesForMediaBatch } from '$lib/server/subtitles/services/SubtitleImportService.js';
@@ -43,6 +42,9 @@ import { tmdb } from '$lib/server/tmdb.js';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
 import { refreshSeriesMetadata } from '$lib/server/metadata/metadata-refresh.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesByIdApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/series/[id]

--- a/src/routes/api/library/series/[id]/alternate-titles/+server.ts
+++ b/src/routes/api/library/series/[id]/alternate-titles/+server.ts
@@ -10,7 +10,9 @@ import {
 	removeAlternateTitle
 } from '$lib/server/services/AlternateTitleService.js';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesAlternateTitlesApi', logDomain: 'scans' });
 
 const addTitleSchema = z.object({
 	title: z.string().min(1).max(500)

--- a/src/routes/api/library/series/[id]/auto-search/+server.ts
+++ b/src/routes/api/library/series/[id]/auto-search/+server.ts
@@ -11,10 +11,12 @@ import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
 import { db } from '$lib/server/db/index.js';
 import { series } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import type { SearchProgressUpdate } from '$lib/server/downloads/MultiSeasonSearchStrategy.js';
 import { collectAutoSearchIssues } from '$lib/server/library/autoSearchIssues.js';
 import { getAutoSearchPreflightIssue } from '$lib/server/library/autoSearchPreflight.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesAutoSearchApi', logDomain: 'scans' });
 
 /**
  * Auto-Search Request Types

--- a/src/routes/api/library/series/[id]/episode-groups/+server.ts
+++ b/src/routes/api/library/series/[id]/episode-groups/+server.ts
@@ -8,11 +8,13 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { series } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
+import { createChildLogger } from '$lib/logging';
 import {
 	fetchEpisodeGroups,
 	buildEpisodeGroupInfoList
 } from '$lib/server/metadata/EpisodeGroupService.js';
-import { logger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesEpisodeGroupsApi', logDomain: 'scans' });
 
 export const GET: RequestHandler = async ({ params }) => {
 	try {

--- a/src/routes/api/library/series/[id]/refresh/+server.ts
+++ b/src/routes/api/library/series/[id]/refresh/+server.ts
@@ -15,7 +15,6 @@ import { db } from '$lib/server/db/index.js';
 import { series, seasons, episodes, episodeFiles } from '$lib/server/db/schema.js';
 import { eq, inArray } from 'drizzle-orm';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging';
 import { todayDateString } from '$lib/utils/format.js';
 import { enrichAnimeMetadata } from '$lib/server/metadata/provider-resolution.js';
 import {
@@ -26,11 +25,14 @@ import {
 import { isLikelyAnimeMedia } from '$lib/shared/anime-classification.js';
 import { resolveLanguage } from '$lib/server/metadata/metadata-refresh.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
+import { createChildLogger } from '$lib/logging';
 import {
 	startRefresh,
 	stopRefresh,
 	isSeriesRefreshing
 } from '$lib/server/library/ActiveSearchTracker.js';
+
+const logger = createChildLogger({ module: 'LibrarySeriesRefreshApi', logDomain: 'scans' });
 
 interface ProgressEvent {
 	type: 'progress';

--- a/src/routes/api/library/series/[id]/stream/+server.ts
+++ b/src/routes/api/library/series/[id]/stream/+server.ts
@@ -15,8 +15,10 @@ import {
 import { eq, asc, inArray, and } from 'drizzle-orm';
 import type { RequestHandler } from '@sveltejs/kit';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents';
-import { logger } from '$lib/logging';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesStreamApi', logDomain: 'scans' });
 
 // Local type definitions
 interface EpisodeFileInfo {

--- a/src/routes/api/library/series/batch/+server.ts
+++ b/src/routes/api/library/series/batch/+server.ts
@@ -11,10 +11,12 @@ import {
 } from '$lib/server/db/schema.js';
 import { eq, inArray } from 'drizzle-orm';
 import { deleteDirectoryWithinRoot } from '$lib/server/filesystem/delete-helpers.js';
-import { logger } from '$lib/logging';
 import { deleteAllAlternateTitles } from '$lib/server/services/index.js';
 import { monitoringSearchService } from '$lib/server/monitoring/search/MonitoringSearchService.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibrarySeriesBatchApi', logDomain: 'scans' });
 
 /**
  * PATCH /api/library/series/batch

--- a/src/routes/api/library/status/+server.ts
+++ b/src/routes/api/library/status/+server.ts
@@ -1,11 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
+import { createChildLogger } from '$lib/logging';
 import {
 	getLibraryStatus,
 	type LibraryStatusMap,
 	type LibraryStatus
 } from '$lib/server/library/status.js';
-import { logger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryStatusApi', logDomain: 'scans' });
 
 /**
  * POST /api/library/status

--- a/src/routes/api/library/unmatched/+server.ts
+++ b/src/routes/api/library/unmatched/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { unmatchedFileService } from '$lib/server/library/unmatched-file-service.js';
 import { libraryJobService } from '$lib/server/library/jobs/LibraryJobService.js';
-import { logger } from '$lib/logging';
 import type { UnmatchedFilters } from '$lib/types/unmatched.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryUnmatchedApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/unmatched

--- a/src/routes/api/library/unmatched/[id]/+server.ts
+++ b/src/routes/api/library/unmatched/[id]/+server.ts
@@ -1,8 +1,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { unmatchedFileService } from '$lib/server/library/unmatched-file-service.js';
-import { logger } from '$lib/logging';
 import type { MatchRequest } from '$lib/types/unmatched.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryUnmatchedByIdApi', logDomain: 'scans' });
 
 /**
  * GET /api/library/unmatched/[id]

--- a/src/routes/api/library/unmatched/issues/+server.ts
+++ b/src/routes/api/library/unmatched/issues/+server.ts
@@ -3,8 +3,10 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { movies, rootFolders, series } from '$lib/server/db/schema.js';
 import { sql } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import type { LibraryIssue, RootFolderOption } from '$lib/types/unmatched.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryUnmatchedIssuesApi', logDomain: 'scans' });
 
 function resolveIssue(rootFolderId: string | null): LibraryIssue['issue'] {
 	if (rootFolderId === null || rootFolderId === '' || rootFolderId === 'null') {

--- a/src/routes/api/library/unmatched/match/+server.ts
+++ b/src/routes/api/library/unmatched/match/+server.ts
@@ -1,10 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { unmatchedFileService } from '$lib/server/library/unmatched-file-service.js';
-import { logger } from '$lib/logging';
 import { parseBody } from '$lib/server/api/validate.js';
 import { unmatchedMatchSchema } from '$lib/validation/schemas.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryUnmatchedMatchApi', logDomain: 'scans' });
 
 export const POST: RequestHandler = async ({ request }: { request: Request }) => {
 	try {

--- a/src/routes/api/livetv/accounts/+server.ts
+++ b/src/routes/api/livetv/accounts/+server.ts
@@ -8,9 +8,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvAccountManager } from '$lib/server/livetv/LiveTvAccountManager';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { liveTvAccountCreateSchema } from '$lib/validation/schemas.js';
 import { isAppError } from '$lib/errors';
+
+const logger = createChildLogger({ module: 'LiveTvAccounts', logDomain: 'livetv' });
 
 /**
  * List all Live TV accounts

--- a/src/routes/api/livetv/accounts/[id]/+server.ts
+++ b/src/routes/api/livetv/accounts/[id]/+server.ts
@@ -12,9 +12,11 @@ import { getLiveTvAccountManager } from '$lib/server/livetv/LiveTvAccountManager
 import { getEpgService, getEpgScheduler } from '$lib/server/livetv/epg';
 import { getEpgSyncState } from '$lib/server/livetv/epg/EpgSyncState';
 import { liveTvEvents } from '$lib/server/livetv/LiveTvEvents';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { z } from 'zod';
 import { ValidationError } from '$lib/errors';
+
+const logger = createChildLogger({ module: 'LiveTvAccountById', logDomain: 'livetv' });
 
 // Validation schema for updating Live TV accounts
 const liveTvAccountUpdateSchema = z.object({

--- a/src/routes/api/livetv/accounts/[id]/test/+server.ts
+++ b/src/routes/api/livetv/accounts/[id]/test/+server.ts
@@ -7,8 +7,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvAccountManager } from '$lib/server/livetv/LiveTvAccountManager';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
+
+const logger = createChildLogger({ module: 'LiveTvAccountTest', logDomain: 'livetv' });
 
 /**
  * Test an existing Live TV account by ID

--- a/src/routes/api/livetv/accounts/test/+server.ts
+++ b/src/routes/api/livetv/accounts/test/+server.ts
@@ -7,12 +7,14 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getProvider } from '$lib/server/livetv/providers';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { toFriendlyLiveTvTestError } from '$lib/livetv/errorMessages';
 import { probeStalkerEndpoint } from '$lib/server/livetv/stalker/StalkerPortalClient';
 import { z } from 'zod';
 import { ValidationError } from '$lib/errors';
 import type { LiveTvAccount } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvAccountsTest', logDomain: 'livetv' });
 
 // Validation schema for testing Live TV accounts
 const liveTvAccountTestSchema = z.object({

--- a/src/routes/api/livetv/categories/+server.ts
+++ b/src/routes/api/livetv/categories/+server.ts
@@ -7,7 +7,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvChannelService } from '$lib/server/livetv/LiveTvChannelService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvCategories', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async ({ url }) => {
 	const channelService = getLiveTvChannelService();

--- a/src/routes/api/livetv/channel-categories/+server.ts
+++ b/src/routes/api/livetv/channel-categories/+server.ts
@@ -9,8 +9,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelCategoryService } from '$lib/server/livetv/categories';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { channelCategoryFormSchema } from '$lib/validation/schemas.js';
+
+const logger = createChildLogger({ module: 'LiveTvChannelCategories', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/livetv/channel-categories/[id]/+server.ts
+++ b/src/routes/api/livetv/channel-categories/[id]/+server.ts
@@ -10,8 +10,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelCategoryService } from '$lib/server/livetv/categories';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ChannelCategoryFormData } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvChannelCategoryById', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async ({ params }) => {
 	try {

--- a/src/routes/api/livetv/channel-categories/reorder/+server.ts
+++ b/src/routes/api/livetv/channel-categories/reorder/+server.ts
@@ -8,7 +8,9 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelCategoryService } from '$lib/server/livetv/categories';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvChannelCategoriesReorder', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {

--- a/src/routes/api/livetv/channels/+server.ts
+++ b/src/routes/api/livetv/channels/+server.ts
@@ -7,8 +7,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvChannelService } from '$lib/server/livetv/LiveTvChannelService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ChannelQueryOptions } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvChannels', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async ({ url }) => {
 	const channelService = getLiveTvChannelService();

--- a/src/routes/api/livetv/channels/sync/+server.ts
+++ b/src/routes/api/livetv/channels/sync/+server.ts
@@ -8,7 +8,9 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvChannelService, getLiveTvAccountManager } from '$lib/server/livetv';
 import { liveTvEvents } from '$lib/server/livetv/LiveTvEvents';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvChannelsSync', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ request }) => {
 	const channelService = getLiveTvChannelService();

--- a/src/routes/api/livetv/channels/sync/status/+server.ts
+++ b/src/routes/api/livetv/channels/sync/status/+server.ts
@@ -7,7 +7,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLiveTvChannelService } from '$lib/server/livetv/LiveTvChannelService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvChannelsSyncStatus', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async () => {
 	const channelService = getLiveTvChannelService();

--- a/src/routes/api/livetv/channels/with-epg/+server.ts
+++ b/src/routes/api/livetv/channels/with-epg/+server.ts
@@ -17,7 +17,9 @@ import {
 	epgPrograms
 } from '$lib/server/db/schema';
 import { eq, like, sql, and, gt } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvChannelsWithEpg', logDomain: 'livetv' });
 
 interface ChannelWithEpgInfo {
 	id: string;

--- a/src/routes/api/livetv/cinephage-iptv/countries/+server.ts
+++ b/src/routes/api/livetv/cinephage-iptv/countries/+server.ts
@@ -6,9 +6,11 @@
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { getStreamingIndexerSettings } from '$lib/server/streaming/settings.js';
 import { getCinephageCore } from '$lib/server/cinephage/core/CinephageCore.js';
+
+const logger = createChildLogger({ module: 'LiveTvCinephageIptvCountries', logDomain: 'livetv' });
 
 const CINEPHAGE_API_BASE = 'https://api.cinephage.net';
 const CACHE_TTL = 24 * 60 * 60 * 1000;

--- a/src/routes/api/livetv/epg.xml/+server.ts
+++ b/src/routes/api/livetv/epg.xml/+server.ts
@@ -15,8 +15,10 @@ import {
 	buildResolvedPlanForLineup,
 	mapGuideDataToRequestedChannels
 } from '$lib/server/livetv/epg/epg-utils';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ChannelLineupItemWithDetails, EpgProgram } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvEpgXml', logDomain: 'livetv' });
 
 /**
  * Format a Date as XMLTV timestamp (YYYYMMDDHHmmss +ZZZZ)

--- a/src/routes/api/livetv/epg/channel/[id]/+server.ts
+++ b/src/routes/api/livetv/epg/channel/[id]/+server.ts
@@ -11,9 +11,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getEpgService } from '$lib/server/livetv/epg';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'LiveTvEpgChannelById', logDomain: 'livetv' });
 
 const DEFAULT_HOURS = 6;
 

--- a/src/routes/api/livetv/epg/guide/+server.ts
+++ b/src/routes/api/livetv/epg/guide/+server.ts
@@ -17,9 +17,11 @@ import {
 	mapGuideDataToRequestedChannels
 } from '$lib/server/livetv/epg/epg-utils';
 import { channelLineupService } from '$lib/server/livetv/lineup';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'LiveTvEpgGuide', logDomain: 'livetv' });
 
 const DEFAULT_HOURS = 6;
 

--- a/src/routes/api/livetv/epg/now/+server.ts
+++ b/src/routes/api/livetv/epg/now/+server.ts
@@ -11,8 +11,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getEpgService } from '$lib/server/livetv/epg';
 import { channelLineupService } from '$lib/server/livetv/lineup';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { EpgProgram, EpgProgramWithProgress } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvEpgNow', logDomain: 'livetv' });
 
 interface NowNextEntry {
 	now: EpgProgramWithProgress | null;

--- a/src/routes/api/livetv/epg/status/+server.ts
+++ b/src/routes/api/livetv/epg/status/+server.ts
@@ -11,7 +11,9 @@ import { getEpgSyncState } from '$lib/server/livetv/epg/EpgSyncState';
 import { db } from '$lib/server/db';
 import { livetvAccounts } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvEpgStatus', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/livetv/epg/sync/+server.ts
+++ b/src/routes/api/livetv/epg/sync/+server.ts
@@ -16,7 +16,9 @@ import { getEpgService, getEpgScheduler } from '$lib/server/livetv/epg';
 import { EPG_SYNC_CANCELLED_MESSAGE } from '$lib/server/livetv/epg/EpgService';
 import { getEpgSyncState } from '$lib/server/livetv/epg/EpgSyncState';
 import { liveTvEvents } from '$lib/server/livetv/LiveTvEvents';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvEpgSync', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ url }) => {
 	const accountId = url.searchParams.get('accountId');

--- a/src/routes/api/livetv/lineup/+server.ts
+++ b/src/routes/api/livetv/lineup/+server.ts
@@ -9,8 +9,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { AddToLineupRequest } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvLineup', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/livetv/lineup/[id]/+server.ts
+++ b/src/routes/api/livetv/lineup/[id]/+server.ts
@@ -10,8 +10,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { updateChannelSchema } from '$lib/validation/schemas.js';
+
+const logger = createChildLogger({ module: 'LiveTvLineupById', logDomain: 'livetv' });
 
 export const GET: RequestHandler = async ({ params }) => {
 	try {

--- a/src/routes/api/livetv/lineup/[id]/backups/+server.ts
+++ b/src/routes/api/livetv/lineup/[id]/backups/+server.ts
@@ -7,9 +7,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup/ChannelLineupService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { addBackupLinkSchema } from '$lib/validation/schemas.js';
+
+const logger = createChildLogger({ module: 'LiveTvLineupBackups', logDomain: 'livetv' });
 
 /**
  * Get all backup links for a lineup item

--- a/src/routes/api/livetv/lineup/[id]/backups/[backupId]/+server.ts
+++ b/src/routes/api/livetv/lineup/[id]/backups/[backupId]/+server.ts
@@ -6,7 +6,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup/ChannelLineupService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvLineupBackupById', logDomain: 'livetv' });
 
 /**
  * Remove a backup link

--- a/src/routes/api/livetv/lineup/[id]/backups/reorder/+server.ts
+++ b/src/routes/api/livetv/lineup/[id]/backups/reorder/+server.ts
@@ -6,9 +6,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup/ChannelLineupService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import type { ReorderBackupsRequest } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvLineupBackupsReorder', logDomain: 'livetv' });
 
 /**
  * Reorder backup links for a lineup item

--- a/src/routes/api/livetv/lineup/bulk-category/+server.ts
+++ b/src/routes/api/livetv/lineup/bulk-category/+server.ts
@@ -8,7 +8,9 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvLineupBulkCategory', logDomain: 'livetv' });
 
 interface BulkSetCategoryRequest {
 	itemIds: string[];

--- a/src/routes/api/livetv/lineup/bulk-clean-names/+server.ts
+++ b/src/routes/api/livetv/lineup/bulk-clean-names/+server.ts
@@ -8,8 +8,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { BulkApplyCleanNamesRequest } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvLineupBulkCleanNames', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {

--- a/src/routes/api/livetv/lineup/remove/+server.ts
+++ b/src/routes/api/livetv/lineup/remove/+server.ts
@@ -8,8 +8,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { RemoveFromLineupRequest } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvLineupRemove', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {

--- a/src/routes/api/livetv/lineup/reorder/+server.ts
+++ b/src/routes/api/livetv/lineup/reorder/+server.ts
@@ -8,8 +8,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup';
 import { ValidationError } from '$lib/errors';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ReorderLineupRequest } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvLineupReorder', logDomain: 'livetv' });
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {

--- a/src/routes/api/livetv/playlist.m3u/+server.ts
+++ b/src/routes/api/livetv/playlist.m3u/+server.ts
@@ -21,8 +21,10 @@
 import type { RequestHandler } from './$types';
 import { channelLineupService } from '$lib/server/livetv/lineup/ChannelLineupService';
 import { getBaseUrlAsync } from '$lib/server/streaming/url';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import type { ChannelLineupItemWithDetails } from '$lib/types/livetv';
+
+const logger = createChildLogger({ module: 'LiveTvPlaylistM3u', logDomain: 'livetv' });
 
 /**
  * Build an M3U playlist from lineup items

--- a/src/routes/api/livetv/portals/+server.ts
+++ b/src/routes/api/livetv/portals/+server.ts
@@ -9,8 +9,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getStalkerPortalManager } from '$lib/server/livetv/stalker';
 import { stalkerPortalCreateSchema } from '$lib/validation/schemas';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError, isAppError } from '$lib/errors';
+
+const logger = createChildLogger({ module: 'LiveTvPortals', logDomain: 'livetv' });
 
 /**
  * List all portals

--- a/src/routes/api/livetv/portals/[id]/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/+server.ts
@@ -10,8 +10,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getStalkerPortalManager } from '$lib/server/livetv/stalker';
 import { stalkerPortalUpdateSchema } from '$lib/validation/schemas';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
+
+const logger = createChildLogger({ module: 'LiveTvPortalById', logDomain: 'livetv' });
 
 /**
  * Get a portal by ID

--- a/src/routes/api/livetv/portals/[id]/scan/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/scan/+server.ts
@@ -7,9 +7,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPortalScannerService } from '$lib/server/livetv/stalker';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'LiveTvPortalScan', logDomain: 'livetv' });
 
 const randomScanSchema = z.object({
 	type: z.literal('random'),

--- a/src/routes/api/livetv/portals/[id]/scan/history/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/scan/history/+server.ts
@@ -7,7 +7,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPortalScannerService } from '$lib/server/livetv/stalker';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvPortalScanHistory', logDomain: 'livetv' });
 
 /**
  * Get scan history for a portal

--- a/src/routes/api/livetv/portals/[id]/scan/results/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/scan/results/+server.ts
@@ -8,7 +8,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPortalScannerService, type ScanResult } from '$lib/server/livetv/stalker';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvPortalScanResults', logDomain: 'livetv' });
 
 /**
  * Get scan results for a portal

--- a/src/routes/api/livetv/portals/[id]/scan/results/approve/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/scan/results/approve/+server.ts
@@ -7,9 +7,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPortalScannerService } from '$lib/server/livetv/stalker';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'LiveTvPortalScanResultsApprove', logDomain: 'livetv' });
 
 const approveSchema = z.object({
 	resultIds: z.array(z.string()).min(1)

--- a/src/routes/api/livetv/portals/[id]/scan/results/ignore/+server.ts
+++ b/src/routes/api/livetv/portals/[id]/scan/results/ignore/+server.ts
@@ -7,9 +7,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPortalScannerService } from '$lib/server/livetv/stalker';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { ValidationError } from '$lib/errors';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'LiveTvPortalScanResultsIgnore', logDomain: 'livetv' });
 
 const ignoreSchema = z.object({
 	resultIds: z.array(z.string()).min(1)

--- a/src/routes/api/livetv/portals/detect/+server.ts
+++ b/src/routes/api/livetv/portals/detect/+server.ts
@@ -8,7 +8,9 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getStalkerPortalManager } from '$lib/server/livetv/stalker';
 import { stalkerPortalDetectSchema } from '$lib/validation/schemas';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvPortalDetect', logDomain: 'livetv' });
 
 /**
  * Detect portal type from URL

--- a/src/routes/api/livetv/stream/[lineupId]/[...path]/+server.ts
+++ b/src/routes/api/livetv/stream/[lineupId]/[...path]/+server.ts
@@ -19,7 +19,9 @@ import {
 } from '$lib/server/livetv/streaming/StreamUrlCache.js';
 import { rewriteHlsPlaylistUrls } from '$lib/server/streaming/utils/hls-rewrite.js';
 import { STB_USER_AGENT } from '$lib/server/livetv/stalker/StalkerPortalClient.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LiveTvStreamProxy', logDomain: 'livetv' });
 
 // Streaming constants
 const LIVETV_SEGMENT_FETCH_TIMEOUT_MS = 15000; // Fail faster for quicker retry/failover

--- a/src/routes/api/logos/+server.ts
+++ b/src/routes/api/logos/+server.ts
@@ -1,8 +1,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { getLogoDownloadService } from '$lib/server/logos/LogoDownloadService.js';
 import { listLogos } from '$lib/server/logos/logo-library.js';
+
+const logger = createChildLogger({ module: 'LogosApi', logDomain: 'system' });
 
 /**
  * GET /api/logos

--- a/src/routes/api/logos/countries/+server.ts
+++ b/src/routes/api/logos/countries/+server.ts
@@ -1,8 +1,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { getLogoDownloadService } from '$lib/server/logos/LogoDownloadService.js';
 import { listLogoCountries } from '$lib/server/logos/logo-library.js';
+
+const logger = createChildLogger({ module: 'LogosCountriesApi', logDomain: 'system' });
 
 /**
  * GET /api/logos/countries

--- a/src/routes/api/logos/download/+server.ts
+++ b/src/routes/api/logos/download/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLogoDownloadService } from '$lib/server/logos/LogoDownloadService.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LogosDownloadApi', logDomain: 'system' });
 
 /**
  * POST /api/logos/download

--- a/src/routes/api/logos/download/stream/+server.ts
+++ b/src/routes/api/logos/download/stream/+server.ts
@@ -2,7 +2,9 @@ import type { RequestHandler } from './$types';
 import { createSSEStream } from '$lib/server/sse';
 import { getLogoDownloadService } from '$lib/server/logos/LogoDownloadService';
 import type { LogoDownloadProgress } from '$lib/server/logos/LogoDownloadService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LogosDownloadStreamApi', logDomain: 'system' });
 
 /**
  * GET /api/logos/download/stream

--- a/src/routes/api/logos/file/[country]/[filename]/+server.ts
+++ b/src/routes/api/logos/file/[country]/[filename]/+server.ts
@@ -1,8 +1,11 @@
 import type { RequestHandler } from './$types';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { LOGOS_DIR } from '$lib/server/logos/constants.js';
+
+const logger = createChildLogger({ module: 'LogosFileApi', logDomain: 'system' });
 
 /**
  * GET /api/logos/file/[country]/[filename]

--- a/src/routes/api/logos/status/+server.ts
+++ b/src/routes/api/logos/status/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getLogoDownloadService } from '$lib/server/logos/LogoDownloadService.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LogosStatusApi', logDomain: 'system' });
 
 /**
  * GET /api/logos/status

--- a/src/routes/api/media-server-stats/+server.ts
+++ b/src/routes/api/media-server-stats/+server.ts
@@ -6,20 +6,32 @@ import {
 	mediaServerSyncedRuns,
 	mediaBrowserServers
 } from '$lib/server/db/schema';
-import { sql, desc } from 'drizzle-orm';
+import { sql, desc, eq, and, or, isNull } from 'drizzle-orm';
 import type {
 	StatsSummary,
 	AggregatedMediaItem,
 	ServerSyncStatus
 } from '$lib/server/mediaServerStats/types.js';
 
-function bucketResolution(height: number | null): string {
-	if (!height) return 'Unknown';
-	if (height >= 2160) return '4K';
-	if (height >= 1080) return '1080p';
-	if (height >= 720) return '720p';
-	if (height >= 480) return '480p';
-	return 'SD';
+/**
+ * Matches the (tmdbId, tvdbId, title) identifying key aggregateItems() groups by.
+ * Used to re-fetch full row detail for a small, already-ranked set of items
+ * instead of loading the whole table.
+ */
+function matchesIdentifyingKey(key: {
+	tmdbId: number | null;
+	tvdbId: number | null;
+	title: string;
+}) {
+	return and(
+		key.tmdbId != null
+			? eq(mediaServerSyncedItems.tmdbId, key.tmdbId)
+			: isNull(mediaServerSyncedItems.tmdbId),
+		key.tvdbId != null
+			? eq(mediaServerSyncedItems.tvdbId, key.tvdbId)
+			: isNull(mediaServerSyncedItems.tvdbId),
+		eq(mediaServerSyncedItems.title, key.title)
+	);
 }
 
 function aggregateItems(
@@ -86,18 +98,29 @@ function aggregateItems(
 }
 
 export const GET: RequestHandler = async () => {
+	const resolutionBucket = sql`CASE
+		WHEN ${mediaServerSyncedItems.height} >= 2160 THEN '4K'
+		WHEN ${mediaServerSyncedItems.height} >= 1080 THEN '1080p'
+		WHEN ${mediaServerSyncedItems.height} >= 720 THEN '720p'
+		WHEN ${mediaServerSyncedItems.height} >= 480 THEN '480p'
+		WHEN ${mediaServerSyncedItems.height} IS NULL THEN 'Unknown'
+		ELSE 'SD'
+	END`;
+
 	const [
 		totalPlaysRow,
 		uniqueItemsRow,
 		serversSyncedRow,
 		totalFileSizeRow,
-		allItems,
+		resolutionRows,
 		codecRows,
 		hdrRows,
 		audioCodecRows,
 		containerRows,
 		servers,
-		syncRuns
+		itemCountsByServerRows,
+		topPlayedKeys,
+		largestRawRows
 	] = await Promise.all([
 		db
 			.select({ total: sql<number>`coalesce(sum(${mediaServerSyncedItems.playCount}), 0)` })
@@ -115,7 +138,10 @@ export const GET: RequestHandler = async () => {
 		db
 			.select({ total: sql<number>`coalesce(sum(${mediaServerSyncedItems.fileSize}), 0)` })
 			.from(mediaServerSyncedItems),
-		db.select().from(mediaServerSyncedItems),
+		db
+			.select({ label: resolutionBucket.as('label'), count: sql<number>`count(*)` })
+			.from(mediaServerSyncedItems)
+			.groupBy(resolutionBucket),
 		db
 			.select({
 				videoCodec: mediaServerSyncedItems.videoCodec,
@@ -153,16 +179,73 @@ export const GET: RequestHandler = async () => {
 			.groupBy(mediaServerSyncedItems.containerFormat)
 			.orderBy(sql`count(*) desc`),
 		db.select().from(mediaBrowserServers),
-		db.select().from(mediaServerSyncedRuns).orderBy(desc(mediaServerSyncedRuns.startedAt))
+		db
+			.select({ serverId: mediaServerSyncedItems.serverId, count: sql<number>`count(*)` })
+			.from(mediaServerSyncedItems)
+			.where(sql`${mediaServerSyncedItems.serverId} IS NOT NULL`)
+			.groupBy(mediaServerSyncedItems.serverId),
+		db
+			.select({
+				tmdbId: mediaServerSyncedItems.tmdbId,
+				tvdbId: mediaServerSyncedItems.tvdbId,
+				title: mediaServerSyncedItems.title
+			})
+			.from(mediaServerSyncedItems)
+			.groupBy(
+				mediaServerSyncedItems.tmdbId,
+				mediaServerSyncedItems.tvdbId,
+				mediaServerSyncedItems.title
+			)
+			.orderBy(sql`sum(${mediaServerSyncedItems.playCount}) desc`)
+			.limit(25),
+		db
+			.select()
+			.from(mediaServerSyncedItems)
+			.where(sql`${mediaServerSyncedItems.fileSize} IS NOT NULL`)
+			.orderBy(desc(mediaServerSyncedItems.fileSize))
+			.limit(10)
 	]);
 
-	const resolutionMap = new Map<string, number>();
-	for (const item of allItems) {
-		const label = bucketResolution(item.height);
-		resolutionMap.set(label, (resolutionMap.get(label) ?? 0) + 1);
-	}
-	const resolutionBreakdown = Array.from(resolutionMap.entries())
-		.map(([label, count]) => ({ label, count }))
+	// Latest sync run per server - one small limited query per (bounded, small) server
+	// list instead of loading the whole run-history table.
+	const syncRuns = (
+		await Promise.all(
+			servers.map((server) =>
+				db
+					.select()
+					.from(mediaServerSyncedRuns)
+					.where(eq(mediaServerSyncedRuns.serverId, server.id))
+					.orderBy(desc(mediaServerSyncedRuns.startedAt))
+					.limit(1)
+			)
+		)
+	).flat();
+
+	// Fetch full row detail only for the items that actually made the top-25/top-10
+	// lists above, so serverBreakdown can still be built without loading every row.
+	const topPlayedRows =
+		topPlayedKeys.length > 0
+			? await db
+					.select()
+					.from(mediaServerSyncedItems)
+					.where(or(...topPlayedKeys.map(matchesIdentifyingKey)))
+			: [];
+
+	const largestKeys = largestRawRows.map((item) => ({
+		tmdbId: item.tmdbId,
+		tvdbId: item.tvdbId,
+		title: item.title
+	}));
+	const largestDetailRows =
+		largestKeys.length > 0
+			? await db
+					.select()
+					.from(mediaServerSyncedItems)
+					.where(or(...largestKeys.map(matchesIdentifyingKey)))
+			: [];
+
+	const resolutionBreakdown = resolutionRows
+		.map((r) => ({ label: r.label as string, count: r.count }))
 		.sort((a, b) => b.count - a.count);
 
 	const codecBreakdown = codecRows.map((r) => ({
@@ -188,47 +271,38 @@ export const GET: RequestHandler = async () => {
 		count: r.count
 	}));
 
-	const aggregated = aggregateItems(allItems);
-	const topPlayedItems = aggregated
+	const topPlayedItems = aggregateItems(topPlayedRows)
 		.sort((a, b) => b.totalPlayCount - a.totalPlayCount)
 		.slice(0, 25);
 
-	const largestItems = allItems
-		.filter((item) => item.fileSize != null)
-		.sort((a, b) => (b.fileSize ?? 0) - (a.fileSize ?? 0))
-		.slice(0, 10)
-		.map((item) => {
-			const agg = aggregated.find(
-				(a) => a.tmdbId === item.tmdbId && a.tvdbId === item.tvdbId && a.title === item.title
-			);
-			return (
-				agg ?? {
-					tmdbId: item.tmdbId ?? null,
-					tvdbId: item.tvdbId ?? null,
-					imdbId: item.imdbId ?? null,
-					title: item.title,
-					year: item.year ?? null,
-					itemType: item.itemType,
-					totalPlayCount: item.playCount ?? 0,
-					lastPlayedDate: item.lastPlayedDate ?? null,
-					serverBreakdown: []
-				}
-			);
-		});
+	const largestAggregated = aggregateItems(largestDetailRows);
+	const largestItems = largestRawRows.map((item) => {
+		const agg = largestAggregated.find(
+			(a) => a.tmdbId === item.tmdbId && a.tvdbId === item.tvdbId && a.title === item.title
+		);
+		return (
+			agg ?? {
+				tmdbId: item.tmdbId ?? null,
+				tvdbId: item.tvdbId ?? null,
+				imdbId: item.imdbId ?? null,
+				title: item.title,
+				year: item.year ?? null,
+				itemType: item.itemType,
+				totalPlayCount: item.playCount ?? 0,
+				lastPlayedDate: item.lastPlayedDate ?? null,
+				serverBreakdown: []
+			}
+		);
+	});
 
 	const latestRunsMap = new Map<string, (typeof syncRuns)[0]>();
 	for (const run of syncRuns) {
-		if (!latestRunsMap.has(run.serverId)) {
-			latestRunsMap.set(run.serverId, run);
-		}
+		latestRunsMap.set(run.serverId, run);
 	}
 
-	const itemCountsMap = new Map<string, number>();
-	for (const item of allItems) {
-		if (item.serverId) {
-			itemCountsMap.set(item.serverId, (itemCountsMap.get(item.serverId) ?? 0) + 1);
-		}
-	}
+	const itemCountsMap = new Map<string, number>(
+		itemCountsByServerRows.map((r) => [r.serverId as string, r.count])
+	);
 
 	const serverStatuses: ServerSyncStatus[] = servers.map((server) => {
 		const latestRun = latestRunsMap.get(server.id);

--- a/src/routes/api/monitoring/search/cutoff-unmet/+server.ts
+++ b/src/routes/api/monitoring/search/cutoff-unmet/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchCutoffUnmetApi',
+	logDomain: 'monitoring'
+});
 
 /**
  * POST /api/monitoring/search/cutoff-unmet

--- a/src/routes/api/monitoring/search/metadata-refresh/+server.ts
+++ b/src/routes/api/monitoring/search/metadata-refresh/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchMetadataRefreshApi',
+	logDomain: 'monitoring'
+});
 
 export const POST: RequestHandler = async (event) => {
 	const authError = requireAdmin(event);

--- a/src/routes/api/monitoring/search/missing-subtitles/+server.ts
+++ b/src/routes/api/monitoring/search/missing-subtitles/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchMissingSubtitlesApi',
+	logDomain: 'monitoring'
+});
 
 /**
  * POST /api/monitoring/search/missing-subtitles

--- a/src/routes/api/monitoring/search/missing/+server.ts
+++ b/src/routes/api/monitoring/search/missing/+server.ts
@@ -1,8 +1,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'MonitoringSearchMissingApi', logDomain: 'monitoring' });
 
 /**
  * POST /api/monitoring/search/missing

--- a/src/routes/api/monitoring/search/new-episodes/+server.ts
+++ b/src/routes/api/monitoring/search/new-episodes/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchNewEpisodesApi',
+	logDomain: 'monitoring'
+});
 
 /**
  * POST /api/monitoring/search/new-episodes

--- a/src/routes/api/monitoring/search/pending-releases/+server.ts
+++ b/src/routes/api/monitoring/search/pending-releases/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchPendingReleasesApi',
+	logDomain: 'monitoring'
+});
 
 /**
  * POST /api/monitoring/search/pending-releases

--- a/src/routes/api/monitoring/search/subtitle-upgrade/+server.ts
+++ b/src/routes/api/monitoring/search/subtitle-upgrade/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({
+	module: 'MonitoringSearchSubtitleUpgradeApi',
+	logDomain: 'monitoring'
+});
 
 /**
  * POST /api/monitoring/search/subtitle-upgrade

--- a/src/routes/api/monitoring/search/upgrade/+server.ts
+++ b/src/routes/api/monitoring/search/upgrade/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
 import { monitoringSearchService } from '$lib/server/monitoring/search/MonitoringSearchService.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'MonitoringSearchUpgradeApi', logDomain: 'monitoring' });
 
 /**
  * POST /api/monitoring/search/upgrade

--- a/src/routes/api/monitoring/settings/+server.ts
+++ b/src/routes/api/monitoring/settings/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
 import { monitoringSettingsUpdateSchema } from '$lib/validation/schemas.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'MonitoringSettingsApi', logDomain: 'monitoring' });
 
 /**
  * GET /api/monitoring/settings

--- a/src/routes/api/monitoring/status/+server.ts
+++ b/src/routes/api/monitoring/status/+server.ts
@@ -1,7 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'MonitoringStatusApi', logDomain: 'monitoring' });
 
 /**
  * GET /api/monitoring/status

--- a/src/routes/api/naming/presets/+server.ts
+++ b/src/routes/api/naming/presets/+server.ts
@@ -10,9 +10,11 @@ import {
 	type NamingPreset
 } from '$lib/server/library/naming/presets';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { namingPresetCreateSchema } from '$lib/validation/schemas.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'NamingPresetsApi', logDomain: 'scans' });
 
 /**
  * GET /api/naming/presets

--- a/src/routes/api/naming/presets/[id]/+server.ts
+++ b/src/routes/api/naming/presets/[id]/+server.ts
@@ -8,9 +8,11 @@ import {
 	type NamingPreset
 } from '$lib/server/library/naming/presets';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { namingPresetUpdateSchema } from '$lib/validation/schemas.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'NamingPresetByIdApi', logDomain: 'scans' });
 
 /**
  * GET /api/naming/presets/[id]

--- a/src/routes/api/naming/presets/[id]/apply/+server.ts
+++ b/src/routes/api/naming/presets/[id]/apply/+server.ts
@@ -5,8 +5,10 @@ import { namingPresets } from '$lib/server/db/schema';
 import { getBuiltInPreset, type NamingPreset } from '$lib/server/library/naming/presets';
 import { namingSettingsService } from '$lib/server/library/naming/NamingSettingsService';
 import { eq } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'NamingPresetApplyApi', logDomain: 'scans' });
 
 /**
  * POST /api/naming/presets/[id]/apply

--- a/src/routes/api/naming/preview/+server.ts
+++ b/src/routes/api/naming/preview/+server.ts
@@ -6,9 +6,11 @@ import {
 	type NamingConfig
 } from '$lib/server/library/naming/NamingService';
 import { namingSettingsService } from '$lib/server/library/naming/NamingSettingsService';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { namingPreviewSchema } from '$lib/validation/schemas.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'NamingPreviewApi', logDomain: 'scans' });
 
 /**
  * Sample data for previews

--- a/src/routes/api/naming/validate/+server.ts
+++ b/src/routes/api/naming/validate/+server.ts
@@ -1,9 +1,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
 import { tokenRegistry } from '$lib/server/library/naming/tokens';
 import { TemplateEngine } from '$lib/server/library/naming/template';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'NamingValidateApi', logDomain: 'scans' });
 
 const templateEngine = new TemplateEngine(tokenRegistry);
 

--- a/src/routes/api/quality-presets/+server.ts
+++ b/src/routes/api/quality-presets/+server.ts
@@ -1,7 +1,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+
+const logger = createChildLogger({ module: 'QualityPresetsApi', logDomain: 'system' });
 
 /**
  * @deprecated These endpoints are REMOVED. Use /api/scoring-profiles instead.

--- a/src/routes/api/queue/[id]/+server.ts
+++ b/src/routes/api/queue/[id]/+server.ts
@@ -12,7 +12,9 @@ import { and, desc, eq } from 'drizzle-orm';
 import { getDownloadClientManager } from '$lib/server/downloadClients/DownloadClientManager';
 import { downloadMonitor } from '$lib/server/downloadClients/monitoring';
 import { upsertQueueTombstoneFromQueueItem } from '$lib/server/downloadClients/monitoring/QueueTombstoneService';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'QueueItemApi', logDomain: 'downloads' });
 
 const DEFAULT_QUEUE_REMOVE_CLIENT_TIMEOUT_MS = 3000;
 

--- a/src/routes/api/queue/[id]/retry/+server.ts
+++ b/src/routes/api/queue/[id]/retry/+server.ts
@@ -7,10 +7,12 @@ import { getDownloadClientManager } from '$lib/server/downloadClients/DownloadCl
 import { getImportService } from '$lib/server/downloadClients/import';
 import { getContentPath, buildTorrentRecoveryPath } from '$lib/server/downloadClients/monitoring';
 import type { DownloadInfo } from '$lib/server/downloadClients/core/interfaces';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { redactUrl } from '$lib/server/utils/urlSecurity';
 import { matchesImportError } from '$lib/types/activity.js';
 import { DebridHandler } from '$lib/server/downloads/handlers/DebridHandler.js';
+
+const logger = createChildLogger({ module: 'QueueRetryApi', logDomain: 'downloads' });
 
 const MAX_IMPORT_ATTEMPTS = 10;
 const AMBIGUOUS_SUBMISSION_MARKER = '[ambiguous_submission]';

--- a/src/routes/api/queue/clear-failed/+server.ts
+++ b/src/routes/api/queue/clear-failed/+server.ts
@@ -11,7 +11,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { downloadMonitor } from '$lib/server/downloadClients/monitoring';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'QueueClearFailedApi', logDomain: 'downloads' });
 
 export const POST: RequestHandler = async ({ url }) => {
 	const dryRun = url.searchParams.get('dryRun') === 'true';

--- a/src/routes/api/queue/history/+server.ts
+++ b/src/routes/api/queue/history/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db';
 import { downloadHistory, movies, series } from '$lib/server/db/schema';
 import { eq, desc, and, isNotNull, isNull, inArray } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'QueueHistoryApi', logDomain: 'downloads' });
 
 /**
  * GET - Get download history with optional filtering

--- a/src/routes/api/queue/refresh/+server.ts
+++ b/src/routes/api/queue/refresh/+server.ts
@@ -9,7 +9,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { downloadMonitor } from '$lib/server/downloadClients/monitoring';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'QueueRefreshApi', logDomain: 'downloads' });
 
 export const POST: RequestHandler = async () => {
 	logger.info('Manual queue refresh requested');

--- a/src/routes/api/queue/relink-orphans/+server.ts
+++ b/src/routes/api/queue/relink-orphans/+server.ts
@@ -13,7 +13,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { downloadMonitor } from '$lib/server/downloadClients/monitoring';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'QueueRelinkOrphansApi', logDomain: 'downloads' });
 
 export const POST: RequestHandler = async () => {
 	logger.info('Orphan relink requested');

--- a/src/routes/api/rename/execute/+server.ts
+++ b/src/routes/api/rename/execute/+server.ts
@@ -1,7 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { RenamePreviewService } from '$lib/server/library/naming/RenamePreviewService';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { parseBody } from '$lib/server/api/validate.js';
 import { ValidationError } from '$lib/errors';
@@ -9,6 +8,9 @@ import { diskScanService } from '$lib/server/library/disk-scan.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
 import { renamePreviewCache } from '$lib/server/library/naming/RenamePreviewCache.js';
 import { renameExecuteSchema } from '$lib/server/library/naming/rename-execute-schema.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'RenameExecuteApi', logDomain: 'scans' });
 
 export const POST: RequestHandler = async (event) => {
 	const authError = requireAdmin(event);

--- a/src/routes/api/rename/execute/+server.ts
+++ b/src/routes/api/rename/execute/+server.ts
@@ -7,6 +7,7 @@ import { parseBody } from '$lib/server/api/validate.js';
 import { ValidationError } from '$lib/errors';
 import { diskScanService } from '$lib/server/library/disk-scan.js';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { renamePreviewCache } from '$lib/server/library/naming/RenamePreviewCache.js';
 import { renameExecuteSchema } from '$lib/server/library/naming/rename-execute-schema.js';
 
 export const POST: RequestHandler = async (event) => {
@@ -49,6 +50,8 @@ export const POST: RequestHandler = async (event) => {
 				source: mediaType === 'episode' ? 'series' : 'movie',
 				reason: 'renames-executed'
 			});
+			// Invalidate preview cache: paths have changed on disk and in the DB.
+			renamePreviewCache.invalidateAll();
 		}
 
 		return json(result);

--- a/src/routes/api/rename/preview/+server.ts
+++ b/src/routes/api/rename/preview/+server.ts
@@ -1,145 +1,280 @@
 /**
  * Bulk Rename Preview API
  *
- * GET /api/rename/preview?mediaType=movie|tv|all[&offset=N&limit=N&category=willChange]
- * Returns a preview of all files that would be renamed based on current naming settings.
+ * GET /api/rename/preview?mediaType=movie|tv|all
+ *
+ * Always returns an NDJSON stream (application/x-ndjson) so the client can
+ * show counts and items progressively. Three paths:
+ *
+ *   1. Cache fresh: emits cached items in 500-item batches then "done"
+ *   2. Partially stale: recomputes only the stale mediaIds, patches the cache,
+ *  	then serves the merged result
+ *   3. Cold / fully stale: streams counts first ("start"), then item batches
+ * 		progressively as the full compute runs
  */
 
-import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
 	RenamePreviewService,
-	type RenamePreviewResult
+	type RenameStreamEvent
 } from '$lib/server/library/naming/RenamePreviewService';
+import type { RenamePreviewResult } from '$lib/library/naming/types.js';
+import { renamePreviewCache } from '$lib/server/library/naming/RenamePreviewCache.js';
+import { db } from '$lib/server/db';
+import { movieFiles, episodeFiles } from '$lib/server/db/schema';
+import { count } from 'drizzle-orm';
 import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 
-const DEFAULT_PAGE_SIZE = 500;
+const STREAM_BATCH_SIZE = 500;
 
-function paginate(items: unknown[], offset: number, limit: number) {
-	const start = Math.max(0, offset);
-	const end = Math.min(items.length, start + limit);
-	return items.slice(start, end);
+function ndjsonLine(obj: unknown): Uint8Array {
+	return new TextEncoder().encode(JSON.stringify(obj) + '\n');
+}
+
+function* iterateBatches<T>(arr: T[], size: number): Generator<T[]> {
+	for (let i = 0; i < arr.length; i += size) {
+		yield arr.slice(i, i + size);
+	}
 }
 
 /**
- * GET /api/rename/preview
- * Get preview of all files that would be renamed
- *
- * Query params:
- * - mediaType: 'movie' | 'tv' | 'all' (default: 'all')
- * - offset: starting index for paginated results (default: 0)
- * - limit: max items to return (default: 500)
- * - category: filter to 'willChange' | 'alreadyCorrect' | 'collisions' | 'errors' (optional)
+ * Stream a fully-computed result (cache-warm path).
+ * All data is already in memory; batching prevents one huge JSON parse on the client.
  */
-export const GET: RequestHandler = async (event) => {
-	const authError = requireAdmin(event);
-	if (authError) return authError;
+async function streamFromCache(
+	result: RenamePreviewResult,
+	controller: ReadableStreamDefaultController
+): Promise<void> {
+	controller.enqueue(
+		ndjsonLine({
+			type: 'start',
+			totalFiles: result.totalFiles,
+			computing: false
+		} satisfies RenameStreamEvent)
+	);
 
-	const { url } = event;
-	try {
-		const mediaType = url.searchParams.get('mediaType') || 'all';
-		const offset = Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0);
-		const limit = Math.max(
-			1,
-			Math.min(
-				2000,
-				parseInt(url.searchParams.get('limit') || String(DEFAULT_PAGE_SIZE), 10) ||
-					DEFAULT_PAGE_SIZE
-			)
+	for (const batch of iterateBatches(result.willChange, STREAM_BATCH_SIZE)) {
+		controller.enqueue(
+			ndjsonLine({ type: 'items', category: 'willChange', data: batch } satisfies RenameStreamEvent)
 		);
-		const category = url.searchParams.get('category') || undefined;
+	}
+	for (const batch of iterateBatches(result.alreadyCorrect, STREAM_BATCH_SIZE)) {
+		controller.enqueue(
+			ndjsonLine({
+				type: 'items',
+				category: 'alreadyCorrect',
+				data: batch
+			} satisfies RenameStreamEvent)
+		);
+	}
+	for (const batch of iterateBatches(result.collisions, STREAM_BATCH_SIZE)) {
+		controller.enqueue(
+			ndjsonLine({ type: 'items', category: 'collisions', data: batch } satisfies RenameStreamEvent)
+		);
+	}
+	for (const batch of iterateBatches(result.errors, STREAM_BATCH_SIZE)) {
+		controller.enqueue(
+			ndjsonLine({ type: 'items', category: 'errors', data: batch } satisfies RenameStreamEvent)
+		);
+	}
 
-		const service = new RenamePreviewService();
-		let result: RenamePreviewResult;
-
-		if (mediaType === 'movie') {
-			result = await service.previewAllMovies();
-		} else if (mediaType === 'tv') {
-			result = await service.previewAllEpisodes();
-		} else {
-			const movieResult = await service.previewAllMovies();
-			const episodeResult = await service.previewAllEpisodes();
-
-			result = {
-				willChange: [...movieResult.willChange, ...episodeResult.willChange],
-				alreadyCorrect: [...movieResult.alreadyCorrect, ...episodeResult.alreadyCorrect],
-				collisions: [...movieResult.collisions, ...episodeResult.collisions],
-				errors: [...movieResult.errors, ...episodeResult.errors],
-				totalFiles: movieResult.totalFiles + episodeResult.totalFiles,
-				totalWillChange: movieResult.totalWillChange + episodeResult.totalWillChange,
-				totalAlreadyCorrect: movieResult.totalAlreadyCorrect + episodeResult.totalAlreadyCorrect,
-				totalCollisions: movieResult.totalCollisions + episodeResult.totalCollisions,
-				totalErrors: movieResult.totalErrors + episodeResult.totalErrors
-			};
-		}
-
-		// Return counts always, but paginate item arrays to avoid sending
-		// massive responses for large libraries.
-		const counts = {
+	controller.enqueue(
+		ndjsonLine({
+			type: 'done',
 			totalFiles: result.totalFiles,
 			totalWillChange: result.totalWillChange,
 			totalAlreadyCorrect: result.totalAlreadyCorrect,
 			totalCollisions: result.totalCollisions,
 			totalErrors: result.totalErrors
-		};
+		} satisfies RenameStreamEvent)
+	);
+}
 
-		if (category === 'willChange') {
-			return json({
-				success: true,
-				...counts,
-				items: paginate(result.willChange, offset, limit),
-				offset,
-				limit,
-				total: result.totalWillChange
-			});
-		}
-		if (category === 'alreadyCorrect') {
-			return json({
-				success: true,
-				...counts,
-				items: paginate(result.alreadyCorrect, offset, limit),
-				offset,
-				limit,
-				total: result.totalAlreadyCorrect
-			});
-		}
-		if (category === 'collisions') {
-			return json({
-				success: true,
-				...counts,
-				items: paginate(result.collisions, offset, limit),
-				offset,
-				limit,
-				total: result.totalCollisions
-			});
-		}
-		if (category === 'errors') {
-			return json({
-				success: true,
-				...counts,
-				items: paginate(result.errors, offset, limit),
-				offset,
-				limit,
-				total: result.totalErrors
-			});
-		}
+/**
+ * Stream a cold-cache full compute.
+ * Emits a "start" with a DB-count estimate first so the UI can show progress,
+ * then streams item batches as they are computed.
+ */
+async function streamFullCompute(
+	mediaType: 'movie' | 'tv' | 'all',
+	controller: ReadableStreamDefaultController
+): Promise<{ movieResult?: RenamePreviewResult; tvResult?: RenamePreviewResult }> {
+	// Fast DB count for progress estimate.
+	const [movieFileCount, episodeFileCount] = await Promise.all([
+		db
+			.select({ c: count() })
+			.from(movieFiles)
+			.then((r) => r[0]?.c ?? 0),
+		db
+			.select({ c: count() })
+			.from(episodeFiles)
+			.then((r) => r[0]?.c ?? 0)
+	]);
 
-		return json({ success: true, ...result });
-	} catch (error) {
-		logger.error(
-			{
-				error: error instanceof Error ? error.message : String(error)
-			},
-			'[RenamePreview API] Failed to generate preview'
-		);
+	const estimatedFiles =
+		mediaType === 'movie'
+			? movieFileCount
+			: mediaType === 'tv'
+				? episodeFileCount
+				: movieFileCount + episodeFileCount;
 
-		return json(
-			{
-				error: 'Failed to generate rename preview',
-				details: error instanceof Error ? error.message : 'Unknown error'
-			},
-			{ status: 500 }
-		);
+	controller.enqueue(
+		ndjsonLine({
+			type: 'start',
+			totalFiles: estimatedFiles,
+			computing: true
+		} satisfies RenameStreamEvent)
+	);
+
+	const service = new RenamePreviewService();
+	const emit = (event: RenameStreamEvent) => controller.enqueue(ndjsonLine(event));
+
+	let movieResult: RenamePreviewResult | undefined;
+	let tvResult: RenamePreviewResult | undefined;
+
+	if (mediaType === 'movie' || mediaType === 'all') {
+		movieResult = await service.previewAllMovies(emit);
+		renamePreviewCache.set('movie', movieResult);
 	}
+	if (mediaType === 'tv' || mediaType === 'all') {
+		tvResult = await service.previewAllEpisodes(emit);
+		renamePreviewCache.set('tv', tvResult);
+	}
+
+	// Compute combined totals for the "done" event.
+	const totalFiles = (movieResult?.totalFiles ?? 0) + (tvResult?.totalFiles ?? 0);
+	const totalWillChange = (movieResult?.totalWillChange ?? 0) + (tvResult?.totalWillChange ?? 0);
+	const totalAlreadyCorrect =
+		(movieResult?.totalAlreadyCorrect ?? 0) + (tvResult?.totalAlreadyCorrect ?? 0);
+	const totalCollisions = (movieResult?.totalCollisions ?? 0) + (tvResult?.totalCollisions ?? 0);
+	const totalErrors = (movieResult?.totalErrors ?? 0) + (tvResult?.totalErrors ?? 0);
+
+	controller.enqueue(
+		ndjsonLine({
+			type: 'done',
+			totalFiles,
+			totalWillChange,
+			totalAlreadyCorrect,
+			totalCollisions,
+			totalErrors
+		} satisfies RenameStreamEvent)
+	);
+
+	return { movieResult, tvResult };
+}
+
+export const GET: RequestHandler = async (event) => {
+	const authError = requireAdmin(event);
+	if (authError) return authError;
+
+	const { url } = event;
+	const mediaType = (url.searchParams.get('mediaType') || 'all') as 'movie' | 'tv' | 'all';
+
+	const needsMovie = mediaType === 'movie' || mediaType === 'all';
+	const needsTv = mediaType === 'tv' || mediaType === 'all';
+
+	const movieFresh = !needsMovie || renamePreviewCache.isFresh('movie');
+	const tvFresh = !needsTv || renamePreviewCache.isFresh('tv');
+	const moviePartial = needsMovie && renamePreviewCache.isPartiallyCached('movie');
+	const tvPartial = needsTv && renamePreviewCache.isPartiallyCached('tv');
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			try {
+				// Path 1: both caches fully fresh — emit from cache
+				if (movieFresh && tvFresh) {
+					const merged = buildMergedResult(mediaType);
+					await streamFromCache(merged, controller);
+					controller.close();
+					return;
+				}
+
+				// Path 2: one or both partially stale — patch only the stale mediaIds,
+				// then serve the merged cached result.
+				if (moviePartial || tvPartial) {
+					const service = new RenamePreviewService();
+
+					if (moviePartial) {
+						const staleIds = renamePreviewCache.getStaleIds('movie');
+						const freshResult = await service.previewMoviesByIds([...staleIds]);
+						renamePreviewCache.applyPatch('movie', staleIds, freshResult);
+					}
+					if (tvPartial) {
+						const staleIds = renamePreviewCache.getStaleIds('tv');
+						const freshResult = await service.previewSeriesByIds([...staleIds]);
+						renamePreviewCache.applyPatch('tv', staleIds, freshResult);
+					}
+
+					// Both relevant caches are now fresh — stream from cache.
+					const merged = buildMergedResult(mediaType);
+					await streamFromCache(merged, controller);
+					controller.close();
+					return;
+				}
+
+				// Path 3: cold or fully stale — full streaming compute
+				await streamFullCompute(mediaType, controller);
+				controller.close();
+			} catch (error) {
+				logger.error(
+					{ error: error instanceof Error ? error.message : String(error) },
+					'[RenamePreview API] Failed to generate preview'
+				);
+				try {
+					controller.enqueue(
+						ndjsonLine({ type: 'error', message: 'Failed to generate rename preview' })
+					);
+				} catch {
+					// controller may already be closed
+				}
+				controller.close();
+			}
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'application/x-ndjson',
+			'Cache-Control': 'no-cache',
+			'X-Content-Type-Options': 'nosniff'
+		}
+	});
 };
+
+function buildMergedResult(mediaType: 'movie' | 'tv' | 'all'): RenamePreviewResult {
+	const movieResult = mediaType !== 'tv' ? renamePreviewCache.get('movie') : null;
+	const tvResult = mediaType !== 'movie' ? renamePreviewCache.get('tv') : null;
+
+	if (mediaType === 'movie' && movieResult) return movieResult;
+	if (mediaType === 'tv' && tvResult) return tvResult;
+
+	// Merge both
+	const m = movieResult ?? emptyResult();
+	const t = tvResult ?? emptyResult();
+	return {
+		willChange: [...m.willChange, ...t.willChange],
+		alreadyCorrect: [...m.alreadyCorrect, ...t.alreadyCorrect],
+		collisions: [...m.collisions, ...t.collisions],
+		errors: [...m.errors, ...t.errors],
+		totalFiles: m.totalFiles + t.totalFiles,
+		totalWillChange: m.totalWillChange + t.totalWillChange,
+		totalAlreadyCorrect: m.totalAlreadyCorrect + t.totalAlreadyCorrect,
+		totalCollisions: m.totalCollisions + t.totalCollisions,
+		totalErrors: m.totalErrors + t.totalErrors
+	};
+}
+
+function emptyResult(): RenamePreviewResult {
+	return {
+		willChange: [],
+		alreadyCorrect: [],
+		collisions: [],
+		errors: [],
+		totalFiles: 0,
+		totalWillChange: 0,
+		totalAlreadyCorrect: 0,
+		totalCollisions: 0,
+		totalErrors: 0
+	};
+}

--- a/src/routes/api/rename/preview/+server.ts
+++ b/src/routes/api/rename/preview/+server.ts
@@ -23,8 +23,10 @@ import { renamePreviewCache } from '$lib/server/library/naming/RenamePreviewCach
 import { db } from '$lib/server/db';
 import { movieFiles, episodeFiles } from '$lib/server/db/schema';
 import { count } from 'drizzle-orm';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'RenamePreviewApi', logDomain: 'scans' });
 
 const STREAM_BATCH_SIZE = 500;
 

--- a/src/routes/api/rename/preview/movie/[id]/+server.ts
+++ b/src/routes/api/rename/preview/movie/[id]/+server.ts
@@ -8,8 +8,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { RenamePreviewService } from '$lib/server/library/naming/RenamePreviewService';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'RenamePreviewMovieApi', logDomain: 'scans' });
 
 /**
  * GET /api/rename/preview/movie/:id

--- a/src/routes/api/rename/preview/series/[id]/+server.ts
+++ b/src/routes/api/rename/preview/series/[id]/+server.ts
@@ -8,8 +8,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { RenamePreviewService } from '$lib/server/library/naming/RenamePreviewService';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'RenamePreviewSeriesApi', logDomain: 'scans' });
 
 /**
  * GET /api/rename/preview/series/:id

--- a/src/routes/api/rename/reorganize-batch/+server.ts
+++ b/src/routes/api/rename/reorganize-batch/+server.ts
@@ -14,13 +14,15 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { RenamePreviewService } from '$lib/server/library/naming/RenamePreviewService.js';
-import { logger } from '$lib/logging/index.js';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { parseBody } from '$lib/server/api/validate.js';
 import { diskScanService } from '$lib/server/library/disk-scan.js';
 import { z } from 'zod';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
 import type { ReorganizeBatchResult } from '$lib/library/naming/types.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'RenameReorganizeBatchApi', logDomain: 'scans' });
 
 const reorganizeBatchSchema = z.object({
 	items: z

--- a/src/routes/api/rename/reorganize/+server.ts
+++ b/src/routes/api/rename/reorganize/+server.ts
@@ -13,12 +13,14 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { RenamePreviewService } from '$lib/server/library/naming/RenamePreviewService';
-import { logger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { parseBody } from '$lib/server/api/validate.js';
 import { diskScanService } from '$lib/server/library/disk-scan.js';
 import { z } from 'zod';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'RenameReorganizeApi', logDomain: 'scans' });
 
 const reorganizeSchema = z.object({
 	mediaId: z.string().min(1, 'mediaId is required'),

--- a/src/routes/api/reports/[type]/+server.ts
+++ b/src/routes/api/reports/[type]/+server.ts
@@ -20,6 +20,23 @@ const VALID_TYPES = [
 
 type ReportType = (typeof VALID_TYPES)[number];
 
+// This handler serves all four report types through one shared route, so the
+// log domain is picked per-request from the type param rather than fixed at
+// the module level - matches the domain each type's underlying pipeline
+// stage already logs under elsewhere (grab decisions vs. post-download
+// import vs. library scan/rename).
+function reportTypeDomain(type: ReportType): 'downloads' | 'imports' | 'scans' {
+	switch (type) {
+		case 'rejected-releases':
+			return 'downloads';
+		case 'import-failures':
+			return 'imports';
+		case 'renaming-failures':
+		case 'unmatched-imports':
+			return 'scans';
+	}
+}
+
 /**
  * GET /api/reports/[type]
  * List diagnostic report records for a given type with pagination.
@@ -308,7 +325,10 @@ export const GET: RequestHandler = async ({ params, url }) => {
 			}
 		});
 	} catch (err) {
-		logger.error({ err, type }, '[Reports] Failed to load report records');
+		logger.error(
+			{ err, type, logDomain: reportTypeDomain(type) },
+			'[Reports] Failed to load report records'
+		);
 		return json({ success: false, error: 'Failed to load report records' }, { status: 500 });
 	}
 };
@@ -432,7 +452,10 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 
 		return json({ success: true, data: { updated } });
 	} catch (err) {
-		logger.error({ err, type }, '[Reports] Failed to update record status');
+		logger.error(
+			{ err, type, logDomain: reportTypeDomain(type) },
+			'[Reports] Failed to update record status'
+		);
 		return json({ success: false, error: 'Failed to update records' }, { status: 500 });
 	}
 };

--- a/src/routes/api/reports/import-failures-stats/+server.ts
+++ b/src/routes/api/reports/import-failures-stats/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { importFailures } from '$lib/server/db/schema.js';
 import { count, eq, ne, and, gt } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsImportFailuresStats', logDomain: 'imports' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/reports/import-failures/[id]/retry/+server.ts
+++ b/src/routes/api/reports/import-failures/[id]/retry/+server.ts
@@ -4,7 +4,9 @@ import { db } from '$lib/server/db/index.js';
 import { importFailures, downloadQueue } from '$lib/server/db/schema.js';
 import { eq, or, and } from 'drizzle-orm';
 import { getImportService } from '$lib/server/downloadClients/import';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsImportFailuresRetry', logDomain: 'imports' });
 
 /**
  * POST /api/reports/import-failures/[id]/retry

--- a/src/routes/api/reports/rejected-releases/[id]/override/+server.ts
+++ b/src/routes/api/reports/rejected-releases/[id]/override/+server.ts
@@ -5,7 +5,9 @@ import { rejectedReleases, movies, series } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { grabService } from '$lib/server/downloads/GrabService.js';
 import { requireAuth } from '$lib/server/auth/authorization.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsRejectedOverride', logDomain: 'downloads' });
 
 /**
  * POST /api/reports/rejected-releases/[id]/override

--- a/src/routes/api/reports/rejected-stats/+server.ts
+++ b/src/routes/api/reports/rejected-stats/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { rejectedReleases } from '$lib/server/db/schema.js';
 import { count, eq, ne, and, gt } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsRejectedStats', logDomain: 'downloads' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/reports/renaming-failures-stats/+server.ts
+++ b/src/routes/api/reports/renaming-failures-stats/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { renamingFailures } from '$lib/server/db/schema.js';
 import { count, eq, ne, and, gt, or } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsRenamingFailuresStats', logDomain: 'scans' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/reports/renaming-failures/[id]/retry/+server.ts
+++ b/src/routes/api/reports/renaming-failures/[id]/retry/+server.ts
@@ -5,7 +5,9 @@ import { renamingFailures, movieFiles, episodeFiles } from '$lib/server/db/schem
 import { eq } from 'drizzle-orm';
 import { rename, mkdir, access } from 'fs/promises';
 import { dirname, basename } from 'path';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsRenamingFailuresRetry', logDomain: 'scans' });
 
 const NON_RETRYABLE = new Set(['source_not_found', 'path_too_long', 'invalid_chars']);
 

--- a/src/routes/api/reports/summary/+server.ts
+++ b/src/routes/api/reports/summary/+server.ts
@@ -8,7 +8,10 @@ import {
 	unmatchedFiles
 } from '$lib/server/db/schema.js';
 import { count, ne } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+// Cross-cutting summary across all four report types - not tied to one pipeline stage.
+const logger = createChildLogger({ module: 'ReportsSummary', logDomain: 'system' });
 
 /**
  * GET /api/reports/summary

--- a/src/routes/api/reports/unmatched-stats/+server.ts
+++ b/src/routes/api/reports/unmatched-stats/+server.ts
@@ -3,7 +3,9 @@ import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/db/index.js';
 import { unmatchedFiles } from '$lib/server/db/schema.js';
 import { count, gt, inArray } from 'drizzle-orm';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ReportsUnmatchedStats', logDomain: 'scans' });
 
 export const GET: RequestHandler = async () => {
 	try {

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -8,7 +8,8 @@ import {
 } from '$lib/server/indexers/types';
 import { searchQuerySchema } from '$lib/validation/schemas';
 import { qualityFilter, type EnrichmentOptions } from '$lib/server/quality';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { redactUrl } from '$lib/server/utils/urlSecurity';
 import { db } from '$lib/server/db';
 import { movies, series, settings } from '$lib/server/db/schema';
@@ -20,6 +21,8 @@ import {
 	fetchAndStoreMovieAlternateTitles,
 	fetchAndStoreSeriesAlternateTitles
 } from '$lib/server/services/AlternateTitleService';
+
+const logger = createChildLogger({ module: 'SearchApi', logDomain: 'system' });
 
 /**
  * Per-indexer search timeout for interactive searches.

--- a/src/routes/api/settings/external-url/+server.ts
+++ b/src/routes/api/settings/external-url/+server.ts
@@ -1,9 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { getSystemSettingsService } from '$lib/server/settings/SystemSettingsService.js';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'ExternalUrlSettingsApi', logDomain: 'system' });
 
 const externalUrlSchema = z.object({
 	url: z.string().url().nullable().or(z.literal(''))

--- a/src/routes/api/settings/logs/history/+server.ts
+++ b/src/routes/api/settings/logs/history/+server.ts
@@ -1,10 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import { logHistoryService } from '$lib/server/logging/log-history.js';
 import { logHistoryQuerySchema } from '$lib/validation/schemas.js';
+
+const logger = createChildLogger({ module: 'LogHistoryApi', logDomain: 'system' });
 
 export const GET: RequestHandler = async (event) => {
 	const authError = requireAdmin(event);

--- a/src/routes/api/settings/logs/settings/+server.ts
+++ b/src/routes/api/settings/logs/settings/+server.ts
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
 
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { DEFAULT_CAPTURED_LOG_LEVEL } from '$lib/logging/log-capture';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import {
@@ -10,6 +10,8 @@ import {
 	MAX_LOG_RETENTION_DAYS,
 	logHistoryService
 } from '$lib/server/logging/log-history.js';
+
+const logger = createChildLogger({ module: 'LogSettingsApi', logDomain: 'system' });
 
 const updateSettingsSchema = z.object({
 	retentionDays: z.coerce.number().int().min(1).max(MAX_LOG_RETENTION_DAYS).optional(),

--- a/src/routes/api/settings/logs/settings/+server.ts
+++ b/src/routes/api/settings/logs/settings/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 
 import { logger } from '$lib/logging';
+import { DEFAULT_CAPTURED_LOG_LEVEL } from '$lib/logging/log-capture';
 import { requireAdmin } from '$lib/server/auth/authorization.js';
 import {
 	DEFAULT_LOG_RETENTION_DAYS,
@@ -10,8 +11,9 @@ import {
 	logHistoryService
 } from '$lib/server/logging/log-history.js';
 
-const updateRetentionSchema = z.object({
-	retentionDays: z.coerce.number().int().min(1).max(MAX_LOG_RETENTION_DAYS)
+const updateSettingsSchema = z.object({
+	retentionDays: z.coerce.number().int().min(1).max(MAX_LOG_RETENTION_DAYS).optional(),
+	minLevel: z.enum(['debug', 'info', 'warn', 'error']).optional()
 });
 
 export const GET: RequestHandler = async (event) => {
@@ -19,19 +21,21 @@ export const GET: RequestHandler = async (event) => {
 	if (authError) return authError;
 
 	try {
-		const retentionDays = await logHistoryService.getRetentionDays();
+		const [retentionDays, minLevel] = await Promise.all([
+			logHistoryService.getRetentionDays(),
+			logHistoryService.getMinCaptureLevel()
+		]);
 		return json({
 			success: true,
 			retentionDays,
 			defaultRetentionDays: DEFAULT_LOG_RETENTION_DAYS,
-			maxRetentionDays: MAX_LOG_RETENTION_DAYS
+			maxRetentionDays: MAX_LOG_RETENTION_DAYS,
+			minLevel,
+			defaultMinLevel: DEFAULT_CAPTURED_LOG_LEVEL
 		});
 	} catch (error) {
-		logger.error({ err: error }, 'Failed to load log retention settings');
-		return json(
-			{ success: false, error: 'Failed to load log retention settings' },
-			{ status: 500 }
-		);
+		logger.error({ err: error }, 'Failed to load log settings');
+		return json({ success: false, error: 'Failed to load log settings' }, { status: 500 });
 	}
 };
 
@@ -46,7 +50,7 @@ export const PUT: RequestHandler = async (event) => {
 		return json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
 	}
 
-	const parsed = updateRetentionSchema.safeParse(body);
+	const parsed = updateSettingsSchema.safeParse(body);
 	if (!parsed.success) {
 		return json(
 			{
@@ -59,13 +63,17 @@ export const PUT: RequestHandler = async (event) => {
 	}
 
 	try {
-		const retentionDays = await logHistoryService.setRetentionDays(parsed.data.retentionDays);
-		return json({ success: true, retentionDays });
+		const [retentionDays, minLevel] = await Promise.all([
+			parsed.data.retentionDays !== undefined
+				? logHistoryService.setRetentionDays(parsed.data.retentionDays)
+				: logHistoryService.getRetentionDays(),
+			parsed.data.minLevel !== undefined
+				? logHistoryService.setMinCaptureLevel(parsed.data.minLevel)
+				: logHistoryService.getMinCaptureLevel()
+		]);
+		return json({ success: true, retentionDays, minLevel });
 	} catch (error) {
-		logger.error({ err: error }, 'Failed to update log retention settings');
-		return json(
-			{ success: false, error: 'Failed to update log retention settings' },
-			{ status: 500 }
-		);
+		logger.error({ err: error }, 'Failed to update log settings');
+		return json({ success: false, error: 'Failed to update log settings' }, { status: 500 });
 	}
 };

--- a/src/routes/api/settings/system/api-keys/+server.ts
+++ b/src/routes/api/settings/system/api-keys/+server.ts
@@ -5,7 +5,9 @@ import {
 	ensureDefaultApiKeysForUser,
 	getManagedApiKeysForRequest
 } from '$lib/server/auth/index.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'ApiKeysApi', logDomain: 'auth' });
 
 // POST /api/settings/system/api-keys - Auto-generate Main and Media Streaming API keys
 export const POST: RequestHandler = async (event) => {

--- a/src/routes/api/settings/system/api-keys/[id]/regenerate/+server.ts
+++ b/src/routes/api/settings/system/api-keys/[id]/regenerate/+server.ts
@@ -1,7 +1,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { regenerateRecoverableApiKey } from '$lib/server/auth/index.js';
+
+const logger = createChildLogger({ module: 'ApiKeysRegenerateApi', logDomain: 'auth' });
 
 // POST /api/settings/system/api-keys/[id]/regenerate - Regenerate an API key
 export const POST: RequestHandler = async ({ params, request, locals }) => {

--- a/src/routes/api/smartlists/external/preview/+server.ts
+++ b/src/routes/api/smartlists/external/preview/+server.ts
@@ -9,10 +9,15 @@ import type { RequestHandler } from './$types';
 import { providerRegistry } from '$lib/server/smartlists/providers/ProviderRegistry.js';
 import { externalIdResolver } from '$lib/server/smartlists/ExternalIdResolver.js';
 import { presetService } from '$lib/server/smartlists/presets/PresetService.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { z } from 'zod';
 import { smartListExternalPreviewSchema } from '$lib/validation/schemas.js';
 import { contentFilterPipeline } from '$lib/server/filters/ContentFilterPipeline.js';
+
+const logger = createChildLogger({
+	module: 'SmartListsExternalPreviewApi',
+	logDomain: 'monitoring'
+});
 
 export const POST: RequestHandler = async ({ request, url }) => {
 	const isTest = url.pathname.endsWith('/test');

--- a/src/routes/api/smartlists/preview/+server.ts
+++ b/src/routes/api/smartlists/preview/+server.ts
@@ -8,9 +8,11 @@ import type { RequestHandler } from './$types';
 import { tmdb, type DiscoverParams } from '$lib/server/tmdb.js';
 import { type SmartListFilters } from '$lib/server/db/schema.js';
 import { contentFilterPipeline } from '$lib/server/filters/ContentFilterPipeline.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { z } from 'zod';
 import { smartListPreviewSchema } from '$lib/validation/schemas.js';
+
+const logger = createChildLogger({ module: 'SmartListsPreviewApi', logDomain: 'monitoring' });
 
 function buildDiscoverParams(filters: SmartListFilters, sortBy: string): DiscoverParams {
 	const params: DiscoverParams = {

--- a/src/routes/api/smartlists/refresh-all/+server.ts
+++ b/src/routes/api/smartlists/refresh-all/+server.ts
@@ -6,7 +6,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'SmartListsRefreshAllApi', logDomain: 'monitoring' });
 
 export const POST: RequestHandler = async () => {
 	try {

--- a/src/routes/api/streaming/usenet/[mountId]/check/+server.ts
+++ b/src/routes/api/streaming/usenet/[mountId]/check/+server.ts
@@ -7,9 +7,11 @@
 
 import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { getUsenetStreamService } from '$lib/server/streaming/usenet/UsenetStreamService';
 import { getNzbMountManager } from '$lib/server/streaming/nzb/NzbMountManager';
+
+const logger = createChildLogger({ module: 'UsenetMountCheckApi', logDomain: 'streams' });
 
 export const GET: RequestHandler = async ({ params }) => {
 	const { mountId } = params;

--- a/src/routes/api/subtitles/auto-search/+server.ts
+++ b/src/routes/api/subtitles/auto-search/+server.ts
@@ -7,8 +7,10 @@ import { db } from '$lib/server/db';
 import { movies, episodes, series } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { parseBody, assertFound } from '$lib/server/api/validate.js';
+
+const logger = createChildLogger({ module: 'SubtitleAutoSearchApi', logDomain: 'subtitles' });
 
 const autoSearchSchema = z
 	.object({

--- a/src/routes/api/subtitles/auto-search/batch/+server.ts
+++ b/src/routes/api/subtitles/auto-search/batch/+server.ts
@@ -9,8 +9,10 @@ import { subtitleBatchAutoSearchSchema } from '$lib/validation/schemas.js';
 import type { SubtitleBatchAutoSearchRequest } from '$lib/validation/schemas.js';
 import { parseBody } from '$lib/server/api/validate.js';
 import { createSSEOperationStream } from '$lib/server/sse.js';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
 import type { SubtitleSearchResult } from '$lib/server/subtitles/types.js';
+
+const logger = createChildLogger({ module: 'SubtitleAutoSearchBatchApi', logDomain: 'subtitles' });
 
 interface BatchProgressEvent {
 	current: number;

--- a/src/routes/api/subtitles/language-profiles/bulk-assign/+server.ts
+++ b/src/routes/api/subtitles/language-profiles/bulk-assign/+server.ts
@@ -7,8 +7,13 @@ import { inArray, and, eq } from 'drizzle-orm';
 import { LanguageProfileService } from '$lib/server/subtitles/services/LanguageProfileService';
 import { searchSubtitlesForMediaBatch } from '$lib/server/subtitles/services/SubtitleImportService';
 import { monitoringScheduler } from '$lib/server/monitoring/MonitoringScheduler';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { parseBody, assertFound } from '$lib/server/api/validate.js';
+
+const logger = createChildLogger({
+	module: 'SubtitleLanguageProfileBulkAssignApi',
+	logDomain: 'subtitles'
+});
 
 /**
  * Schema for bulk profile assignment request

--- a/src/routes/api/subtitles/providers/reorder/+server.ts
+++ b/src/routes/api/subtitles/providers/reorder/+server.ts
@@ -2,8 +2,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { getSubtitleProviderManager } from '$lib/server/subtitles/services/SubtitleProviderManager';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { parseBody } from '$lib/server/api/validate.js';
+
+const logger = createChildLogger({ module: 'SubtitleProviderReorderApi', logDomain: 'subtitles' });
 
 /**
  * Schema for reordering providers

--- a/src/routes/api/tasks/history/[historyId]/activity/+server.ts
+++ b/src/routes/api/tasks/history/[historyId]/activity/+server.ts
@@ -10,7 +10,9 @@ import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { monitoringHistory, movies, series, episodes } from '$lib/server/db/schema.js';
 import { eq, desc } from 'drizzle-orm';
-import { logger } from '$lib/logging/index.js';
+import { createChildLogger } from '$lib/logging/index.js';
+
+const logger = createChildLogger({ module: 'TaskHistoryActivityApi', logDomain: 'monitoring' });
 
 export interface ActivityItem {
 	id: string;

--- a/src/routes/api/user/language/+server.ts
+++ b/src/routes/api/user/language/+server.ts
@@ -4,9 +4,12 @@ import { db } from '$lib/server/db';
 import { user } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { locales } from '$lib/paraglide/runtime.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { parseBody } from '$lib/server/api/validate.js';
 import { z } from 'zod';
+
+const logger = createChildLogger({ module: 'UserLanguageApi', logDomain: 'system' });
 
 const userLanguageSchema = z.object({
 	language: z.string().min(1, 'Language is required')

--- a/src/routes/calendar/+page.server.ts
+++ b/src/routes/calendar/+page.server.ts
@@ -3,7 +3,9 @@ import { getCalendarData } from '$lib/server/calendar/queries.js';
 import { getCalendarPreferences } from '$lib/server/settings/calendar-preferences.js';
 import { calendarPreferencesSchema } from '$lib/validation/schemas.js';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'CalendarPage', logDomain: 'system' });
 
 export const load: PageServerLoad = async ({ url }) => {
 	const monthParam = url.searchParams.get('month');

--- a/src/routes/discover/+page.server.ts
+++ b/src/routes/discover/+page.server.ts
@@ -3,7 +3,8 @@ import { getDiscoverResults } from '$lib/server/discover';
 import { contentFilterPipeline } from '$lib/server/filters/ContentFilterPipeline.js';
 import type { WatchProvider } from '$lib/types/tmdb';
 import type { TmdbCertificationsResponse } from '$lib/server/tmdb';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import {
 	parseDiscoverParams,
 	isDefaultView as checkDefaultView,
@@ -16,6 +17,8 @@ import { settings } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 
 import type { PageServerLoad } from './$types';
+
+const logger = createChildLogger({ module: 'DiscoverPage', logDomain: 'system' });
 
 export const load: PageServerLoad = async ({ url }) => {
 	const params = parseDiscoverParams(url.searchParams);

--- a/src/routes/discover/movie/[id]/+page.server.ts
+++ b/src/routes/discover/movie/[id]/+page.server.ts
@@ -1,7 +1,8 @@
 import { tmdb } from '$lib/server/tmdb';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import {
 	enrichWithLibraryStatus,
 	getLibraryStatus,
@@ -9,6 +10,8 @@ import {
 } from '$lib/server/library/status';
 import { keywordBlocklistService } from '$lib/server/settings/KeywordBlocklistService.js';
 import { enrichWithReleaseDates } from '$lib/server/release-enrichment.js';
+
+const logger = createChildLogger({ module: 'DiscoverMoviePage', logDomain: 'system' });
 
 export const load: PageServerLoad = async ({ params }) => {
 	const id = parseInt(params.id);

--- a/src/routes/discover/person/[id]/+page.server.ts
+++ b/src/routes/discover/person/[id]/+page.server.ts
@@ -1,7 +1,9 @@
 import { tmdb } from '$lib/server/tmdb';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'DiscoverPersonPage', logDomain: 'system' });
 
 export const load: PageServerLoad = async ({ params }) => {
 	const id = parseInt(params.id);

--- a/src/routes/discover/tv/[id]/+page.server.ts
+++ b/src/routes/discover/tv/[id]/+page.server.ts
@@ -1,13 +1,16 @@
 import { tmdb } from '$lib/server/tmdb';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import {
 	enrichWithLibraryStatus,
 	getLibraryStatus,
 	filterBlockedMedia
 } from '$lib/server/library/status';
 import { keywordBlocklistService } from '$lib/server/settings/KeywordBlocklistService.js';
+
+const logger = createChildLogger({ module: 'DiscoverTvPage', logDomain: 'system' });
 
 export const load: PageServerLoad = async ({ params }) => {
 	const id = parseInt(params.id);

--- a/src/routes/library/movie/[id]/+page.server.ts
+++ b/src/routes/library/movie/[id]/+page.server.ts
@@ -15,11 +15,13 @@ import type { PageServerLoad } from './$types';
 import type { LibraryMovie, MovieFile, QualityProfileSummary } from '$lib/types/library';
 import type { MovieDetails } from '$lib/types/tmdb';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging';
 import { isMovieSearching } from '$lib/server/library/ActiveSearchTracker.js';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMoviePage', logDomain: 'scans' });
 
 export interface QueueItemInfo {
 	id: string;

--- a/src/routes/library/movies/+page.server.ts
+++ b/src/routes/library/movies/+page.server.ts
@@ -10,10 +10,12 @@ import {
 import { eq, and, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { Actions, PageServerLoad } from './$types';
 import type { LibraryMovie, MovieFile, QualityProfileSummary } from '$lib/types/library';
-import { logger } from '$lib/logging';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryMoviesListPage', logDomain: 'scans' });
 
 export const load: PageServerLoad = async ({ url }) => {
 	// Parse URL params for sorting and filtering

--- a/src/routes/library/movies/+page.server.ts
+++ b/src/routes/library/movies/+page.server.ts
@@ -7,7 +7,7 @@ import {
 	scoringProfiles,
 	downloadQueue
 } from '$lib/server/db/schema.js';
-import { eq, and, inArray, isNotNull } from 'drizzle-orm';
+import { eq, and, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { Actions, PageServerLoad } from './$types';
 import type { LibraryMovie, MovieFile, QualityProfileSummary } from '$lib/types/library';
 import { logger } from '$lib/logging';
@@ -177,26 +177,36 @@ export const load: PageServerLoad = async ({ url }) => {
 			).length
 		}));
 
-		// Extract unique file attribute values for filter dropdowns
-		const uniqueResolutions = new Set<string>();
-		const uniqueCodecs = new Set<string>();
-		const uniqueHdrFormats = new Set<string>();
-
-		for (const movie of moviesWithFiles) {
-			for (const file of movie.files) {
-				if (file.quality?.resolution) uniqueResolutions.add(file.quality.resolution);
-				if (file.mediaInfo?.videoCodec) uniqueCodecs.add(file.mediaInfo.videoCodec);
-				if (file.mediaInfo?.hdrFormat) uniqueHdrFormats.add(file.mediaInfo.hdrFormat);
-			}
-		}
-
-		const uniqueCollections = new Set<string>();
-		for (const movie of moviesWithFiles) {
-			if (movie.collectionName) {
-				uniqueCollections.add(movie.collectionName);
-			}
-		}
-		const sortedCollections = [...uniqueCollections].sort();
+		// Unique file attribute values for filter dropdowns.
+		const resolutionExpr = sql`json_extract(${movieFiles.quality}, '$.resolution')`;
+		const codecExpr = sql`json_extract(${movieFiles.mediaInfo}, '$.videoCodec')`;
+		const hdrExpr = sql`json_extract(${movieFiles.mediaInfo}, '$.hdrFormat')`;
+		const [resolutionRows, codecRows, hdrRows, collectionRows] = await Promise.all([
+			db
+				.select({ value: resolutionExpr.as('value') })
+				.from(movieFiles)
+				.where(sql`${resolutionExpr} IS NOT NULL`)
+				.groupBy(resolutionExpr),
+			db
+				.select({ value: codecExpr.as('value') })
+				.from(movieFiles)
+				.where(sql`${codecExpr} IS NOT NULL`)
+				.groupBy(codecExpr),
+			db
+				.select({ value: hdrExpr.as('value') })
+				.from(movieFiles)
+				.where(sql`${hdrExpr} IS NOT NULL`)
+				.groupBy(hdrExpr),
+			db
+				.select({ value: movies.collectionName })
+				.from(movies)
+				.where(isNotNull(movies.collectionName))
+				.groupBy(movies.collectionName)
+		]);
+		const uniqueResolutions = new Set(resolutionRows.map((r) => r.value as string));
+		const uniqueCodecs = new Set(codecRows.map((r) => r.value as string));
+		const uniqueHdrFormats = new Set(hdrRows.map((r) => r.value as string));
+		const sortedCollections = collectionRows.map((r) => r.value as string).sort();
 
 		// Fetch quality profiles and resolve the effective default profile ID
 		const dbProfiles = await db
@@ -411,16 +421,23 @@ export const actions: Actions = {
 				return { success: true };
 			}
 
-			const allMovies = await db
+			// Movies with a real libraryId (the modern, common case) can be updated
+			// directly with no SELECT at all. Only legacy movies with libraryId
+			// NULL need the join-based subtype inference below, so that fallback
+			// query is scoped to just that (shrinking, legacy-only) subset instead
+			// of every movie in the library.
+			await db.update(movies).set({ monitored }).where(eq(movies.libraryId, selectedLibrary.id));
+
+			const legacyMovies = await db
 				.select({
 					id: movies.id,
-					libraryId: movies.libraryId,
 					rootFolderMediaSubType: rootFolders.mediaSubType,
 					libraryMediaSubType: libraries.mediaSubType
 				})
 				.from(movies)
 				.leftJoin(rootFolders, eq(movies.rootFolderId, rootFolders.id))
-				.leftJoin(libraries, eq(movies.libraryId, libraries.id));
+				.leftJoin(libraries, eq(movies.libraryId, libraries.id))
+				.where(isNull(movies.libraryId));
 
 			const inferLegacySubtype = (movie: {
 				rootFolderMediaSubType?: string | null;
@@ -430,11 +447,8 @@ export const actions: Actions = {
 				return candidate === 'anime' ? 'anime' : 'standard';
 			};
 
-			const scopedIds = allMovies
+			const legacyScopedIds = legacyMovies
 				.filter((movie) => {
-					if (movie.libraryId) {
-						return movie.libraryId === selectedLibrary.id;
-					}
 					const inferredSubtype = inferLegacySubtype(movie);
 					if (selectedLibrary.mediaSubType === 'anime') return inferredSubtype === 'anime';
 					if (selectedLibrary.mediaSubType === 'standard') return inferredSubtype === 'standard';
@@ -442,8 +456,8 @@ export const actions: Actions = {
 				})
 				.map((m) => m.id);
 
-			if (scopedIds.length > 0) {
-				await db.update(movies).set({ monitored }).where(inArray(movies.id, scopedIds));
+			if (legacyScopedIds.length > 0) {
+				await db.update(movies).set({ monitored }).where(inArray(movies.id, legacyScopedIds));
 			}
 
 			libraryMediaEvents.emitLibraryDataChanged({

--- a/src/routes/library/tv/+page.server.ts
+++ b/src/routes/library/tv/+page.server.ts
@@ -9,7 +9,7 @@ import {
 	episodeFiles,
 	downloadQueue
 } from '$lib/server/db/schema.js';
-import { eq, and, inArray, ne, isNotNull } from 'drizzle-orm';
+import { eq, and, inArray, ne, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { Actions, PageServerLoad } from './$types';
 import type { LibrarySeries, EpisodeFile, QualityProfileSummary } from '$lib/types/library';
 import { logger } from '$lib/logging';
@@ -127,16 +127,46 @@ export const load: PageServerLoad = async ({ url }) => {
 			}
 		}
 
-		// Fetch all episode files for file-type filtering, size aggregation, and derived episode-file counts.
-		const allEpisodeFiles = await db
-			.select({
-				seriesId: episodeFiles.seriesId,
-				episodeIds: episodeFiles.episodeIds,
-				size: episodeFiles.size,
-				quality: episodeFiles.quality,
-				mediaInfo: episodeFiles.mediaInfo
-			})
-			.from(episodeFiles);
+		// Fetch all episode files for file-type filtering and derived episode-file
+		// counts (episodeIds is a JSON array cross-referenced against aired
+		// episodes below.
+		const resolutionExpr = sql`json_extract(${episodeFiles.quality}, '$.resolution')`;
+		const codecExpr = sql`json_extract(${episodeFiles.mediaInfo}, '$.videoCodec')`;
+		const hdrExpr = sql`json_extract(${episodeFiles.mediaInfo}, '$.hdrFormat')`;
+		const [allEpisodeFiles, sizeBySeriesRows, resolutionRows, codecRows, hdrRows] =
+			await Promise.all([
+				db
+					.select({
+						seriesId: episodeFiles.seriesId,
+						episodeIds: episodeFiles.episodeIds,
+						size: episodeFiles.size,
+						quality: episodeFiles.quality,
+						mediaInfo: episodeFiles.mediaInfo
+					})
+					.from(episodeFiles),
+				db
+					.select({
+						seriesId: episodeFiles.seriesId,
+						total: sql<number>`coalesce(sum(${episodeFiles.size}), 0)`
+					})
+					.from(episodeFiles)
+					.groupBy(episodeFiles.seriesId),
+				db
+					.select({ value: resolutionExpr.as('value') })
+					.from(episodeFiles)
+					.where(sql`${resolutionExpr} IS NOT NULL`)
+					.groupBy(resolutionExpr),
+				db
+					.select({ value: codecExpr.as('value') })
+					.from(episodeFiles)
+					.where(sql`${codecExpr} IS NOT NULL`)
+					.groupBy(codecExpr),
+				db
+					.select({ value: hdrExpr.as('value') })
+					.from(episodeFiles)
+					.where(sql`${hdrExpr} IS NOT NULL`)
+					.groupBy(hdrExpr)
+			]);
 
 		const episodeFilesBySeries = new Map<string, Set<string>>();
 		for (const file of allEpisodeFiles) {
@@ -156,14 +186,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		}
 
 		// Calculate percentages and format data using derived episode/file linkage (source of truth).
-		// Build seriesId -> total size map
-		const seriesTotalSizeMap = new Map<string, number>();
-		for (const file of allEpisodeFiles) {
-			seriesTotalSizeMap.set(
-				file.seriesId,
-				(seriesTotalSizeMap.get(file.seriesId) ?? 0) + (file.size ?? 0)
-			);
-		}
+		const seriesTotalSizeMap = new Map(sizeBySeriesRows.map((r) => [r.seriesId, r.total]));
 
 		const seriesWithStats: (LibrarySeries & {
 			libraryId?: string | null;
@@ -240,18 +263,10 @@ export const load: PageServerLoad = async ({ url }) => {
 			).length
 		}));
 
-		// Extract unique file attribute values for filter dropdowns
-		const uniqueResolutions = new Set<string>();
-		const uniqueCodecs = new Set<string>();
-		const uniqueHdrFormats = new Set<string>();
-
-		for (const file of allEpisodeFiles) {
-			const quality = file.quality as EpisodeFile['quality'];
-			const mediaInfo = file.mediaInfo as EpisodeFile['mediaInfo'];
-			if (quality?.resolution) uniqueResolutions.add(quality.resolution);
-			if (mediaInfo?.videoCodec) uniqueCodecs.add(mediaInfo.videoCodec);
-			if (mediaInfo?.hdrFormat) uniqueHdrFormats.add(mediaInfo.hdrFormat);
-		}
+		// Unique file attribute values for filter dropdowns.
+		const uniqueResolutions = new Set(resolutionRows.map((r) => r.value as string));
+		const uniqueCodecs = new Set(codecRows.map((r) => r.value as string));
+		const uniqueHdrFormats = new Set(hdrRows.map((r) => r.value as string));
 
 		// Fetch quality profiles and resolve the effective default profile ID
 		const dbProfiles = await db
@@ -279,27 +294,38 @@ export const load: PageServerLoad = async ({ url }) => {
 			isDefault: p.id === resolvedDefaultId
 		}));
 
-		// Build sets of series IDs that have matching files (for filtering)
+		// Build sets of series IDs that have matching files (for filtering).
 		const seriesWithResolution = new Set<string>();
 		const seriesWithCodec = new Set<string>();
 		const seriesWithHdr = new Set<string>();
 		const seriesWithSdr = new Set<string>();
+		const needsResolutionMembership = resolution !== 'all';
+		const needsCodecMembership = videoCodec !== 'all';
+		const needsSdrMembership = hdrFormat === 'sdr';
+		const needsHdrMembership = hdrFormat !== 'all' && hdrFormat !== 'sdr';
 
-		for (const file of allEpisodeFiles) {
-			const quality = file.quality as EpisodeFile['quality'];
-			const mediaInfo = file.mediaInfo as EpisodeFile['mediaInfo'];
+		if (
+			needsResolutionMembership ||
+			needsCodecMembership ||
+			needsSdrMembership ||
+			needsHdrMembership
+		) {
+			for (const file of allEpisodeFiles) {
+				const quality = file.quality as EpisodeFile['quality'];
+				const mediaInfo = file.mediaInfo as EpisodeFile['mediaInfo'];
 
-			if (resolution !== 'all' && quality?.resolution === resolution) {
-				seriesWithResolution.add(file.seriesId);
-			}
-			if (videoCodec !== 'all' && mediaInfo?.videoCodec === videoCodec) {
-				seriesWithCodec.add(file.seriesId);
-			}
-			if (!mediaInfo?.hdrFormat) {
-				seriesWithSdr.add(file.seriesId);
-			}
-			if (hdrFormat !== 'all' && hdrFormat !== 'sdr' && mediaInfo?.hdrFormat === hdrFormat) {
-				seriesWithHdr.add(file.seriesId);
+				if (needsResolutionMembership && quality?.resolution === resolution) {
+					seriesWithResolution.add(file.seriesId);
+				}
+				if (needsCodecMembership && mediaInfo?.videoCodec === videoCodec) {
+					seriesWithCodec.add(file.seriesId);
+				}
+				if (needsSdrMembership && !mediaInfo?.hdrFormat) {
+					seriesWithSdr.add(file.seriesId);
+				}
+				if (needsHdrMembership && mediaInfo?.hdrFormat === hdrFormat) {
+					seriesWithHdr.add(file.seriesId);
+				}
 			}
 		}
 
@@ -480,18 +506,10 @@ export const actions: Actions = {
 				) ?? defaultLibrary;
 
 			if (!selectedLibrary) {
-				const allSeriesIds = (await db.select({ id: series.id }).from(series)).map((s) => s.id);
+				// Global toggle across every series - no scoping needed for the cascade.
 				await db.update(series).set({ monitored });
-				if (allSeriesIds.length > 0) {
-					await db
-						.update(seasons)
-						.set({ monitored })
-						.where(inArray(seasons.seriesId, allSeriesIds));
-					await db
-						.update(episodes)
-						.set({ monitored })
-						.where(inArray(episodes.seriesId, allSeriesIds));
-				}
+				await db.update(seasons).set({ monitored });
+				await db.update(episodes).set({ monitored });
 				libraryMediaEvents.emitLibraryDataChanged({
 					source: 'series',
 					reason: 'toggle-all-monitored'
@@ -499,16 +517,31 @@ export const actions: Actions = {
 				return { success: true };
 			}
 
-			const allSeries = await db
+			// Series with a real libraryId (the modern, common case) can be updated
+			// and cascaded directly via a correlated subquery - no row fetch needed.
+			// Only legacy series with libraryId NULL need the join-based subtype
+			// inference below, scoped to just that (shrinking) subset.
+			const modernSeriesIds = db
+				.select({ id: series.id })
+				.from(series)
+				.where(eq(series.libraryId, selectedLibrary.id));
+			await db.update(series).set({ monitored }).where(eq(series.libraryId, selectedLibrary.id));
+			await db.update(seasons).set({ monitored }).where(inArray(seasons.seriesId, modernSeriesIds));
+			await db
+				.update(episodes)
+				.set({ monitored })
+				.where(inArray(episodes.seriesId, modernSeriesIds));
+
+			const legacySeries = await db
 				.select({
 					id: series.id,
-					libraryId: series.libraryId,
 					rootFolderMediaSubType: rootFolders.mediaSubType,
 					libraryMediaSubType: libraries.mediaSubType
 				})
 				.from(series)
 				.leftJoin(rootFolders, eq(series.rootFolderId, rootFolders.id))
-				.leftJoin(libraries, eq(series.libraryId, libraries.id));
+				.leftJoin(libraries, eq(series.libraryId, libraries.id))
+				.where(isNull(series.libraryId));
 
 			const inferLegacySubtype = (show: {
 				rootFolderMediaSubType?: string | null;
@@ -518,11 +551,8 @@ export const actions: Actions = {
 				return candidate === 'anime' ? 'anime' : 'standard';
 			};
 
-			const scopedIds = allSeries
+			const scopedIds = legacySeries
 				.filter((show) => {
-					if (show.libraryId) {
-						return show.libraryId === selectedLibrary.id;
-					}
 					const inferredSubtype = inferLegacySubtype(show);
 					if (selectedLibrary.mediaSubType === 'anime') return inferredSubtype === 'anime';
 					if (selectedLibrary.mediaSubType === 'standard') return inferredSubtype === 'standard';

--- a/src/routes/library/tv/+page.server.ts
+++ b/src/routes/library/tv/+page.server.ts
@@ -12,12 +12,14 @@ import {
 import { eq, and, inArray, ne, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { Actions, PageServerLoad } from './$types';
 import type { LibrarySeries, EpisodeFile, QualityProfileSummary } from '$lib/types/library';
-import { logger } from '$lib/logging';
 import { todayDateString } from '$lib/utils/format.js';
 import { matchesSeriesStatusFilter } from '$lib/utils/format-status.js';
 import { getLibraryEntityService } from '$lib/server/library/LibraryEntityService.js';
 import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
 import { libraryMediaEvents } from '$lib/server/library/LibraryMediaEvents.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryTvListPage', logDomain: 'scans' });
 
 export const load: PageServerLoad = async ({ url }) => {
 	// Parse URL params for sorting and filtering

--- a/src/routes/library/tv/[id]/+page.server.ts
+++ b/src/routes/library/tv/[id]/+page.server.ts
@@ -19,9 +19,11 @@ import { ACTIVE_DOWNLOAD_STATUSES } from '$lib/types/queue';
 import type { QualityProfileSummary } from '$lib/types/library';
 import type { TVShowDetails } from '$lib/types/tmdb';
 import { tmdb } from '$lib/server/tmdb.js';
-import { logger } from '$lib/logging';
 import { resolveMissingAnimeProviderRefs } from '$lib/server/metadata/provider-ref-resolver.js';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
+import { createChildLogger } from '$lib/logging';
+
+const logger = createChildLogger({ module: 'LibraryTvPage', logDomain: 'scans' });
 
 export interface SeasonWithEpisodes {
 	id: string;

--- a/src/routes/settings/library/filters/+page.server.ts
+++ b/src/routes/settings/library/filters/+page.server.ts
@@ -4,8 +4,11 @@ import { tmdb } from '$lib/server/tmdb';
 import { eq } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 import type { GlobalTmdbFilters } from '$lib/types/tmdb';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
 import { TMDB } from '$lib/config/constants.js';
+
+// TMDB content-filter settings (genre exclusions etc.), not disk scanning - 'system' fits better than 'scans'.
+const logger = createChildLogger({ module: 'LibraryFiltersSettingsPage', logDomain: 'system' });
 
 export const load: PageServerLoad = async () => {
 	// Fetch current settings

--- a/src/routes/settings/library/libraries/+page.svelte
+++ b/src/routes/settings/library/libraries/+page.svelte
@@ -250,7 +250,7 @@
 						<span class="label-text text-base-content">
 							{m.settings_libraries_scan_watch()}
 						</span>
-						<div class="text-xs text-base-content/60">
+						<div class="text-xs whitespace-normal text-base-content/60">
 							{m.settings_libraries_scan_watch_hint()}
 						</div>
 					</div>
@@ -267,7 +267,7 @@
 						<span class="label-text text-base-content">
 							{m.settings_libraries_scan_on_startup()}
 						</span>
-						<div class="text-xs text-base-content/60">
+						<div class="text-xs whitespace-normal text-base-content/60">
 							{m.settings_libraries_scan_on_startup_hint()}
 						</div>
 					</div>

--- a/src/routes/settings/library/naming/rename/+page.svelte
+++ b/src/routes/settings/library/naming/rename/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { SvelteSet } from 'svelte/reactivity';
 	import * as m from '$lib/paraglide/messages.js';
-	import { getRenamePreview, executeRename, reorganizeFolderBatch } from '$lib/api/settings.js';
+	import { executeRename, reorganizeFolderBatch } from '$lib/api/settings.js';
 	import {
 		RefreshCw,
 		CheckCircle,
@@ -20,11 +20,17 @@
 		FileEdit,
 		FolderSync
 	} from 'lucide-svelte';
-	import type { RenamePreviewResult, RenameExecuteResult } from '$lib/library/naming/types.js';
+	import type {
+		RenamePreviewResult,
+		RenameExecuteResult,
+		RenameStreamEvent
+	} from '$lib/library/naming/types.js';
 	import { chunkFileIds } from '$lib/library/naming/batch-rename';
 
 	// State
 	let loading = $state(true);
+	let computing = $state(false); // true while streaming items after counts arrived
+	let computingTotal = $state(0); // estimated total from "start" event for progress
 	let executing = $state(false);
 	let confirmPending = $state(false);
 	let reorganizing = $state(false);
@@ -54,32 +60,108 @@
 
 	async function loadPreview() {
 		loading = true;
+		computing = false;
+		computingTotal = 0;
+		error = null;
+		preview = {
+			willChange: [],
+			alreadyCorrect: [],
+			collisions: [],
+			errors: [],
+			totalFiles: 0,
+			totalWillChange: 0,
+			totalAlreadyCorrect: 0,
+			totalCollisions: 0,
+			totalErrors: 0
+		};
+		selectedIds.clear();
+		confirmPending = false;
+
+		// Kick off scan-status check in parallel with the stream.
+		fetch('/api/library/scan/status')
+			.then((r) => r.json())
+			.then((s) => {
+				scanInProgress = Boolean(s?.scanning);
+			})
+			.catch(() => {});
 
 		try {
-			const [result, scanStatus] = await Promise.all([
-				getRenamePreview(mediaTypeFilter),
-				fetch('/api/library/scan/status')
-					.then((r) => r.json())
-					.catch(() => ({ scanning: false }))
-			]);
-			scanInProgress = Boolean(scanStatus?.scanning);
+			const params = new URLSearchParams({ mediaType: mediaTypeFilter });
+			const res = await fetch(`/api/rename/preview?${params}`);
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
-			if (!result.success) {
-				throw new Error(result.error || 'Failed to load preview');
+			const body = res.body;
+			if (!body) throw new Error('Empty response');
+
+			const reader = body.getReader();
+			const decoder = new TextDecoder();
+			let buf = '';
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buf += decoder.decode(value, { stream: true });
+				const lines = buf.split('\n');
+				buf = lines.pop() ?? '';
+				for (const line of lines) {
+					if (line.trim()) handleStreamEvent(JSON.parse(line) as RenameStreamEvent);
+				}
 			}
-
-			preview = result as unknown as RenamePreviewResult;
-
-			// Auto-select all "will change" items
-			selectedIds.clear();
-			for (const item of preview?.willChange || []) {
-				selectedIds.add(item.fileId);
-			}
-			confirmPending = false;
+			if (buf.trim()) handleStreamEvent(JSON.parse(buf) as RenameStreamEvent);
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load preview';
 		} finally {
 			loading = false;
+			computing = false;
+		}
+	}
+
+	function handleStreamEvent(msg: RenameStreamEvent) {
+		if (!preview) return;
+
+		if (msg.type === 'start') {
+			computingTotal = msg.totalFiles;
+			computing = msg.computing;
+			loading = false;
+		} else if (msg.type === 'items') {
+			if (msg.category === 'willChange') {
+				preview.willChange.push(...msg.data);
+				preview.totalWillChange = preview.willChange.length;
+				for (const item of msg.data) selectedIds.add(item.fileId);
+			} else if (msg.category === 'alreadyCorrect') {
+				preview.alreadyCorrect.push(...msg.data);
+				preview.totalAlreadyCorrect = preview.alreadyCorrect.length;
+			} else if (msg.category === 'collisions') {
+				// Items sent here may have been tentatively added to willChange during
+				// a cold-cache stream; remove them from willChange before adding to collisions.
+				const collisionIds = new Set(msg.data.map((i) => i.fileId));
+				preview.willChange = preview.willChange.filter((i) => !collisionIds.has(i.fileId));
+				for (const id of collisionIds) selectedIds.delete(id);
+				preview.collisions.push(...msg.data);
+				preview.totalWillChange = preview.willChange.length;
+				preview.totalCollisions = preview.collisions.length;
+			} else if (msg.category === 'errors') {
+				preview.errors.push(...msg.data);
+				preview.totalErrors = preview.errors.length;
+			}
+			preview.totalFiles =
+				preview.totalWillChange +
+				preview.totalAlreadyCorrect +
+				preview.totalCollisions +
+				preview.totalErrors;
+		} else if (msg.type === 'done') {
+			// Finalize with accurate server-computed counts.
+			preview.totalFiles = msg.totalFiles;
+			preview.totalWillChange = msg.totalWillChange;
+			preview.totalAlreadyCorrect = msg.totalAlreadyCorrect;
+			preview.totalCollisions = msg.totalCollisions;
+			preview.totalErrors = msg.totalErrors;
+			loading = false;
+			computing = false;
+		} else if (msg.type === 'error') {
+			error = msg.message;
+			loading = false;
+			computing = false;
 		}
 	}
 
@@ -408,6 +490,22 @@
 			</div>
 		</div>
 	{:else if preview}
+		{#if computing}
+			<!-- Computing banner: counts visible but items still streaming -->
+			<div
+				class="mb-4 flex items-center gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3"
+			>
+				<RefreshCw class="h-4 w-4 shrink-0 animate-spin text-primary" />
+				<div class="min-w-0 flex-1">
+					<p class="text-sm font-medium">Computing rename preview…</p>
+					{#if computingTotal > 0}
+						<p class="text-xs text-base-content/60">
+							{preview.totalFiles.toLocaleString()} / {computingTotal.toLocaleString()} files processed
+						</p>
+					{/if}
+				</div>
+			</div>
+		{/if}
 		<!-- Media Type Filter & Summary -->
 		<div class="mb-6 space-y-4">
 			<!-- Media Type Pills -->

--- a/src/routes/settings/monitoring/logs/+page.server.ts
+++ b/src/routes/settings/monitoring/logs/+page.server.ts
@@ -1,7 +1,11 @@
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
 
-import { CAPTURED_LOG_DOMAINS, CAPTURED_LOG_LEVELS } from '$lib/logging/log-capture';
+import {
+	CAPTURED_LOG_DOMAINS,
+	CAPTURED_LOG_LEVELS,
+	DEFAULT_CAPTURED_LOG_LEVEL
+} from '$lib/logging/log-capture';
 import {
 	DEFAULT_LOG_RETENTION_DAYS,
 	MAX_LOG_RETENTION_DAYS,
@@ -37,6 +41,8 @@ export const load = async ({ locals }: RequestEvent) => {
 		availableDomains: [...CAPTURED_LOG_DOMAINS],
 		retentionDays: await logHistoryService.getRetentionDays(),
 		defaultRetentionDays: DEFAULT_LOG_RETENTION_DAYS,
-		maxRetentionDays: MAX_LOG_RETENTION_DAYS
+		maxRetentionDays: MAX_LOG_RETENTION_DAYS,
+		minLevel: await logHistoryService.getMinCaptureLevel(),
+		defaultMinLevel: DEFAULT_CAPTURED_LOG_LEVEL
 	};
 };

--- a/src/routes/settings/monitoring/logs/+page.svelte
+++ b/src/routes/settings/monitoring/logs/+page.svelte
@@ -7,10 +7,11 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { SettingsPage } from '$lib/components/ui/settings';
 	import { layoutState, deriveMobileSseStatus } from '$lib/layout.svelte';
-	import type {
-		CapturedLogDomain,
-		CapturedLogEntry,
-		CapturedLogLevel
+	import {
+		DOMAIN_LABELS,
+		type CapturedLogDomain,
+		type CapturedLogEntry,
+		type CapturedLogLevel
 	} from '$lib/logging/log-capture';
 	import { createDynamicSSE } from '$lib/sse';
 	import { toasts } from '$lib/stores/toast.svelte';
@@ -32,6 +33,8 @@
 		retentionDays: number;
 		defaultRetentionDays: number;
 		maxRetentionDays: number;
+		minLevel: CapturedLogLevel;
+		defaultMinLevel: CapturedLogLevel;
 	}
 
 	interface LogHistoryResponse {
@@ -45,13 +48,43 @@
 	}
 
 	const LIVE_BUFFER_LIMIT = 300;
+	const MAX_LIVE_ENTRIES = 500;
+	const MAX_TOTAL_ENTRIES = 5000;
 	const DEFAULT_LEVELS: CapturedLogLevel[] = ['debug', 'info', 'warn', 'error'];
+	const VIEW_FILTER_STORAGE_KEY = 'cinephage.logs.viewFilter';
+
+	interface StoredViewFilter {
+		levels?: CapturedLogLevel[];
+		domain?: CapturedLogDomain | 'all';
+	}
+
+	function loadStoredViewFilter(): StoredViewFilter | null {
+		if (typeof window === 'undefined') return null;
+		try {
+			const raw = window.localStorage.getItem(VIEW_FILTER_STORAGE_KEY);
+			if (!raw) return null;
+			return JSON.parse(raw) as StoredViewFilter;
+		} catch {
+			return null;
+		}
+	}
+
+	function saveViewFilter(): void {
+		if (typeof window === 'undefined') return;
+		try {
+			const stored: StoredViewFilter = { levels: [...levels], domain: selectedDomain };
+			window.localStorage.setItem(VIEW_FILTER_STORAGE_KEY, JSON.stringify(stored));
+		} catch {
+			/* localStorage unavailable (private mode, quota, etc.) - view filter just won't persist */
+		}
+	}
 
 	let { data }: { data: PageData } = $props();
 	const availableLevels = $derived(data.availableLevels);
 	const availableDomains = $derived(data.availableDomains);
 	const defaultRetentionDays = $derived(data.defaultRetentionDays);
 	const maxRetentionDays = $derived(data.maxRetentionDays);
+	const defaultMinLevel = $derived(data.defaultMinLevel);
 
 	let entries = $state<CapturedLogEntry[]>([]);
 	let historyLoading = $state(false);
@@ -73,7 +106,10 @@
 	let to = $state('');
 
 	let retentionDays = $state(7);
-	let retentionSaving = $state(false);
+	let minLevel = $state<CapturedLogLevel>('info');
+	let logSettingsSaving = $state(false);
+	let logSettingsOpen = $state(false);
+	let logSettingsContainer = $state<HTMLDivElement | null>(null);
 
 	let livePaused = $state(false);
 	let autoFollowEnabled = $state(true);
@@ -111,17 +147,31 @@
 			historyPagesLoaded.add(data.initialPage);
 		}
 		retentionDays = data.retentionDays;
+		minLevel = data.minLevel;
 		selectedEntryId = null;
+
+		const storedFilter = loadStoredViewFilter();
+		let restoredNonDefaultFilter = false;
+		if (storedFilter?.levels && storedFilter.levels.length > 0) {
+			levels.clear();
+			for (const level of storedFilter.levels) levels.add(level);
+			if (storedFilter.levels.length !== DEFAULT_LEVELS.length) restoredNonDefaultFilter = true;
+		}
+		if (storedFilter?.domain && storedFilter.domain !== 'all') {
+			selectedDomain = storedFilter.domain;
+			restoredNonDefaultFilter = true;
+		}
+
 		lastLoadedFilterKey = buildFilterKey();
 
-		// If a correlationId was provided, immediately load filtered history
-		if (search) void loadHistoryPage(1, 'replace');
+		// If a correlationId was provided, or a non-default view filter was
+		// restored, immediately load history matching that filter.
+		if (search || restoredNonDefaultFilter) void loadHistoryPage(1, 'replace');
 	});
 
 	$effect(() => {
 		if (!initialized) return;
-		if (retentionSaving) return;
-		retentionDays = data.retentionDays;
+		saveViewFilter();
 	});
 
 	const selectedEntry = $derived.by(
@@ -223,6 +273,12 @@
 		mobileInspectorOpen = false;
 	}
 
+	function handleWindowClick(event: MouseEvent): void {
+		if (!logSettingsOpen || !logSettingsContainer) return;
+		if (event.target instanceof Node && logSettingsContainer.contains(event.target)) return;
+		logSettingsOpen = false;
+	}
+
 	function handleListScroll(): void {
 		if (!listViewport) return;
 		isNearTop = listViewport.scrollTop < 24;
@@ -269,7 +325,7 @@
 	}
 
 	function replaceEntries(nextEntries: CapturedLogEntry[]): void {
-		entries = dedupeAndSort(nextEntries);
+		entries = dedupeAndSort(nextEntries, MAX_LIVE_ENTRIES);
 	}
 
 	function queueLiveEntry(entry: CapturedLogEntry): void {
@@ -339,8 +395,8 @@
 			const nextEntries = payload.entries ?? [];
 			entries =
 				mode === 'append'
-					? dedupeAndSort([...entries, ...nextEntries])
-					: dedupeAndSort(nextEntries);
+					? dedupeAndSort([...entries, ...nextEntries], MAX_TOTAL_ENTRIES)
+					: dedupeAndSort(nextEntries, MAX_LIVE_ENTRIES);
 
 			historyTotal = payload.total ?? 0;
 			historyPage = payload.page ?? page;
@@ -445,16 +501,18 @@
 		}
 	}
 
-	async function saveRetentionDays(): Promise<void> {
-		retentionSaving = true;
+	async function saveLogSettings(): Promise<void> {
+		logSettingsSaving = true;
 		try {
-			const payload = await updateLogSettings(retentionDays);
+			const payload = await updateLogSettings({ retentionDays, minLevel });
 			retentionDays = payload.retentionDays ?? retentionDays;
-			toasts.success(`Log retention updated to ${retentionDays} days`);
+			minLevel = payload.minLevel ?? minLevel;
+			toasts.success('Log settings saved');
+			logSettingsOpen = false;
 		} catch (error) {
-			toasts.error(error instanceof Error ? error.message : 'Failed to save log retention');
+			toasts.error(error instanceof Error ? error.message : 'Failed to save log settings');
 		} finally {
-			retentionSaving = false;
+			logSettingsSaving = false;
 		}
 	}
 
@@ -479,6 +537,10 @@
 			fractionalSecondDigits: 3,
 			hour12: false
 		}).format(new Date(value));
+	}
+
+	function capitalize(value: string): string {
+		return value.charAt(0).toUpperCase() + value.slice(1);
 	}
 
 	function levelBadgeClass(level: CapturedLogLevel, active: boolean): string {
@@ -507,7 +569,8 @@
 	}
 
 	function getSource(entry: CapturedLogEntry): string {
-		const parts = [entry.logDomain, entry.component, entry.service, entry.module].filter(
+		const domainLabel = entry.logDomain ? DOMAIN_LABELS[entry.logDomain] : undefined;
+		const parts = [domainLabel, entry.component, entry.service, entry.module].filter(
 			(v): v is string => typeof v === 'string' && v.length > 0
 		);
 		const deduped = parts.filter((v, i) => i === 0 || v !== parts[i - 1]);
@@ -549,6 +612,7 @@
 	onkeydown={(e) => {
 		if (e.key === 'Escape' && selectedEntryId) closeInspector();
 	}}
+	onclick={handleWindowClick}
 />
 
 {#snippet inspectorBody(entry: CapturedLogEntry)}
@@ -661,7 +725,7 @@
 					>
 						<option value="all">All domains</option>
 						{#each availableDomains as domain (domain)}
-							<option value={domain}>{domain}</option>
+							<option value={domain}>{DOMAIN_LABELS[domain]}</option>
 						{/each}
 					</select>
 				</div>
@@ -743,8 +807,16 @@
 				<span class="h-5 w-px shrink-0 bg-base-300"></span>
 
 				<!-- Retention dropdown -->
-				<div class="dropdown">
-					<button class="btn gap-1.5 btn-ghost text-xs btn-sm" aria-label="Log retention settings">
+				<div
+					class="dropdown"
+					class:dropdown-open={logSettingsOpen}
+					bind:this={logSettingsContainer}
+				>
+					<button
+						class="btn gap-1.5 btn-ghost text-xs btn-sm"
+						aria-label="Log retention settings"
+						onclick={() => (logSettingsOpen = !logSettingsOpen)}
+					>
 						<CalendarSync class="h-3.5 w-3.5" />
 						<span class="font-mono">{retentionDays}d</span>
 					</button>
@@ -772,17 +844,48 @@
 								<button
 									class="btn ml-auto btn-ghost btn-xs"
 									onclick={() => (retentionDays = defaultRetentionDays)}
-									disabled={retentionSaving}
+									disabled={logSettingsSaving}
 								>
 									Default
 								</button>
 							</div>
+
+							<div class="my-3 h-px bg-base-300"></div>
+
+							<p
+								class="mb-3 text-[10px] font-medium tracking-widest text-base-content/50 uppercase"
+							>
+								Minimum Level Captured
+							</p>
+							<p class="mb-3 text-xs text-base-content/50">
+								Entries below this level are not written to disk.
+							</p>
+							<div class="mb-3 flex items-center gap-2">
+								<select
+									id="min-level"
+									class="select flex-1 select-xs"
+									bind:value={minLevel}
+									disabled={logSettingsSaving}
+								>
+									{#each availableLevels as level (level)}
+										<option value={level}>{capitalize(level)}</option>
+									{/each}
+								</select>
+								<button
+									class="btn btn-ghost btn-xs"
+									onclick={() => (minLevel = defaultMinLevel)}
+									disabled={logSettingsSaving}
+								>
+									Default
+								</button>
+							</div>
+
 							<button
 								class="btn w-full btn-primary btn-xs"
-								onclick={saveRetentionDays}
-								disabled={retentionSaving}
+								onclick={saveLogSettings}
+								disabled={logSettingsSaving}
 							>
-								{#if retentionSaving}
+								{#if logSettingsSaving}
 									<Loader2 class="h-3 w-3 animate-spin" />
 								{/if}
 								Save

--- a/src/routes/settings/monitoring/status/+layout.server.ts
+++ b/src/routes/settings/monitoring/status/+layout.server.ts
@@ -46,25 +46,23 @@ export const load: LayoutServerLoad = async ({ parent }) => {
 		.groupBy(mediaServerSyncedItems.videoCodec)
 		.orderBy(sql`count(*) desc`);
 
-	const allItems = await db
+	const resolutionBucket = sql`CASE
+		WHEN ${mediaServerSyncedItems.height} >= 2160 THEN '4K'
+		WHEN ${mediaServerSyncedItems.height} >= 1080 THEN '1080p'
+		WHEN ${mediaServerSyncedItems.height} >= 720 THEN '720p'
+		WHEN ${mediaServerSyncedItems.height} >= 480 THEN '480p'
+		ELSE 'SD'
+	END`;
+	const resolutionRows = await db
 		.select({
-			height: mediaServerSyncedItems.height
+			label: resolutionBucket.as('label'),
+			count: sql<number>`count(*)`
 		})
 		.from(mediaServerSyncedItems)
-		.where(sql`${mediaServerSyncedItems.height} IS NOT NULL`);
-
-	const resolutionMap = new Map<string, number>();
-	for (const item of allItems) {
-		const h = item.height ?? 0;
-		let label = 'SD';
-		if (h >= 2160) label = '4K';
-		else if (h >= 1080) label = '1080p';
-		else if (h >= 720) label = '720p';
-		else if (h >= 480) label = '480p';
-		resolutionMap.set(label, (resolutionMap.get(label) ?? 0) + 1);
-	}
-	const resolutionBreakdown = Array.from(resolutionMap.entries())
-		.map(([label, count]) => ({ label, count }))
+		.where(sql`${mediaServerSyncedItems.height} IS NOT NULL`)
+		.groupBy(resolutionBucket);
+	const resolutionBreakdown = resolutionRows
+		.map((r) => ({ label: r.label as string, count: r.count }))
 		.sort((a, b) => b.count - a.count);
 
 	const hdrRows = await db

--- a/src/routes/settings/monitoring/status/+page.svelte
+++ b/src/routes/settings/monitoring/status/+page.svelte
@@ -480,7 +480,7 @@
 			{#if activeInsights.length > 0 || dismissedInsights.length > 0}
 				<button
 					type="button"
-					class="btn gap-2 btn-ghost btn-sm"
+					class="btn gap-1 btn-ghost btn-sm"
 					onclick={() => (insightsOpen = true)}
 				>
 					<Lightbulb class="h-4 w-4" />

--- a/src/routes/settings/system/+layout.server.ts
+++ b/src/routes/settings/system/+layout.server.ts
@@ -1,12 +1,15 @@
 import type { LayoutServerLoad } from './$types';
 import { getManagedApiKeysForRequest } from '$lib/server/auth/index.js';
 import { error } from '@sveltejs/kit';
-import { logger } from '$lib/logging';
+import { createChildLogger } from '$lib/logging';
+
 import { getSystemSettingsService } from '$lib/server/settings/SystemSettingsService.js';
 import { db } from '$lib/server/db';
 import { settings } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { getMetadataProviderConfig } from '$lib/server/metadata/provider-settings.js';
+
+const logger = createChildLogger({ module: 'SystemSettingsLayout', logDomain: 'system' });
 
 export const load: LayoutServerLoad = async ({ request, locals }) => {
 	// Require authentication


### PR DESCRIPTION
## Summary

Investigates and resolves a cluster of freeze/hang issues reported on large libraries: non-idempotent database inserts causing crashes on concurrent writes, an inotify watch-descriptor exhaustion bug in the filesystem watcher, several unbounded full-table-scan queries blocking the event loop on dashboard/monitoring pages, and a Logs page that could freeze the browser tab itself. Also completes a full audit of the app's log-domain scoping so every log entry is correctly categorized instead of falling back to unscoped/mislabeled output.

## Related Issues

[Library size too large?](https://discord.com/channels/1449917989561303165/1537513215792128120)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Dependency update
- [ ] Other:

## Changes Made

- Made every remaining non-idempotent INSERT site use `onConflictDoNothing()` with a re-fetch fallback where the returned ID is needed downstream (`media-matcher.ts`, `SmartListService.ts`, `DataRepairService.ts`, movie/episode file inserts) - fixes UNIQUE constraint crashes under concurrent writes on large libraries
- Replaced chokidar with `@parcel/watcher` in the library filesystem watcher: chokidar creates one native watch per **file** in addition to per directory, exhausting `fs.inotify.max_user_watches` on large libraries; `@parcel/watcher` watches at the directory level only
- Added `AbortSignal.timeout()` to the Docker healthcheck's `fetch()` call so a hung app can't accumulate zombie healthcheck processes
- Fixed graceful shutdown ordering: `wal_checkpoint(TRUNCATE)` ->`sqlite.close()` -> `process.exit(0)` on all exit paths, including the timeout fallback (previously exited with code 1, which some orchestrators treat as a crash)
- Added an in-memory rename-preview cache with per-mediaId staleness tracking and progressive NDJSON streaming, so large-library rename previews return instantly on repeat visits and show progress instead of blocking on cold computation; capped rename-execution concurrency to avoid file-descriptor exhaustion on large batch renames
- Eliminated unbounded full-table-scan queries that loaded entire tables into memory just to compute a handful of aggregate values in JS, replacing them with SQL `GROUP BY`/`CASE`/correlated-subquery equivalents - covers the monitoring dashboard, library list pages, calendar/homepage, a media-server-stats endpoint, and several background insight rules (root cause of several reported multi-minute UI freezes)
- Fixed the Logs page causing the browser tab itself to become unresponsive: capped the live-tail entry buffer and stopped re-sorting the entire unbounded entry list on every incoming log line; added a real event-loop yield to the server-side log-file scanner for the same underlying reason
- Added a persisted "minimum level captured" setting (previously only a client-side view filter existed, which reset on every page load) and fixed the domain filter dropdown to show friendly labels instead of raw identifiers
- Audited every log call site and assigned each a correct domain instead of falling back to unscoped/mislabeled output; folded two invalid domain values (`main`, `settings`) that were never part of the recognized domain list into `system`; reordered the domain filter alphabetically by display label

## Areas Affected

- [x] UI/Frontend
- [x] API/Backend
- [ ] Indexers
- [ ] Download Clients
- [x] Library Management
- [x] Database/Schema
- [ ] Subtitles
- [ ] Documentation

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] All tests pass (`npm run test`)
- [x] Type checking passes (`npm run check`)

## Checklist

- [x] Code follows project conventions
- [x] Ran `npm run format`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Svelte 5 runes used correctly (`$state`, `$derived`, `$effect`, `$props`)
- [x] No new warnings in console or build output
- [ ] Documentation updated (if applicable)

## Screenshots

N/A
